### PR TITLE
refactor: remove /memory from entries sync endpoint path

### DIFF
--- a/common/agent-webui/src/client/services.gen.ts
+++ b/common/agent-webui/src/client/services.gen.ts
@@ -220,14 +220,14 @@ export class ConversationsService {
    * @throws ApiError
    */
   public static syncConversationMemory(
-    data: $OpenApiTs["/v1/conversations/{conversationId}/memory/entries/sync"]["post"]["req"],
+    data: $OpenApiTs["/v1/conversations/{conversationId}/entries/sync"]["post"]["req"],
   ): CancelablePromise<
-    | $OpenApiTs["/v1/conversations/{conversationId}/memory/entries/sync"]["post"]["res"][200]
-    | $OpenApiTs["/v1/conversations/{conversationId}/memory/entries/sync"]["post"]["res"][200]
+    | $OpenApiTs["/v1/conversations/{conversationId}/entries/sync"]["post"]["res"][200]
+    | $OpenApiTs["/v1/conversations/{conversationId}/entries/sync"]["post"]["res"][200]
   > {
     return __request(OpenAPI, {
       method: "POST",
-      url: "/v1/conversations/{conversationId}/memory/entries/sync",
+      url: "/v1/conversations/{conversationId}/entries/sync",
       path: {
         conversationId: data.conversationId,
       },

--- a/common/agent-webui/src/client/types.gen.ts
+++ b/common/agent-webui/src/client/types.gen.ts
@@ -335,7 +335,7 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/v1/conversations/{conversationId}/memory/entries/sync": {
+  "/v1/conversations/{conversationId}/entries/sync": {
     post: {
       req: {
         conversationId: string;

--- a/common/agent-webui/src/components/chat-panel.tsx
+++ b/common/agent-webui/src/components/chat-panel.tsx
@@ -1094,9 +1094,7 @@ export function ChatPanel({
       return "none";
     }
     return forks
-      .map(
-        (fork) => `${fork.conversationId ?? ""}:${fork.forkedAtConversationId ?? ""}:${fork.forkedAtEntryId ?? ""}`,
-      )
+      .map((fork) => `${fork.conversationId ?? ""}:${fork.forkedAtConversationId ?? ""}:${fork.forkedAtEntryId ?? ""}`)
       .sort()
       .join("|");
   }, [forksQuery.data]);

--- a/docs/enhancements/018-rename-messages-to-entrys.md
+++ b/docs/enhancements/018-rename-messages-to-entrys.md
@@ -198,7 +198,7 @@ CreateEntryRequest:
 | `GET /v1/conversations/{conversationId}/messages` | `GET /v1/conversations/{conversationId}/entries` |
 | `POST /v1/conversations/{conversationId}/messages` | `POST /v1/conversations/{conversationId}/entries` |
 | `POST /v1/conversations/{conversationId}/messages/{messageId}/fork` | `POST /v1/conversations/{conversationId}/entries/{entryId}/fork` |
-| `POST /v1/conversations/{conversationId}/memory/messages/sync` | `POST /v1/conversations/{conversationId}/memory/entries/sync` |
+| `POST /v1/conversations/{conversationId}/memory/messages/sync` | `POST /v1/conversations/{conversationId}/entries/sync` |
 | `POST /v1/user/search/messages` | `POST /v1/user/search/entries` |
 
 #### SearchResult Schema Update

--- a/memory-service-contracts/src/main/resources/openapi.yml
+++ b/memory-service-contracts/src/main/resources/openapi.yml
@@ -271,7 +271,7 @@ paths:
       security:
         - BearerAuth: []
 
-  /v1/conversations/{conversationId}/memory/entries/sync:
+  /v1/conversations/{conversationId}/entries/sync:
     post:
       tags: [Conversations]
       summary: Synchronize the agent memory epoch

--- a/memory-service/src/main/java/io/github/chirino/memory/api/ConversationsResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/ConversationsResource.java
@@ -286,7 +286,7 @@ public class ConversationsResource {
     }
 
     @POST
-    @Path("/conversations/{conversationId}/memory/entries/sync")
+    @Path("/conversations/{conversationId}/entries/sync")
     public Response syncMemoryEntries(
             @PathParam("conversationId") String conversationId, SyncEntriesRequest request) {
         if (apiKeyContext == null || !apiKeyContext.hasValidApiKey()) {

--- a/memory-service/src/test/java/io/github/chirino/memory/cucumber/StepDefinitions.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/cucumber/StepDefinitions.java
@@ -807,9 +807,7 @@ public class StepDefinitions {
         var requestSpec = given().contentType(MediaType.APPLICATION_JSON).body(rendered);
         requestSpec = authenticateRequest(requestSpec);
         this.lastResponse =
-                requestSpec
-                        .when()
-                        .post("/v1/conversations/{id}/memory/entries/sync", conversationId);
+                requestSpec.when().post("/v1/conversations/{id}/entries/sync", conversationId);
     }
 
     @io.cucumber.java.en.Then("the sync response should contain {int} entries")


### PR DESCRIPTION
Simplify the API path from /v1/conversations/{id}/memory/entries/sync to /v1/conversations/{id}/entries/sync for consistency with other entry-related endpoints.