### PR TITLE
refactor: move shareConversation to /memberships and rename admin sea…

### DIFF
--- a/common/agent-webui/src/client/schemas.gen.ts
+++ b/common/agent-webui/src/client/schemas.gen.ts
@@ -192,7 +192,7 @@ export const $ForkFromEntryRequest = {
 export const $Channel = {
   type: "string",
   description: "Logical channel of the entry within the conversation.",
-  enum: ["history", "memory", "summary"],
+  enum: ["history", "memory", "transcript"],
 } as const;
 
 export const $Entry = {
@@ -392,38 +392,38 @@ export const $SyncEntriesResponse = {
   },
 } as const;
 
-export const $CreateSummaryRequest = {
+export const $IndexTranscriptRequest = {
   type: "object",
-  required: ["title", "summary", "untilEntryId", "summarizedAt"],
+  required: ["conversationId", "transcript", "untilEntryId"],
   properties: {
+    conversationId: {
+      type: "string",
+      description: "The conversation to index.",
+    },
     title: {
       type: "string",
-      description: "Conversation title to store/update.",
+      nullable: true,
+      description: "Optional conversation title to store/update.",
     },
-    summary: {
+    transcript: {
       type: "string",
-      description: "Summary text.",
+      description: "Transcript text to index for semantic search.",
     },
     untilEntryId: {
       type: "string",
-      description: "Highest message id covered by the summary (inclusive).",
-    },
-    summarizedAt: {
-      type: "string",
-      format: "date-time",
-      description: "Timestamp of the last message covered by the summary.",
+      description: "Highest entry id covered by the index (inclusive).",
     },
   },
   example: {
+    conversationId: "conv_01HF8XH1XABCD1234EFGH5678",
     title: "Conversation forking design",
-    summary:
+    transcript:
       "User asked several questions about conversation forking. They want to support branching at any message with independent access control per branch.",
-    untilEntryId: "msg_01HF8XJQWXYZ9876ABCD5431",
-    summarizedAt: "2024-05-01T12:34:56Z",
+    untilEntryId: "entry_01HF8XJQWXYZ9876ABCD5431",
   },
 } as const;
 
-export const $SearchEntriesRequest = {
+export const $SearchConversationsRequest = {
   type: "object",
   required: ["query"],
   properties: {

--- a/common/agent-webui/src/client/services.gen.ts
+++ b/common/agent-webui/src/client/services.gen.ts
@@ -309,36 +309,6 @@ export class ConversationsService {
   }
 
   /**
-   * Share conversation with another user
-   * Grants another user access to the conversation with the specified access level.
-   * @param data The data for the request.
-   * @param data.conversationId
-   * @param data.requestBody
-   * @returns ErrorResponse Error response
-   * @returns ConversationMembership Created membership.
-   * @throws ApiError
-   */
-  public static shareConversation(
-    data: $OpenApiTs["/v1/conversations/{conversationId}/forks"]["post"]["req"],
-  ): CancelablePromise<
-    | $OpenApiTs["/v1/conversations/{conversationId}/forks"]["post"]["res"][200]
-    | $OpenApiTs["/v1/conversations/{conversationId}/forks"]["post"]["res"][201]
-  > {
-    return __request(OpenAPI, {
-      method: "POST",
-      url: "/v1/conversations/{conversationId}/forks",
-      path: {
-        conversationId: data.conversationId,
-      },
-      body: data.requestBody,
-      mediaType: "application/json",
-      errors: {
-        404: "Resource not found",
-      },
-    });
-  }
-
-  /**
    * Cancel an in-progress response
    * Requests cancellation of an in-progress response stream for the conversation.
    * Requires WRITER access and an authenticated user session.
@@ -428,6 +398,36 @@ export class SharingService {
   }
 
   /**
+   * Share conversation with another user
+   * Grants another user access to the conversation with the specified access level.
+   * @param data The data for the request.
+   * @param data.conversationId
+   * @param data.requestBody
+   * @returns ErrorResponse Error response
+   * @returns ConversationMembership Created membership.
+   * @throws ApiError
+   */
+  public static shareConversation(
+    data: $OpenApiTs["/v1/conversations/{conversationId}/memberships"]["post"]["req"],
+  ): CancelablePromise<
+    | $OpenApiTs["/v1/conversations/{conversationId}/memberships"]["post"]["res"][200]
+    | $OpenApiTs["/v1/conversations/{conversationId}/memberships"]["post"]["res"][201]
+  > {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/v1/conversations/{conversationId}/memberships",
+      path: {
+        conversationId: data.conversationId,
+      },
+      body: data.requestBody,
+      mediaType: "application/json",
+      errors: {
+        404: "Resource not found",
+      },
+    });
+  }
+
+  /**
    * Update a member's access level
    * @param data The data for the request.
    * @param data.conversationId
@@ -489,7 +489,7 @@ export class SharingService {
 
 export class SearchService {
   /**
-   * Semantic search across user's conversations
+   * Semantic search across conversations
    * Performs semantic and/or keyword search across all conversations the user has access to.
    * Backed by an internal vector store (pgvector, MongoDB, etc.).
    * @param data The data for the request.
@@ -498,44 +498,46 @@ export class SearchService {
    * @returns ErrorResponse Error response
    * @throws ApiError
    */
-  public static searchEntries(
-    data: $OpenApiTs["/v1/user/search/entries"]["post"]["req"],
+  public static searchConversations(
+    data: $OpenApiTs["/v1/conversations/search"]["post"]["req"],
   ): CancelablePromise<
-    | $OpenApiTs["/v1/user/search/entries"]["post"]["res"][200]
-    | $OpenApiTs["/v1/user/search/entries"]["post"]["res"][200]
+    | $OpenApiTs["/v1/conversations/search"]["post"]["res"][200]
+    | $OpenApiTs["/v1/conversations/search"]["post"]["res"][200]
   > {
     return __request(OpenAPI, {
       method: "POST",
-      url: "/v1/user/search/entries",
+      url: "/v1/conversations/search",
       body: data.requestBody,
       mediaType: "application/json",
     });
   }
 
   /**
-   * Store a summarization of previous entries
-   * Stores an internal summarization of previous entries in the conversation.
-   * Summary entries are not visible in user-facing entry lists.
+   * Index a conversation transcript
+   * Indexes conversation transcript content for semantic search. Stores the
+   * provided transcript text as searchable content and updates the conversation
+   * title. The `untilEntryId` tracks which entries have been indexed.
+   *
+   * This endpoint is typically called by agents after processing recent
+   * conversation entries. The transcript text becomes searchable via
+   * the `/v1/conversations/search` endpoint.
+   *
    * Requires a valid agent API key.
    * @param data The data for the request.
-   * @param data.conversationId
    * @param data.requestBody
    * @returns ErrorResponse Error response
-   * @returns Entry The created summary entry.
+   * @returns Entry The index entry was created.
    * @throws ApiError
    */
-  public static createConversationSummary(
-    data: $OpenApiTs["/v1/conversations/{conversationId}/summaries"]["post"]["req"],
+  public static indexConversationTranscript(
+    data: $OpenApiTs["/v1/conversations/index"]["post"]["req"],
   ): CancelablePromise<
-    | $OpenApiTs["/v1/conversations/{conversationId}/summaries"]["post"]["res"][200]
-    | $OpenApiTs["/v1/conversations/{conversationId}/summaries"]["post"]["res"][201]
+    | $OpenApiTs["/v1/conversations/index"]["post"]["res"][200]
+    | $OpenApiTs["/v1/conversations/index"]["post"]["res"][201]
   > {
     return __request(OpenAPI, {
       method: "POST",
-      url: "/v1/conversations/{conversationId}/summaries",
-      path: {
-        conversationId: data.conversationId,
-      },
+      url: "/v1/conversations/index",
       body: data.requestBody,
       mediaType: "application/json",
       errors: {

--- a/common/agent-webui/src/client/types.gen.ts
+++ b/common/agent-webui/src/client/types.gen.ts
@@ -75,7 +75,7 @@ export type ForkFromEntryRequest = {
 /**
  * Logical channel of the entry within the conversation.
  */
-export type Channel = "history" | "memory" | "summary";
+export type Channel = "history" | "memory" | "transcript";
 
 export type Entry = {
   id: string;
@@ -156,26 +156,26 @@ export type SyncEntriesResponse = {
   entries?: Array<Entry>;
 };
 
-export type CreateSummaryRequest = {
+export type IndexTranscriptRequest = {
   /**
-   * Conversation title to store/update.
+   * The conversation to index.
    */
-  title: string;
+  conversationId: string;
   /**
-   * Summary text.
+   * Optional conversation title to store/update.
    */
-  summary: string;
+  title?: string | null;
   /**
-   * Highest message id covered by the summary (inclusive).
+   * Transcript text to index for semantic search.
+   */
+  transcript: string;
+  /**
+   * Highest entry id covered by the index (inclusive).
    */
   untilEntryId: string;
-  /**
-   * Timestamp of the last message covered by the summary.
-   */
-  summarizedAt: string;
 };
 
-export type SearchEntriesRequest = {
+export type SearchConversationsRequest = {
   /**
    * Natural language query.
    */
@@ -392,26 +392,6 @@ export type $OpenApiTs = {
         404: ErrorResponse;
       };
     };
-    post: {
-      req: {
-        conversationId: string;
-        requestBody: ShareConversationRequest;
-      };
-      res: {
-        /**
-         * Error response
-         */
-        200: ErrorResponse;
-        /**
-         * Created membership.
-         */
-        201: ConversationMembership;
-        /**
-         * Resource not found
-         */
-        404: ErrorResponse;
-      };
-    };
   };
   "/v1/conversations/{conversationId}/response": {
     delete: {
@@ -474,6 +454,26 @@ export type $OpenApiTs = {
         404: ErrorResponse;
       };
     };
+    post: {
+      req: {
+        conversationId: string;
+        requestBody: ShareConversationRequest;
+      };
+      res: {
+        /**
+         * Error response
+         */
+        200: ErrorResponse;
+        /**
+         * Created membership.
+         */
+        201: ConversationMembership;
+        /**
+         * Resource not found
+         */
+        404: ErrorResponse;
+      };
+    };
   };
   "/v1/conversations/{conversationId}/memberships/{userId}": {
     patch: {
@@ -516,10 +516,10 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/v1/user/search/entries": {
+  "/v1/conversations/search": {
     post: {
       req: {
-        requestBody: SearchEntriesRequest;
+        requestBody: SearchConversationsRequest;
       };
       res: {
         /**
@@ -529,11 +529,10 @@ export type $OpenApiTs = {
       };
     };
   };
-  "/v1/conversations/{conversationId}/summaries": {
+  "/v1/conversations/index": {
     post: {
       req: {
-        conversationId: string;
-        requestBody: CreateSummaryRequest;
+        requestBody: IndexTranscriptRequest;
       };
       res: {
         /**
@@ -541,7 +540,7 @@ export type $OpenApiTs = {
          */
         200: ErrorResponse;
         /**
-         * The created summary entry.
+         * The index entry was created.
          */
         201: Entry;
         /**

--- a/memory-service-contracts/src/main/resources/openapi-admin.yml
+++ b/memory-service-contracts/src/main/resources/openapi-admin.yml
@@ -342,14 +342,14 @@ paths:
       security:
         - BearerAuth: []
 
-  /v1/admin/search/entries:
+  /v1/admin/conversations/search:
     post:
       tags: [Admin]
       summary: System-wide semantic search (admin/auditor)
       description: |-
         Performs semantic search across all conversations, optionally filtered
         by userId. Requires auditor or admin role.
-      operationId: adminSearchEntries
+      operationId: adminSearchConversations
       requestBody:
         required: true
         content:

--- a/memory-service-contracts/src/main/resources/openapi.yml
+++ b/memory-service-contracts/src/main/resources/openapi.yml
@@ -390,37 +390,6 @@ paths:
           $ref: '#/components/responses/Error'
       security:
         - BearerAuth: []
-    post:
-      tags: [Conversations]
-      summary: Share conversation with another user
-      description: |-
-        Grants another user access to the conversation with the specified access level.
-      operationId: shareConversation
-      parameters:
-        - name: conversationId
-          in: path
-          required: true
-          schema:
-            type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ShareConversationRequest'
-      responses:
-        '201':
-          description: Created membership.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ConversationMembership'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        default:
-          $ref: '#/components/responses/Error'
-      security:
-        - BearerAuth: []
 
   /v1/conversations/{conversationId}/response:
     delete:
@@ -511,6 +480,37 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/ConversationMembership'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/Error'
+      security:
+        - BearerAuth: []
+    post:
+      tags: [Sharing]
+      summary: Share conversation with another user
+      description: |-
+        Grants another user access to the conversation with the specified access level.
+      operationId: shareConversation
+      parameters:
+        - name: conversationId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ShareConversationRequest'
+      responses:
+        '201':
+          description: Created membership.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConversationMembership'
         '404':
           $ref: '#/components/responses/NotFound'
         default:

--- a/memory-service/src/main/java/io/github/chirino/memory/api/AdminResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/AdminResource.java
@@ -293,8 +293,8 @@ public class AdminResource {
     }
 
     @POST
-    @Path("/search/entries")
-    public Response searchEntries(
+    @Path("/conversations/search")
+    public Response searchConversations(
             AdminSearchQuery request, @QueryParam("justification") String justification) {
         try {
             roleResolver.requireAuditor(identity, apiKeyContext);

--- a/memory-service/src/main/java/io/github/chirino/memory/api/ConversationsResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/ConversationsResource.java
@@ -350,7 +350,7 @@ public class ConversationsResource {
     }
 
     @POST
-    @Path("/conversations/{conversationId}/forks")
+    @Path("/conversations/{conversationId}/memberships")
     public Response shareConversation(
             @PathParam("conversationId") String conversationId, ShareConversationRequest request) {
         try {

--- a/memory-service/src/test/java/io/github/chirino/memory/AbstractMemoryServiceTest.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/AbstractMemoryServiceTest.java
@@ -191,7 +191,7 @@ abstract class AbstractMemoryServiceTest {
         given().contentType(MediaType.APPLICATION_JSON)
                 .body(shareRequest)
                 .when()
-                .post("/v1/conversations/{id}/forks", conversationId)
+                .post("/v1/conversations/{id}/memberships", conversationId)
                 .then()
                 .statusCode(201)
                 .body("userId", is("writer"))
@@ -232,7 +232,7 @@ abstract class AbstractMemoryServiceTest {
         given().contentType(MediaType.APPLICATION_JSON)
                 .body(shareRequest)
                 .when()
-                .post("/v1/conversations/{id}/forks", conversationId)
+                .post("/v1/conversations/{id}/memberships", conversationId)
                 .then()
                 .statusCode(403)
                 .body("code", is("forbidden"));

--- a/memory-service/src/test/java/io/github/chirino/memory/cucumber/StepDefinitions.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/cucumber/StepDefinitions.java
@@ -1169,7 +1169,8 @@ public class StepDefinitions {
         String rendered = renderTemplate(requestBody);
         var requestSpec = given().contentType(MediaType.APPLICATION_JSON).body(rendered);
         requestSpec = authenticateRequest(requestSpec);
-        this.lastResponse = requestSpec.when().post("/v1/conversations/{id}/forks", conversationId);
+        this.lastResponse =
+                requestSpec.when().post("/v1/conversations/{id}/memberships", conversationId);
     }
 
     @io.cucumber.java.en.When("I share conversation {string} with user {string} with request:")
@@ -1184,7 +1185,8 @@ public class StepDefinitions {
         }
         var requestSpec = given().contentType(MediaType.APPLICATION_JSON).body(rendered);
         requestSpec = authenticateRequest(requestSpec);
-        this.lastResponse = requestSpec.when().post("/v1/conversations/{id}/forks", renderedConvId);
+        this.lastResponse =
+                requestSpec.when().post("/v1/conversations/{id}/memberships", renderedConvId);
     }
 
     @io.cucumber.java.en.When("I share that conversation with user {string} with request:")

--- a/memory-service/src/test/resources/features/admin-rest.feature
+++ b/memory-service/src/test/resources/features/admin-rest.feature
@@ -127,7 +127,7 @@ Feature: Admin REST API
 
   Scenario: Admin can perform system-wide semantic search
     Given the conversation owned by "bob" has an entry "Searchable content"
-    When I call POST "/v1/admin/search/entries" with body:
+    When I call POST "/v1/admin/conversations/search" with body:
     """
     {
       "query": "Searchable"
@@ -139,7 +139,7 @@ Feature: Admin REST API
   Scenario: Admin search can filter by userId
     Given the conversation owned by "bob" has an entry "Bob's entry"
     Given the conversation owned by "alice" has an entry "Alice's entry"
-    When I call POST "/v1/admin/search/entries" with body:
+    When I call POST "/v1/admin/conversations/search" with body:
     """
     {
       "query": "entry",

--- a/quarkus/examples/agent-quarkus/src/main/java/example/MemoryServiceProxyResource.java
+++ b/quarkus/examples/agent-quarkus/src/main/java/example/MemoryServiceProxyResource.java
@@ -79,7 +79,7 @@ public class MemoryServiceProxyResource {
     }
 
     @POST
-    @Path("/{conversationId}/forks")
+    @Path("/{conversationId}/memberships")
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public Response shareConversation(

--- a/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/runtime/MemoryServiceProxy.java
+++ b/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/runtime/MemoryServiceProxy.java
@@ -104,7 +104,7 @@ public class MemoryServiceProxy {
             ShareConversationRequest request =
                     OBJECT_MAPPER.readValue(body, ShareConversationRequest.class);
             return execute(
-                    () -> conversationsApi().shareConversation(conversationId, request),
+                    () -> sharingApi().shareConversation(conversationId, request),
                     CREATED,
                     "Error sharing history %s",
                     conversationId);

--- a/spring/examples/agent-spring/src/main/java/example/agent/MemoryServiceProxyController.java
+++ b/spring/examples/agent-spring/src/main/java/example/agent/MemoryServiceProxyController.java
@@ -61,7 +61,7 @@ class MemoryServiceProxyController {
         return proxy.listConversationForks(conversationId);
     }
 
-    @PostMapping("/{conversationId}/forks")
+    @PostMapping("/{conversationId}/memberships")
     public ResponseEntity<?> shareConversation(
             @PathVariable String conversationId, @RequestBody String body) {
         return proxy.shareConversation(conversationId, body);

--- a/spring/memory-service-rest-spring/src/main/java/io/github/chirino/memoryservice/client/MemoryServiceProxy.java
+++ b/spring/memory-service-rest-spring/src/main/java/io/github/chirino/memoryservice/client/MemoryServiceProxy.java
@@ -102,7 +102,7 @@ public class MemoryServiceProxy {
         try {
             ShareConversationRequest request =
                     OBJECT_MAPPER.readValue(body, ShareConversationRequest.class);
-            return execute(
+            return executeSharingApi(
                     api -> api.shareConversationWithHttpInfo(conversationId, request),
                     HttpStatus.CREATED);
         } catch (Exception e) {


### PR DESCRIPTION
…rch endpoint

- Move POST shareConversation from /forks to /memberships path
- Change admin search endpoint from /admin/search/entries to /admin/conversations/search
- Update all proxies and generated clients to use new paths