### PR TITLE
refactor: change cancel-response endpoint to DELETE /response

### DIFF
--- a/common/agent-webui/src/client/services.gen.ts
+++ b/common/agent-webui/src/client/services.gen.ts
@@ -348,15 +348,15 @@ export class ConversationsService {
    * @returns ErrorResponse Error response
    * @throws ApiError
    */
-  public static cancelConversationResponse(
-    data: $OpenApiTs["/v1/conversations/{conversationId}/cancel-response"]["post"]["req"],
+  public static deleteConversationResponse(
+    data: $OpenApiTs["/v1/conversations/{conversationId}/response"]["delete"]["req"],
   ): CancelablePromise<
-    | $OpenApiTs["/v1/conversations/{conversationId}/cancel-response"]["post"]["res"][200]
-    | $OpenApiTs["/v1/conversations/{conversationId}/cancel-response"]["post"]["res"][200]
+    | $OpenApiTs["/v1/conversations/{conversationId}/response"]["delete"]["res"][200]
+    | $OpenApiTs["/v1/conversations/{conversationId}/response"]["delete"]["res"][200]
   > {
     return __request(OpenAPI, {
-      method: "POST",
-      url: "/v1/conversations/{conversationId}/cancel-response",
+      method: "DELETE",
+      url: "/v1/conversations/{conversationId}/response",
       path: {
         conversationId: data.conversationId,
       },

--- a/common/agent-webui/src/client/types.gen.ts
+++ b/common/agent-webui/src/client/types.gen.ts
@@ -413,8 +413,8 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/v1/conversations/{conversationId}/cancel-response": {
-    post: {
+  "/v1/conversations/{conversationId}/response": {
+    delete: {
       req: {
         conversationId: string;
       };

--- a/common/agent-webui/src/components/chat-panel.tsx
+++ b/common/agent-webui/src/components/chat-panel.tsx
@@ -1446,7 +1446,7 @@ export function ChatPanel({
         }
         setCanceling(true);
         try {
-          await ConversationsService.cancelConversationResponse({ conversationId: targetConversationId });
+          await ConversationsService.deleteConversationResponse({ conversationId: targetConversationId });
         } catch (error) {
           void error;
         } finally {

--- a/docs/enhancements/004-response-cancel.md
+++ b/docs/enhancements/004-response-cancel.md
@@ -53,7 +53,7 @@ used for token streaming.
 ## API Design
 ### REST (user/agent)
 1) **Cancel an in-progress response**
-   - `POST /v1/conversations/{conversationId}/cancel-response`
+   - `DELETE /v1/conversations/{conversationId}/response`
    - Request: `{ }`
    - Implementation:
      - XADD cancel signal into `conversation:response-x:{conversationId}`.
@@ -95,7 +95,7 @@ Add RPCs to `ResponseResumerService`:
 - No request body fields.
 
 ## Error Semantics
-- `POST /v1/conversations/{conversationId}/cancel-response` returns 200 even if no response is active (idempotent).
+- `DELETE /v1/conversations/{conversationId}/response` returns 200 even if no response is active (idempotent).
 - 404 only if the conversation is not found or caller lacks access.
 - 409 if the response resumer is disabled.
 

--- a/memory-service-contracts/src/main/resources/openapi.yml
+++ b/memory-service-contracts/src/main/resources/openapi.yml
@@ -422,14 +422,14 @@ paths:
       security:
         - BearerAuth: []
 
-  /v1/conversations/{conversationId}/cancel-response:
-    post:
+  /v1/conversations/{conversationId}/response:
+    delete:
       tags: [Conversations]
       summary: Cancel an in-progress response
       description: |-
         Requests cancellation of an in-progress response stream for the conversation.
         Requires WRITER access and an authenticated user session.
-      operationId: cancelConversationResponse
+      operationId: deleteConversationResponse
       parameters:
         - name: conversationId
           in: path

--- a/memory-service/src/main/java/io/github/chirino/memory/api/ConversationsResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/ConversationsResource.java
@@ -539,8 +539,8 @@ public class ConversationsResource {
         }
     }
 
-    @POST
-    @Path("/conversations/{conversationId}/cancel-response")
+    @DELETE
+    @Path("/conversations/{conversationId}/response")
     public Response cancelResponse(@PathParam("conversationId") String conversationId) {
         ResponseResumerBackend backend = resumerSelector.getBackend();
         if (!backend.enabled()) {
@@ -562,7 +562,7 @@ public class ConversationsResource {
             backend.requestCancel(conversationId, resolveAdvertisedAddress());
         } catch (ResponseResumerRedirectException redirect) {
             LOG.infof(
-                    "Redirecting cancel-response for conversationId=%s from %s to %s",
+                    "Redirecting delete-response for conversationId=%s from %s to %s",
                     conversationId, resolveAdvertisedAddress(), redirect.target());
             URI target = buildRedirectLocation(conversationId, redirect.target());
             return forwardCancel(conversationId, target);
@@ -694,7 +694,7 @@ public class ConversationsResource {
         if (target.port() > 0) {
             builder.port(target.port());
         }
-        builder.path("v1/conversations/{conversationId}/cancel-response");
+        builder.path("v1/conversations/{conversationId}/response");
         return builder.build(conversationId);
     }
 

--- a/quarkus/examples/agent-quarkus/src/main/java/example/MemoryServiceProxyResource.java
+++ b/quarkus/examples/agent-quarkus/src/main/java/example/MemoryServiceProxyResource.java
@@ -87,8 +87,8 @@ public class MemoryServiceProxyResource {
         return proxy.shareConversation(conversationId, body);
     }
 
-    @POST
-    @Path("/{conversationId}/cancel-response")
+    @DELETE
+    @Path("/{conversationId}/response")
     public Response cancelResponse(@PathParam("conversationId") String conversationId) {
         return proxy.cancelResponse(conversationId);
     }

--- a/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/runtime/MemoryServiceProxy.java
+++ b/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/runtime/MemoryServiceProxy.java
@@ -116,7 +116,7 @@ public class MemoryServiceProxy {
 
     public Response cancelResponse(String conversationId) {
         return executeVoid(
-                () -> conversationsApi().cancelConversationResponse(conversationId),
+                () -> conversationsApi().deleteConversationResponse(conversationId),
                 OK,
                 "Error cancelling response for history %s",
                 conversationId);

--- a/spring/examples/agent-spring/src/main/java/example/agent/MemoryServiceProxyController.java
+++ b/spring/examples/agent-spring/src/main/java/example/agent/MemoryServiceProxyController.java
@@ -67,7 +67,7 @@ class MemoryServiceProxyController {
         return proxy.shareConversation(conversationId, body);
     }
 
-    @PostMapping("/{conversationId}/cancel-response")
+    @DeleteMapping("/{conversationId}/response")
     public ResponseEntity<?> cancelResponse(@PathVariable String conversationId) {
         return proxy.cancelResponse(conversationId);
     }

--- a/spring/memory-service-rest-spring/src/main/java/io/github/chirino/memoryservice/client/MemoryServiceProxy.java
+++ b/spring/memory-service-rest-spring/src/main/java/io/github/chirino/memoryservice/client/MemoryServiceProxy.java
@@ -114,7 +114,7 @@ public class MemoryServiceProxy {
 
     public ResponseEntity<?> cancelResponse(String conversationId) {
         return execute(
-                api -> api.cancelConversationResponseWithHttpInfo(conversationId), HttpStatus.OK);
+                api -> api.deleteConversationResponseWithHttpInfo(conversationId), HttpStatus.OK);
     }
 
     public ResponseEntity<?> transferConversationOwnership(String conversationId, String body) {


### PR DESCRIPTION
Replace POST /v1/conversations/{conversationId}/cancel-response with DELETE /v1/conversations/{conversationId}/response for a more RESTful API design. Updates operationId from cancelConversationResponse to deleteConversationResponse.