### PR TITLE
feat: add UUID type specifications to API contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,6 @@ nb-configuration.xml
 # TLS Certificates
 .certs/
 
-
+/*.log
 vendor
 .claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,12 @@ A memory service for AI agents that stores messages exchanged with LLMs and user
 - Java: `./mvnw compile`
 - TypeScript: `npm run lint && npm run build` from `common/agent-webui/`
 
+**Test output strategy**: When running tests, redirect output to a file and search for errors instead of using `| tail`. This ensures you see all relevant error context:
+```bash
+./mvnw test > test.log 2>&1
+# Then search for errors using Grep tool on test.log
+```
+
 **Pre-release**: Changes do not need backward compatibility.
 
 ## Skills

--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,8 @@
 * protect against huge api requests.
 * Brand the project and move it to an org/foundation.
 * Look into partitioning the messages table to improve pref.
+* Expose Metrics
+* Support OpenTracing
 
 # Need Dev Feedback for:
 

--- a/docs/enhancements/021-uuid-ids-in-contract.md
+++ b/docs/enhancements/021-uuid-ids-in-contract.md
@@ -1,0 +1,454 @@
+# Enhancement 021: UUID IDs in API Contracts
+
+## Overview
+
+This document proposes adding explicit UUID format specifications to the Memory Service API contracts (OpenAPI and Protocol Buffers). While the implementation already uses UUIDs internally, the API contracts do not communicate this to clients, leading to suboptimal client code generation and unclear documentation.
+
+## Current State
+
+### Internal Implementation
+
+The Memory Service consistently uses `java.util.UUID` for all entity IDs:
+
+| Entity | ID Field | Implementation |
+|--------|----------|----------------|
+| ConversationEntity | `id` | `UUID`, auto-generated via `UUID.randomUUID()` |
+| EntryEntity | `id` | `UUID`, auto-generated via `UUID.randomUUID()` |
+| ConversationGroupEntity | `id` | `UUID`, auto-generated via `UUID.randomUUID()` |
+| TaskEntity | `id` | `UUID`, auto-generated via `UUID.randomUUID()` |
+| ConversationOwnershipTransferEntity | `id` | `UUID`, auto-generated via `UUID.randomUUID()` |
+
+All ID string parameters are parsed using `UUID.fromString()` throughout the codebase (see `PostgresMemoryStore.java` for ~25+ usages).
+
+### API Contract Gaps
+
+**OpenAPI (`openapi.yml`):**
+- All ID fields use `type: string` without `format: uuid`
+- Examples use incorrect ULID-style prefixed IDs: `"conv_01HF8XH1XABCD1234EFGH5678"`
+- Actual API returns standard UUIDs: `"550e8400-e29b-41d4-a716-446655440000"`
+
+**OpenAPI Admin (`openapi-admin.yml`):**
+- Only 2 fields correctly specify `format: uuid` (eviction job ID)
+- All other ID fields lack format specification
+
+**Protocol Buffers (`memory_service.proto`):**
+- All ID fields are `string` with no documentation about UUID format
+- No field-level comments indicating expected format
+- Uses inefficient string encoding (36 bytes) instead of binary (16 bytes)
+
+## Goals
+
+1. **Accurate documentation**: Make API contracts reflect that IDs are UUIDs
+2. **Better code generation**: Enable clients to use native UUID types where available
+3. **Correct examples**: Fix examples to use actual UUID format
+4. **Efficient wire format**: Use binary encoding for UUIDs in gRPC (16 bytes vs 36 bytes)
+5. **Type safety**: Prevent accidental use of arbitrary strings as IDs
+
+## Affected ID Fields
+
+### Conversation IDs
+| Location | Field |
+|----------|-------|
+| Path parameters | `conversationId` |
+| Schema: ConversationSummary | `id` |
+| Schema: Conversation | `id`, `forkedAtConversationId` |
+| Schema: ConversationMembership | `conversationId` |
+| Schema: ConversationForkSummary | `conversationId`, `forkedAtConversationId` |
+| Proto: Conversation | `id`, `forked_at_conversation_id` |
+| Proto: ConversationSummary | `id` |
+| Proto: ConversationMembership | `conversation_id` |
+| Proto: ConversationForkSummary | `conversation_id`, `forked_at_conversation_id` |
+
+### Entry IDs
+| Location | Field |
+|----------|-------|
+| Path parameters | `entryId` |
+| Query parameters | `after` (pagination cursor) |
+| Schema: Entry | `id`, `conversationId` |
+| Schema: Conversation | `forkedAtEntryId` |
+| Schema: ConversationForkSummary | `forkedAtEntryId` |
+| Schema: IndexTranscriptRequest | `conversationId`, `untilEntryId` |
+| Schema: SearchRequest | `conversationIds[]`, `before` |
+| Proto: Entry | `id`, `conversation_id` |
+| Proto: Conversation | `forked_at_entry_id` |
+| Proto: ConversationForkSummary | `forked_at_entry_id` |
+| Proto: IndexTranscriptRequest | `conversation_id`, `until_entry_id` |
+| Proto: SearchEntriesRequest | `conversation_ids[]`, `before` |
+
+### Admin API IDs
+| Location | Field |
+|----------|-------|
+| Path parameters | `conversationId`, `entryId`, `jobId` |
+| Query parameters | `afterEntryId` |
+| Various request/response schemas | (same patterns as user API) |
+
+## Non-UUID IDs (No Changes Needed)
+
+These fields are intentionally NOT UUIDs and should remain as plain strings:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `userId` | String | External identity (e.g., OIDC subject) |
+| `ownerUserId` | String | External identity |
+| `clientId` | String | Agent/client identifier |
+| `nextCursor` | String | Opaque pagination token |
+| `page_token` | String | gRPC pagination token |
+
+## Implementation
+
+### Phase 1: OpenAPI Specification Updates
+
+**File: `memory-service-contracts/src/main/resources/openapi.yml`**
+
+1. Add `format: uuid` to all ID fields:
+```yaml
+# Example for ConversationSummary
+ConversationSummary:
+  type: object
+  properties:
+    id:
+      type: string
+      format: uuid
+      description: Unique identifier for the conversation.
+```
+
+2. Add descriptions to ID fields explaining they are UUIDs
+
+3. Fix all example values to use valid UUIDs:
+```yaml
+example:
+  id: "550e8400-e29b-41d4-a716-446655440000"
+  # Not: "conv_01HF8XH1XABCD1234EFGH5678"
+```
+
+4. Update path parameter schemas:
+```yaml
+parameters:
+  - name: conversationId
+    in: path
+    required: true
+    description: Unique identifier for the conversation (UUID format).
+    schema:
+      type: string
+      format: uuid
+```
+
+**File: `memory-service-contracts/src/main/resources/openapi-admin.yml`**
+
+Apply the same changes to admin API (most already uses `format: uuid` for job IDs).
+
+### Phase 2: Protocol Buffers Updates
+
+**File: `memory-service-contracts/src/main/resources/memory/v1/memory_service.proto`**
+
+Change all UUID ID fields from `string` to `bytes` for efficient binary encoding. UUIDs are exactly 16 bytes, making `bytes` the natural representation:
+
+```protobuf
+message ConversationSummary {
+  // Unique identifier (UUID as 16-byte big-endian binary)
+  bytes id = 1;
+  // ...
+}
+
+message Conversation {
+  // Unique identifier (UUID as 16-byte big-endian binary)
+  bytes id = 1;
+  // ...
+  // Entry ID where this conversation forked (empty if root)
+  bytes forked_at_entry_id = 9;
+  // Conversation ID from which this was forked (empty if root)
+  bytes forked_at_conversation_id = 10;
+}
+
+message Entry {
+  // Unique identifier (UUID as 16-byte big-endian binary)
+  bytes id = 1;
+  // Conversation this entry belongs to
+  bytes conversation_id = 2;
+  // ...
+}
+```
+
+**Benefits of `bytes` over `string`:**
+- **Size efficiency**: 16 bytes vs 36 bytes (56% smaller)
+- **No parsing overhead**: Direct byte copy vs string parsing
+- **Type safety**: Can't accidentally pass arbitrary strings
+- **Standard representation**: RFC 4122 defines UUID as 128-bit value
+
+**Wire format note:** Changing from `string` to `bytes` while keeping the same field number is a breaking change. Both use wire type 2 (length-delimited), but the content interpretation differs. Old clients will misinterpret the bytes as UTF-8 strings. Since this is a pre-release API, we accept this breaking change.
+
+**Server-side conversion helpers:**
+
+```java
+// UUID to bytes (big-endian)
+public static byte[] uuidToBytes(UUID uuid) {
+    ByteBuffer buffer = ByteBuffer.allocate(16);
+    buffer.putLong(uuid.getMostSignificantBits());
+    buffer.putLong(uuid.getLeastSignificantBits());
+    return buffer.array();
+}
+
+// Bytes to UUID
+public static UUID bytesToUuid(byte[] bytes) {
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    long mostSig = buffer.getLong();
+    long leastSig = buffer.getLong();
+    return new UUID(mostSig, leastSig);
+}
+
+// For gRPC ByteString
+public static ByteString uuidToByteString(UUID uuid) {
+    return ByteString.copyFrom(uuidToBytes(uuid));
+}
+
+public static UUID byteStringToUuid(ByteString bytes) {
+    return bytesToUuid(bytes.toByteArray());
+}
+```
+
+**Update gRPC service implementations** to convert between `UUID` and `bytes`:
+
+```java
+// In GrpcConversationsService.java
+@Override
+public void getConversation(GetConversationRequest request,
+                            StreamObserver<Conversation> responseObserver) {
+    UUID conversationId = bytesToUuid(request.getConversationId().toByteArray());
+    // ... fetch conversation ...
+    Conversation.Builder response = Conversation.newBuilder()
+        .setId(uuidToByteString(entity.getId()))
+        // ...
+    responseObserver.onNext(response.build());
+    responseObserver.onCompleted();
+}
+```
+
+### Phase 3: Site Documentation Updates
+
+**File: `site/src/pages/docs/api-contracts.md`**
+
+Add a section documenting ID formats:
+
+```markdown
+## ID Formats
+
+All resource identifiers in the Memory Service API are UUIDs
+(Universally Unique Identifiers). This applies to:
+- Conversation IDs
+- Entry IDs
+- Fork reference IDs
+
+**Note:** User IDs and client IDs are external identifiers and
+do not follow UUID format.
+
+### REST API (JSON)
+
+UUIDs are represented as strings in standard format:
+
+```
+xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+```
+
+Example: `"550e8400-e29b-41d4-a716-446655440000"`
+
+### gRPC API (Protocol Buffers)
+
+UUIDs are represented as 16-byte binary values (big-endian):
+
+| Bytes 0-7 | Bytes 8-15 |
+|-----------|------------|
+| Most significant 64 bits | Least significant 64 bits |
+
+**Java example:**
+```java
+// UUID to bytes
+ByteBuffer buffer = ByteBuffer.allocate(16);
+buffer.putLong(uuid.getMostSignificantBits());
+buffer.putLong(uuid.getLeastSignificantBits());
+byte[] bytes = buffer.array();
+
+// Bytes to UUID
+ByteBuffer buffer = ByteBuffer.wrap(bytes);
+UUID uuid = new UUID(buffer.getLong(), buffer.getLong());
+```
+
+**Go example:**
+```go
+// UUID to bytes - google/uuid package stores as [16]byte
+id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+bytes := id[:] // id is already [16]byte
+
+// Bytes to UUID
+id, err := uuid.FromBytes(bytes)
+```
+```
+
+### Phase 4: Regenerate Clients
+
+After updating contracts, regenerate all client code:
+
+```bash
+./mvnw compile
+```
+
+This will regenerate:
+- Java REST client DTOs
+- Java gRPC stubs
+
+### Phase 5: Verify Tests Pass
+
+Run the full test suite to ensure no regressions:
+
+```bash
+./mvnw test
+```
+
+## Impact Assessment
+
+### Client Code Generation
+
+**REST API (OpenAPI Generator):**
+
+| Language | Before | After |
+|----------|--------|-------|
+| Java | `String` | `java.util.UUID` |
+| TypeScript | `string` | `string` (with JSDoc) |
+| Go | `string` | `uuid.UUID` (depends on config) |
+| Python | `str` | `uuid.UUID` |
+
+**gRPC (all languages):**
+
+| Language | Before | After |
+|----------|--------|-------|
+| Java | `String` | `ByteString` (convert to UUID) |
+| Go | `string` | `[]byte` (convert to uuid.UUID) |
+| Python | `str` | `bytes` (convert to uuid.UUID) |
+| TypeScript | `string` | `Uint8Array` |
+
+### Breaking Changes
+
+**REST API:** None - wire format remains the same (UUIDs serialized as JSON strings)
+
+**gRPC API:** **Breaking change** - wire format changes from UTF-8 string to binary bytes
+- Existing gRPC clients will fail to deserialize responses
+- Clients must regenerate stubs from updated proto
+- Server and clients must be updated together
+
+**Generated REST Clients:**
+- Java clients: `String` → `UUID` type change
+- Other languages: varies by generator
+
+**Generated gRPC Clients:**
+- All languages: `string` → `bytes` type change
+- Requires conversion code to work with UUID types
+
+### Migration for Existing Clients
+
+**REST clients:**
+
+```java
+// Before
+String conversationId = "550e8400-e29b-41d4-a716-446655440000";
+api.getConversation(conversationId);
+
+// After
+UUID conversationId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+api.getConversation(conversationId);
+```
+
+**gRPC clients (Java):**
+
+```java
+// Before
+GetConversationRequest request = GetConversationRequest.newBuilder()
+    .setConversationId("550e8400-e29b-41d4-a716-446655440000")
+    .build();
+
+// After
+UUID uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+ByteBuffer buffer = ByteBuffer.allocate(16);
+buffer.putLong(uuid.getMostSignificantBits());
+buffer.putLong(uuid.getLeastSignificantBits());
+
+GetConversationRequest request = GetConversationRequest.newBuilder()
+    .setConversationId(ByteString.copyFrom(buffer.array()))
+    .build();
+```
+
+**gRPC clients (Go):**
+
+```go
+// Before
+req := &pb.GetConversationRequest{
+    ConversationId: "550e8400-e29b-41d4-a716-446655440000",
+}
+
+// After
+id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+req := &pb.GetConversationRequest{
+    ConversationId: id[:], // UUID is already [16]byte
+}
+```
+
+## Alternatives Considered
+
+### 1. Keep IDs as Unformatted Strings
+- **Pros:** No client migration needed
+- **Cons:** Poor documentation, no type safety, confusing examples, inefficient
+
+### 2. Use Custom OpenAPI Extension
+- **Pros:** Non-breaking
+- **Cons:** Not standard, generators may not support
+
+### 3. Only Update Examples and Descriptions
+- **Pros:** Non-breaking, better docs
+- **Cons:** Miss code generation benefits, still inefficient for gRPC
+
+### 4. Use `string` with Documentation in Proto (instead of `bytes`)
+- **Pros:** Non-breaking for gRPC, simpler client code
+- **Cons:** 56% larger wire format, parsing overhead, less type-safe
+
+### 5. Use a Custom `Uuid` Message Type in Proto
+```protobuf
+message Uuid {
+  fixed64 high = 1;
+  fixed64 low = 2;
+}
+```
+- **Pros:** Self-documenting, efficient (16 bytes + small overhead)
+- **Cons:** More complex, requires wrapper code, non-standard
+
+**Decision:** Use `format: uuid` in OpenAPI and `bytes` in Proto. The benefits of accurate contracts, type-safe clients, and efficient wire format outweigh the migration effort. Since the service is pre-release, breaking changes are acceptable.
+
+## Checklist
+
+### OpenAPI Updates
+- [ ] Update `openapi.yml` with `format: uuid` for all ID fields
+- [ ] Update `openapi.yml` examples to use valid UUIDs
+- [ ] Update `openapi-admin.yml` with `format: uuid` for remaining ID fields
+
+### Protocol Buffers Updates
+- [ ] Change ID fields from `string` to `bytes` in `memory_service.proto`
+- [ ] Add documentation comments explaining UUID binary format
+- [ ] Create `UuidUtils` helper class for UUID ↔ bytes conversion
+
+### Server Implementation Updates
+- [ ] Update gRPC service implementations to use bytes for UUIDs
+- [ ] Update DTO mappers for gRPC responses
+
+### Documentation Updates
+- [ ] Update `site/src/pages/docs/api-contracts.md` with ID format section
+- [ ] Document gRPC UUID bytes format for client developers
+
+### Verification
+- [ ] Regenerate clients with `./mvnw compile`
+- [ ] Run tests with `./mvnw test`
+- [ ] Test gRPC clients with new bytes format
+- [ ] Update changelog
+
+## References
+
+- [OpenAPI Format Specification](https://spec.openapis.org/oas/v3.1.0#format)
+- [RFC 4122 - UUID URN Namespace](https://tools.ietf.org/html/rfc4122) - Section 4.1.2 defines the 128-bit binary layout
+- [Proto3 Scalar Types](https://protobuf.dev/programming-guides/proto3/#scalar) - `bytes` type documentation
+- [Proto3 Best Practices](https://protobuf.dev/programming-guides/dos-donts/)

--- a/memory-service-contracts/src/main/resources/memory/v1/memory_service.proto
+++ b/memory-service-contracts/src/main/resources/memory/v1/memory_service.proto
@@ -7,6 +7,14 @@ import "google/protobuf/struct.proto";
 option java_multiple_files = true;
 option java_package = "io.github.chirino.memory.grpc.v1";
 
+// UUID fields are represented as 16-byte big-endian binary values.
+// Use the most significant 64 bits first, then least significant 64 bits.
+// Example conversion (Java):
+//   ByteBuffer buffer = ByteBuffer.allocate(16);
+//   buffer.putLong(uuid.getMostSignificantBits());
+//   buffer.putLong(uuid.getLeastSignificantBits());
+//   return buffer.array();
+
 message PageRequest {
   string page_token = 1;
   int32 page_size = 2;
@@ -39,7 +47,8 @@ enum Channel {
 }
 
 message ConversationSummary {
-  string id = 1;
+  // Unique identifier (UUID as 16-byte big-endian binary)
+  bytes id = 1;
   string title = 2;
   string owner_user_id = 3;
   string created_at = 4;
@@ -49,7 +58,8 @@ message ConversationSummary {
 }
 
 message Conversation {
-  string id = 1;
+  // Unique identifier (UUID as 16-byte big-endian binary)
+  bytes id = 1;
   string title = 2;
   string owner_user_id = 3;
   string created_at = 4;
@@ -57,12 +67,15 @@ message Conversation {
   string last_message_preview = 6;
   AccessLevel access_level = 7;
   reserved 8; // conversation_group_id removed
-  string forked_at_entry_id = 9;
-  string forked_at_conversation_id = 10;
+  // Entry ID where this conversation forked (empty if root)
+  bytes forked_at_entry_id = 9;
+  // Conversation ID from which this was forked (empty if root)
+  bytes forked_at_conversation_id = 10;
 }
 
 message ConversationMembership {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
   string user_id = 2;
   AccessLevel access_level = 3;
   string created_at = 4;
@@ -70,10 +83,13 @@ message ConversationMembership {
 }
 
 message ConversationForkSummary {
-  string conversation_id = 1;
+  // Forked conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
   reserved 2; // conversation_group_id removed
-  string forked_at_entry_id = 3;
-  string forked_at_conversation_id = 4;
+  // Entry ID at which this conversation forked
+  bytes forked_at_entry_id = 3;
+  // Conversation ID from which this was forked
+  bytes forked_at_conversation_id = 4;
   string title = 5;
   string created_at = 6;
 }
@@ -95,21 +111,26 @@ message ListConversationsResponse {
 }
 
 message GetConversationRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
 }
 
 message DeleteConversationRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
 }
 
 message ForkConversationRequest {
-  string conversation_id = 1;
-  string entry_id = 2;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
+  // Entry ID to fork at (UUID as 16-byte big-endian binary)
+  bytes entry_id = 2;
   string title = 3;
 }
 
 message ListForksRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
 }
 
 message ListForksResponse {
@@ -117,7 +138,8 @@ message ListForksResponse {
 }
 
 message TransferOwnershipRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
   string new_owner_user_id = 2;
 }
 
@@ -130,7 +152,8 @@ message CreateEntryRequest {
 }
 
 message SyncEntriesRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
   repeated CreateEntryRequest entries = 2;
 }
 
@@ -142,12 +165,14 @@ message SyncEntriesResponse {
 }
 
 message AppendEntryRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
   CreateEntryRequest entry = 2;
 }
 
 message ListEntriesRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
   Channel channel = 2;
   string epoch_filter = 3;
   PageRequest page = 4;
@@ -159,8 +184,10 @@ message ListEntriesResponse {
 }
 
 message Entry {
-  string id = 1;
-  string conversation_id = 2;
+  // Unique identifier (UUID as 16-byte big-endian binary)
+  bytes id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 2;
   string user_id = 3;
   Channel channel = 4;
   int64 epoch = 5;
@@ -170,7 +197,8 @@ message Entry {
 }
 
 message ListMembershipsRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
 }
 
 message ListMembershipsResponse {
@@ -178,27 +206,32 @@ message ListMembershipsResponse {
 }
 
 message ShareConversationRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
   string user_id = 2;
   AccessLevel access_level = 3;
 }
 
 message UpdateMembershipRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
   string member_user_id = 2;
   AccessLevel access_level = 3;
 }
 
 message DeleteMembershipRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
   string member_user_id = 2;
 }
 
 message SearchEntriesRequest {
   string query = 1;
   int32 top_k = 2;
-  repeated string conversation_ids = 3;
-  string before = 4;
+  // Conversation identifiers to filter (UUID as 16-byte big-endian binary each)
+  repeated bytes conversation_ids = 3;
+  // Upper bound entry ID for temporal filtering (UUID as 16-byte big-endian binary)
+  bytes before = 4;
 }
 
 message SearchEntriesResponse {
@@ -212,10 +245,12 @@ message SearchResult {
 }
 
 message IndexTranscriptRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
   optional string title = 2;
   string transcript = 3;
-  string until_entry_id = 4;
+  // Highest entry ID covered by the index (UUID as 16-byte big-endian binary)
+  bytes until_entry_id = 4;
 }
 
 message HealthResponse {
@@ -258,13 +293,13 @@ service SearchService {
 service ResponseResumerService {
   // Stream response tokens for a conversation
   rpc StreamResponseTokens(stream StreamResponseTokenRequest) returns (stream StreamResponseTokenResponse);
-  
+
   // Replay cached response tokens from a resume position
   rpc ReplayResponseTokens(ReplayResponseTokensRequest) returns (stream ReplayResponseTokensResponse);
 
   // Cancel an in-progress response
   rpc CancelResponse(CancelResponseRequest) returns (CancelResponseResponse);
-  
+
   // Check if response resumer is enabled
   rpc IsEnabled(google.protobuf.Empty) returns (IsEnabledResponse);
 
@@ -273,7 +308,8 @@ service ResponseResumerService {
 }
 
 message StreamResponseTokenRequest {
-  string conversation_id = 1;  // Only in first message
+  // Conversation identifier (UUID as 16-byte big-endian binary, only in first message)
+  bytes conversation_id = 1;
   string token = 2;            // Token content
   bool complete = 3;           // Set to true in final message
 }
@@ -286,7 +322,8 @@ message StreamResponseTokenResponse {
 }
 
 message ReplayResponseTokensRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
   // Field 2 (resume_position) removed - always replays from beginning
 }
 
@@ -296,7 +333,8 @@ message ReplayResponseTokensResponse {
 }
 
 message CancelResponseRequest {
-  string conversation_id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
 }
 
 message CancelResponseResponse {
@@ -308,9 +346,11 @@ message IsEnabledResponse {
 }
 
 message CheckConversationsRequest {
-  repeated string conversation_ids = 1;
+  // Conversation identifiers (UUID as 16-byte big-endian binary each)
+  repeated bytes conversation_ids = 1;
 }
 
 message CheckConversationsResponse {
-  repeated string conversation_ids = 1;  // Only IDs with responses in progress
+  // Conversation IDs with responses in progress (UUID as 16-byte big-endian binary each)
+  repeated bytes conversation_ids = 1;
 }

--- a/memory-service-contracts/src/main/resources/openapi-admin.yml
+++ b/memory-service-contracts/src/main/resources/openapi-admin.yml
@@ -82,9 +82,10 @@ paths:
         - name: after
           in: query
           required: false
-          description: Cursor for pagination.
+          description: Cursor for pagination (UUID format).
           schema:
             type: string
+            format: uuid
         - name: limit
           in: query
           required: false
@@ -127,9 +128,10 @@ paths:
         - name: id
           in: path
           required: true
-          description: Conversation identifier.
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
         - name: includeDeleted
           in: query
           required: false
@@ -168,9 +170,10 @@ paths:
         - name: id
           in: path
           required: true
-          description: Conversation identifier.
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
       requestBody:
         required: false
         content:
@@ -198,9 +201,10 @@ paths:
         - name: id
           in: path
           required: true
-          description: Conversation identifier.
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
       requestBody:
         required: false
         content:
@@ -239,15 +243,17 @@ paths:
         - name: id
           in: path
           required: true
-          description: Conversation identifier.
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
         - name: after
           in: query
           required: false
-          description: Cursor for pagination.
+          description: Cursor for pagination (UUID format).
           schema:
             type: string
+            format: uuid
         - name: limit
           in: query
           required: false
@@ -307,9 +313,10 @@ paths:
         - name: id
           in: path
           required: true
-          description: Conversation identifier.
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
         - name: includeDeleted
           in: query
           required: false
@@ -533,6 +540,8 @@ components:
       properties:
         id:
           type: string
+          format: uuid
+          description: Unique identifier for the conversation.
         title:
           type: string
           nullable: true
@@ -562,10 +571,14 @@ components:
           properties:
             forkedAtEntryId:
               type: string
+              format: uuid
               nullable: true
+              description: Entry ID where this conversation forked from its parent.
             forkedAtConversationId:
               type: string
+              format: uuid
               nullable: true
+              description: Conversation ID from which this conversation was forked.
 
     AdminActionRequest:
       type: object
@@ -596,8 +609,12 @@ components:
       properties:
         id:
           type: string
+          format: uuid
+          description: Unique identifier for the entry.
         conversationId:
           type: string
+          format: uuid
+          description: Unique identifier for the conversation this entry belongs to.
         userId:
           type: string
           nullable: true
@@ -624,6 +641,8 @@ components:
       properties:
         conversationId:
           type: string
+          format: uuid
+          description: Unique identifier for the conversation.
         userId:
           type: string
         accessLevel:
@@ -647,14 +666,18 @@ components:
           type: array
           items:
             type: string
+            format: uuid
           nullable: true
+          description: Filter search to specific conversations (UUID format).
         userId:
           type: string
           nullable: true
           description: Filter search to conversations owned by this user.
         before:
           type: string
+          format: uuid
           nullable: true
+          description: Optional upper bound entry ID for temporal filtering.
         includeDeleted:
           type: boolean
           default: false

--- a/memory-service-contracts/src/main/resources/openapi.yml
+++ b/memory-service-contracts/src/main/resources/openapi.yml
@@ -45,9 +45,10 @@ paths:
         - name: after
           in: query
           required: false
-          description: Cursor for pagination; returns items after this conversation id.
+          description: Cursor for pagination; returns items after this conversation id (UUID format).
           schema:
             type: string
+            format: uuid
             nullable: true
         - name: limit
           in: query
@@ -116,9 +117,10 @@ paths:
         - name: conversationId
           in: path
           required: true
-          description: Conversation identifier.
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
       responses:
         '200':
           description: The conversation.
@@ -144,8 +146,10 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
       responses:
         '204':
           description: Conversation deleted.
@@ -176,14 +180,17 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
         - name: after
           in: query
           required: false
-          description: Cursor for pagination; returns entries after this entry id.
+          description: Cursor for pagination; returns entries after this entry id (UUID format).
           schema:
             type: string
+            format: uuid
             nullable: true
         - name: limit
           in: query
@@ -249,8 +256,10 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
       requestBody:
         required: true
         content:
@@ -289,8 +298,10 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
       requestBody:
         required: true
         content:
@@ -327,13 +338,17 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
         - name: entryId
           in: path
           required: true
+          description: Entry identifier (UUID format).
           schema:
             type: string
+            format: uuid
       requestBody:
         required: false
         content:
@@ -370,8 +385,10 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
       responses:
         '200':
           description: Forked conversations related to this conversation's root.
@@ -403,8 +420,10 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
       responses:
         '200':
           description: Cancel request accepted.
@@ -432,8 +451,10 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
       requestBody:
         required: true
         content:
@@ -466,8 +487,10 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
       responses:
         '200':
           description: Memberships for the conversation.
@@ -496,8 +519,10 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
       requestBody:
         required: true
         content:
@@ -528,8 +553,10 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
         - name: userId
           in: path
           required: true
@@ -565,8 +592,10 @@ paths:
         - name: conversationId
           in: path
           required: true
+          description: Conversation identifier (UUID format).
           schema:
             type: string
+            format: uuid
         - name: userId
           in: path
           required: true
@@ -699,6 +728,8 @@ components:
       properties:
         id:
           type: string
+          format: uuid
+          description: Unique identifier for the conversation.
         title:
           type: string
           nullable: true
@@ -716,12 +747,12 @@ components:
         accessLevel:
           $ref: '#/components/schemas/AccessLevel'
       example:
-        id: "conv_01HF8XH1XABCD1234EFGH5678"
+        id: "550e8400-e29b-41d4-a716-446655440000"
         title: "Brainstorming UI for memory service"
         ownerUserId: "user_1234"
         createdAt: "2025-01-10T14:32:05Z"
         updatedAt: "2025-01-10T14:45:12Z"
-        lastMessagePreview: "Let’s try modeling forks as separate conversations…"
+        lastMessagePreview: "Let's try modeling forks as separate conversations…"
         accessLevel: "owner"
 
     Conversation:
@@ -731,12 +762,16 @@ components:
           properties:
             forkedAtEntryId:
               type: string
+              format: uuid
               nullable: true
+              description: Entry ID where this conversation forked from its parent.
             forkedAtConversationId:
               type: string
+              format: uuid
               nullable: true
+              description: Conversation ID from which this conversation was forked.
           example:
-            id: "conv_01HF8XH1XABCD1234EFGH5678"
+            id: "550e8400-e29b-41d4-a716-446655440000"
             title: "Brainstorming UI for memory service"
             ownerUserId: "user_1234"
             createdAt: "2025-01-10T14:32:05Z"
@@ -766,6 +801,8 @@ components:
       properties:
         conversationId:
           type: string
+          format: uuid
+          description: Unique identifier for the conversation.
         userId:
           type: string
         accessLevel:
@@ -780,13 +817,17 @@ components:
       properties:
         conversationId:
           type: string
+          format: uuid
+          description: Unique identifier for the forked conversation.
         forkedAtEntryId:
           type: string
-          description: Entry id at which this forked conversation diverged.
+          format: uuid
+          description: Entry ID at which this forked conversation diverged.
         forkedAtConversationId:
           type: string
+          format: uuid
           nullable: true
-          description: Conversation id where the fork occurred.
+          description: Conversation ID where the fork occurred.
         title:
           type: string
           nullable: true
@@ -836,8 +877,12 @@ components:
       properties:
         id:
           type: string
+          format: uuid
+          description: Unique identifier for the entry.
         conversationId:
           type: string
+          format: uuid
+          description: Unique identifier for the conversation this entry belongs to.
         userId:
           type: string
           nullable: true
@@ -871,8 +916,8 @@ components:
           type: string
           format: date-time
       example:
-        id: "entry_01HF8XJQWXYZ9876ABCD5432"
-        conversationId: "conv_01HF8XH1XABCD1234EFGH5678"
+        id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+        conversationId: "550e8400-e29b-41d4-a716-446655440000"
         userId: "user_1234"
         channel: "history"
         epoch: null
@@ -972,8 +1017,8 @@ components:
         noOp: false
         epochIncremented: true
         entries:
-          - id: "entry_01HF8XJQWXYZ9876ABCD5432"
-            conversationId: "conv_01HF8XH1XABCD1234EFGH5678"
+          - id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+            conversationId: "550e8400-e29b-41d4-a716-446655440000"
             userId: "agent_memory"
             channel: "memory"
             epoch: 5
@@ -992,6 +1037,7 @@ components:
       properties:
         conversationId:
           type: string
+          format: uuid
           description: The conversation to index.
         title:
           type: string
@@ -1002,12 +1048,13 @@ components:
           description: Transcript text to index for semantic search.
         untilEntryId:
           type: string
-          description: Highest entry id covered by the index (inclusive).
+          format: uuid
+          description: Highest entry ID covered by the index (inclusive).
       example:
-        conversationId: "conv_01HF8XH1XABCD1234EFGH5678"
+        conversationId: "550e8400-e29b-41d4-a716-446655440000"
         title: "Conversation forking design"
         transcript: "User asked several questions about conversation forking. They want to support branching at any message with independent access control per branch."
-        untilEntryId: "entry_01HF8XJQWXYZ9876ABCD5431"
+        untilEntryId: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 
     SearchConversationsRequest:
       type: object
@@ -1024,18 +1071,21 @@ components:
           type: array
           items:
             type: string
+            format: uuid
           nullable: true
+          description: Filter search to specific conversations (UUID format).
         before:
           type: string
+          format: uuid
           nullable: true
-          description: Optional upper bound entry id for temporal filtering.
+          description: Optional upper bound entry ID for temporal filtering.
       example:
         query: "summary of memory service design decisions"
         topK: 5
         conversationIds:
-          - "conv_01HF8XH1XABCD1234EFGH5678"
-          - "conv_01HF8XH1XABCD1234EFGH5679"
-        before: "entry_01HF8XJQWXYZ9876ABCD5431"
+          - "550e8400-e29b-41d4-a716-446655440000"
+          - "550e8400-e29b-41d4-a716-446655440001"
+        before: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
 
     SearchResult:
       type: object
@@ -1050,8 +1100,8 @@ components:
           nullable: true
       example:
         entry:
-          id: "entry_01HF8XJQWXYZ9876ABCD5430"
-          conversationId: "conv_01HF8XH1XABCD1234EFGH5678"
+          id: "6ba7b810-9dad-11d1-80b4-00c04fd430c9"
+          conversationId: "550e8400-e29b-41d4-a716-446655440000"
           userId: "user_1234"
           channel: "history"
           contentType: "message"

--- a/memory-service/src/main/java/io/github/chirino/memory/api/AdminResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/AdminResource.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import org.jboss.logging.Logger;
 
 @Path("/v1/admin")
@@ -264,7 +265,8 @@ public class AdminResource {
                                     dto -> {
                                         ConversationMembership result =
                                                 new ConversationMembership();
-                                        result.setConversationId(id);
+                                        result.setConversationId(
+                                                id != null ? UUID.fromString(id) : null);
                                         result.setUserId(dto.getUserId());
                                         if (dto.getAccessLevel() != null) {
                                             result.setAccessLevel(
@@ -522,8 +524,9 @@ public class AdminResource {
             return null;
         }
         Entry result = new Entry();
-        result.setId(dto.getId());
-        result.setConversationId(dto.getConversationId());
+        result.setId(dto.getId() != null ? UUID.fromString(dto.getId()) : null);
+        result.setConversationId(
+                dto.getConversationId() != null ? UUID.fromString(dto.getConversationId()) : null);
         result.setUserId(dto.getUserId());
         if (dto.getChannel() != null) {
             result.setChannel(Entry.ChannelEnum.fromString(dto.getChannel().toValue()));

--- a/memory-service/src/main/java/io/github/chirino/memory/api/ConversationsResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/ConversationsResource.java
@@ -64,6 +64,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 
@@ -490,7 +491,7 @@ public class ConversationsResource {
             error.setDetails(Map.of("message", "Index request body is required"));
             return Response.status(Response.Status.BAD_REQUEST).entity(error).build();
         }
-        if (request.getConversationId() == null || request.getConversationId().isBlank()) {
+        if (request.getConversationId() == null) {
             ErrorResponse error = new ErrorResponse();
             error.setError("Invalid request");
             error.setCode("bad_request");
@@ -504,25 +505,25 @@ public class ConversationsResource {
             error.setDetails(Map.of("message", "Transcript text is required"));
             return Response.status(Response.Status.BAD_REQUEST).entity(error).build();
         }
-        if (request.getUntilEntryId() == null || request.getUntilEntryId().isBlank()) {
+        if (request.getUntilEntryId() == null) {
             ErrorResponse error = new ErrorResponse();
             error.setError("Invalid request");
             error.setCode("bad_request");
             error.setDetails(Map.of("message", "untilEntryId is required"));
             return Response.status(Response.Status.BAD_REQUEST).entity(error).build();
         }
-        String conversationId = request.getConversationId();
-        String untilEntryId = request.getUntilEntryId();
+        String conversationId = request.getConversationId().toString();
+        String untilEntryId = request.getUntilEntryId().toString();
         LOG.infof(
                 "Indexing transcript for conversationId=%s, untilEntryId=%s",
                 conversationId, untilEntryId);
         try {
             io.github.chirino.memory.api.dto.IndexTranscriptRequest internal =
                     new io.github.chirino.memory.api.dto.IndexTranscriptRequest();
-            internal.setConversationId(request.getConversationId());
+            internal.setConversationId(conversationId);
             internal.setTitle(request.getTitle());
             internal.setTranscript(request.getTranscript());
-            internal.setUntilEntryId(request.getUntilEntryId());
+            internal.setUntilEntryId(untilEntryId);
 
             EntryDto dto = store().indexTranscript(internal, clientId);
             LOG.infof(
@@ -754,7 +755,7 @@ public class ConversationsResource {
             return null;
         }
         ConversationSummary result = new ConversationSummary();
-        result.setId(dto.getId());
+        result.setId(dto.getId() != null ? UUID.fromString(dto.getId()) : null);
         result.setTitle(dto.getTitle());
         result.setOwnerUserId(dto.getOwnerUserId());
         result.setCreatedAt(parseDate(dto.getCreatedAt()));
@@ -773,7 +774,7 @@ public class ConversationsResource {
             return null;
         }
         Conversation result = new Conversation();
-        result.setId(dto.getId());
+        result.setId(dto.getId() != null ? UUID.fromString(dto.getId()) : null);
         result.setTitle(dto.getTitle());
         result.setOwnerUserId(dto.getOwnerUserId());
         result.setCreatedAt(parseDate(dto.getCreatedAt()));
@@ -785,8 +786,14 @@ public class ConversationsResource {
                             dto.getAccessLevel().name().toLowerCase()));
         }
         // conversationGroupId is not exposed in API responses
-        result.setForkedAtEntryId(dto.getForkedAtEntryId());
-        result.setForkedAtConversationId(dto.getForkedAtConversationId());
+        result.setForkedAtEntryId(
+                dto.getForkedAtEntryId() != null
+                        ? UUID.fromString(dto.getForkedAtEntryId())
+                        : null);
+        result.setForkedAtConversationId(
+                dto.getForkedAtConversationId() != null
+                        ? UUID.fromString(dto.getForkedAtConversationId())
+                        : null);
         return result;
     }
 
@@ -796,7 +803,7 @@ public class ConversationsResource {
             return null;
         }
         ConversationMembership result = new ConversationMembership();
-        result.setConversationId(conversationId);
+        result.setConversationId(conversationId != null ? UUID.fromString(conversationId) : null);
         result.setUserId(dto.getUserId());
         if (dto.getAccessLevel() != null) {
             result.setAccessLevel(
@@ -813,10 +820,17 @@ public class ConversationsResource {
             return null;
         }
         ConversationForkSummary result = new ConversationForkSummary();
-        result.setConversationId(dto.getConversationId());
+        result.setConversationId(
+                dto.getConversationId() != null ? UUID.fromString(dto.getConversationId()) : null);
         // conversationGroupId is not exposed in API responses
-        result.setForkedAtEntryId(dto.getForkedAtEntryId());
-        result.setForkedAtConversationId(dto.getForkedAtConversationId());
+        result.setForkedAtEntryId(
+                dto.getForkedAtEntryId() != null
+                        ? UUID.fromString(dto.getForkedAtEntryId())
+                        : null);
+        result.setForkedAtConversationId(
+                dto.getForkedAtConversationId() != null
+                        ? UUID.fromString(dto.getForkedAtConversationId())
+                        : null);
         result.setTitle(dto.getTitle());
         result.setCreatedAt(parseDate(dto.getCreatedAt()));
         return result;
@@ -827,8 +841,9 @@ public class ConversationsResource {
             return null;
         }
         Entry result = new Entry();
-        result.setId(dto.getId());
-        result.setConversationId(dto.getConversationId());
+        result.setId(dto.getId() != null ? UUID.fromString(dto.getId()) : null);
+        result.setConversationId(
+                dto.getConversationId() != null ? UUID.fromString(dto.getConversationId()) : null);
         result.setUserId(dto.getUserId());
         if (dto.getChannel() != null) {
             result.setChannel(Entry.ChannelEnum.fromString(dto.getChannel().toValue()));

--- a/memory-service/src/main/java/io/github/chirino/memory/api/SearchResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/SearchResource.java
@@ -25,6 +25,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Path("/v1")
 @Authenticated
@@ -58,8 +60,13 @@ public class SearchResource {
                     new io.github.chirino.memory.api.dto.SearchEntriesRequest();
             internal.setQuery(request.getQuery());
             internal.setTopK(request.getTopK());
-            internal.setConversationIds(request.getConversationIds());
-            internal.setBefore(request.getBefore());
+            if (request.getConversationIds() != null) {
+                internal.setConversationIds(
+                        request.getConversationIds().stream()
+                                .map(UUID::toString)
+                                .collect(Collectors.toList()));
+            }
+            internal.setBefore(request.getBefore() != null ? request.getBefore().toString() : null);
 
             List<SearchResultDto> internalResults = vectorStore.search(currentUserId(), internal);
             List<SearchResult> data =
@@ -114,8 +121,9 @@ public class SearchResource {
             return null;
         }
         Entry result = new Entry();
-        result.setId(dto.getId());
-        result.setConversationId(dto.getConversationId());
+        result.setId(dto.getId() != null ? UUID.fromString(dto.getId()) : null);
+        result.setConversationId(
+                dto.getConversationId() != null ? UUID.fromString(dto.getConversationId()) : null);
         result.setUserId(dto.getUserId());
         Channel channel = dto.getChannel();
         if (channel != null) {

--- a/memory-service/src/main/java/io/github/chirino/memory/grpc/ConversationMembershipsGrpcService.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/grpc/ConversationMembershipsGrpcService.java
@@ -1,5 +1,7 @@
 package io.github.chirino.memory.grpc;
 
+import static io.github.chirino.memory.grpc.UuidUtils.byteStringToString;
+
 import com.google.protobuf.Empty;
 import io.github.chirino.memory.api.dto.ConversationMembershipDto;
 import io.github.chirino.memory.api.dto.ShareConversationRequest;
@@ -25,18 +27,16 @@ public class ConversationMembershipsGrpcService extends AbstractGrpcService
         return Uni.createFrom()
                 .item(
                         () -> {
+                            String conversationId = byteStringToString(request.getConversationId());
                             List<ConversationMembershipDto> internal =
-                                    store().listMemberships(
-                                                    currentUserId(), request.getConversationId());
+                                    store().listMemberships(currentUserId(), conversationId);
                             return ListMembershipsResponse.newBuilder()
                                     .addAllMemberships(
                                             internal.stream()
                                                     .map(
                                                             dto ->
                                                                     GrpcDtoMapper.toProto(
-                                                                            dto,
-                                                                            request
-                                                                                    .getConversationId()))
+                                                                            dto, conversationId))
                                                     .collect(Collectors.toList()))
                                     .build();
                         })
@@ -50,16 +50,15 @@ public class ConversationMembershipsGrpcService extends AbstractGrpcService
         return Uni.createFrom()
                 .item(
                         () -> {
+                            String conversationId = byteStringToString(request.getConversationId());
                             ShareConversationRequest internal = new ShareConversationRequest();
                             internal.setUserId(request.getUserId());
                             internal.setAccessLevel(
                                     GrpcDtoMapper.accessLevelFromProto(request.getAccessLevel()));
                             ConversationMembershipDto dto =
                                     store().shareConversation(
-                                                    currentUserId(),
-                                                    request.getConversationId(),
-                                                    internal);
-                            return GrpcDtoMapper.toProto(dto, request.getConversationId());
+                                                    currentUserId(), conversationId, internal);
+                            return GrpcDtoMapper.toProto(dto, conversationId);
                         })
                 .onFailure()
                 .transform(GrpcStatusMapper::map);
@@ -70,6 +69,7 @@ public class ConversationMembershipsGrpcService extends AbstractGrpcService
         return Uni.createFrom()
                 .item(
                         () -> {
+                            String conversationId = byteStringToString(request.getConversationId());
                             ShareConversationRequest internal = new ShareConversationRequest();
                             internal.setUserId(request.getMemberUserId());
                             internal.setAccessLevel(
@@ -77,10 +77,10 @@ public class ConversationMembershipsGrpcService extends AbstractGrpcService
                             ConversationMembershipDto dto =
                                     store().updateMembership(
                                                     currentUserId(),
-                                                    request.getConversationId(),
+                                                    conversationId,
                                                     request.getMemberUserId(),
                                                     internal);
-                            return GrpcDtoMapper.toProto(dto, request.getConversationId());
+                            return GrpcDtoMapper.toProto(dto, conversationId);
                         })
                 .onFailure()
                 .transform(GrpcStatusMapper::map);
@@ -91,9 +91,10 @@ public class ConversationMembershipsGrpcService extends AbstractGrpcService
         return Uni.createFrom()
                 .item(
                         () -> {
+                            String conversationId = byteStringToString(request.getConversationId());
                             store().deleteMembership(
                                             currentUserId(),
-                                            request.getConversationId(),
+                                            conversationId,
                                             request.getMemberUserId());
                             return Empty.getDefaultInstance();
                         })

--- a/memory-service/src/main/java/io/github/chirino/memory/grpc/ConversationsGrpcService.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/grpc/ConversationsGrpcService.java
@@ -1,5 +1,7 @@
 package io.github.chirino.memory.grpc;
 
+import static io.github.chirino.memory.grpc.UuidUtils.byteStringToString;
+
 import com.google.protobuf.Empty;
 import io.github.chirino.memory.api.ConversationListMode;
 import io.github.chirino.memory.api.dto.ConversationDto;
@@ -85,9 +87,9 @@ public class ConversationsGrpcService extends AbstractGrpcService implements Con
         return Uni.createFrom()
                 .item(
                         () -> {
+                            String conversationId = byteStringToString(request.getConversationId());
                             ConversationDto dto =
-                                    store().getConversation(
-                                                    currentUserId(), request.getConversationId());
+                                    store().getConversation(currentUserId(), conversationId);
                             return GrpcDtoMapper.toProto(dto);
                         })
                 .onFailure()
@@ -99,8 +101,8 @@ public class ConversationsGrpcService extends AbstractGrpcService implements Con
         return Uni.createFrom()
                 .item(
                         () -> {
-                            store().deleteConversation(
-                                            currentUserId(), request.getConversationId());
+                            String conversationId = byteStringToString(request.getConversationId());
+                            store().deleteConversation(currentUserId(), conversationId);
                             return Empty.getDefaultInstance();
                         })
                 .onFailure()
@@ -112,6 +114,8 @@ public class ConversationsGrpcService extends AbstractGrpcService implements Con
         return Uni.createFrom()
                 .item(
                         () -> {
+                            String conversationId = byteStringToString(request.getConversationId());
+                            String entryId = byteStringToString(request.getEntryId());
                             ForkFromEntryRequest internal = new ForkFromEntryRequest();
                             if (request.getTitle() != null) {
                                 internal.setTitle(request.getTitle());
@@ -119,8 +123,8 @@ public class ConversationsGrpcService extends AbstractGrpcService implements Con
                             ConversationDto forked =
                                     store().forkConversationAtEntry(
                                                     currentUserId(),
-                                                    request.getConversationId(),
-                                                    request.getEntryId(),
+                                                    conversationId,
+                                                    entryId,
                                                     internal);
                             return GrpcDtoMapper.toProto(forked);
                         })
@@ -133,8 +137,9 @@ public class ConversationsGrpcService extends AbstractGrpcService implements Con
         return Uni.createFrom()
                 .item(
                         () -> {
+                            String conversationId = byteStringToString(request.getConversationId());
                             List<ConversationForkSummaryDto> forks =
-                                    store().listForks(currentUserId(), request.getConversationId());
+                                    store().listForks(currentUserId(), conversationId);
                             return ListForksResponse.newBuilder()
                                     .addAllForks(
                                             forks.stream()
@@ -151,9 +156,10 @@ public class ConversationsGrpcService extends AbstractGrpcService implements Con
         return Uni.createFrom()
                 .item(
                         () -> {
+                            String conversationId = byteStringToString(request.getConversationId());
                             store().requestOwnershipTransfer(
                                             currentUserId(),
-                                            request.getConversationId(),
+                                            conversationId,
                                             request.getNewOwnerUserId());
                             return Empty.getDefaultInstance();
                         })

--- a/memory-service/src/main/java/io/github/chirino/memory/grpc/EntriesGrpcService.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/grpc/EntriesGrpcService.java
@@ -1,5 +1,7 @@
 package io.github.chirino.memory.grpc;
 
+import static io.github.chirino.memory.grpc.UuidUtils.byteStringToString;
+
 import io.github.chirino.memory.api.dto.PagedEntries;
 import io.github.chirino.memory.api.dto.SyncResult;
 import io.github.chirino.memory.client.model.CreateEntryRequest;
@@ -29,8 +31,8 @@ public class EntriesGrpcService extends AbstractGrpcService implements EntriesSe
         return Uni.createFrom()
                 .item(
                         () -> {
-                            if (request.getConversationId() == null
-                                    || request.getConversationId().isBlank()) {
+                            String conversationId = byteStringToString(request.getConversationId());
+                            if (conversationId == null || conversationId.isBlank()) {
                                 throw Status.INVALID_ARGUMENT
                                         .withDescription("conversationId is required")
                                         .asRuntimeException();
@@ -67,7 +69,7 @@ public class EntriesGrpcService extends AbstractGrpcService implements EntriesSe
                             PagedEntries paged =
                                     store().getEntries(
                                                     currentUserId(),
-                                                    request.getConversationId(),
+                                                    conversationId,
                                                     token,
                                                     pageSize,
                                                     channel,
@@ -102,8 +104,8 @@ public class EntriesGrpcService extends AbstractGrpcService implements EntriesSe
                                                 "Agent API key is required to append entries")
                                         .asRuntimeException();
                             }
-                            if (request.getConversationId() == null
-                                    || request.getConversationId().isBlank()) {
+                            String conversationId = byteStringToString(request.getConversationId());
+                            if (conversationId == null || conversationId.isBlank()) {
                                 throw Status.INVALID_ARGUMENT
                                         .withDescription("conversationId is required")
                                         .asRuntimeException();
@@ -131,7 +133,7 @@ public class EntriesGrpcService extends AbstractGrpcService implements EntriesSe
                             List<io.github.chirino.memory.api.dto.EntryDto> appended =
                                     store().appendAgentEntries(
                                                     currentUserId(),
-                                                    request.getConversationId(),
+                                                    conversationId,
                                                     List.of(internal),
                                                     clientId);
                             io.github.chirino.memory.api.dto.EntryDto latest =
@@ -157,8 +159,8 @@ public class EntriesGrpcService extends AbstractGrpcService implements EntriesSe
                                                 "Agent API key is required to sync memory entries")
                                         .asRuntimeException();
                             }
-                            if (request.getConversationId() == null
-                                    || request.getConversationId().isBlank()) {
+                            String conversationId = byteStringToString(request.getConversationId());
+                            if (conversationId == null || conversationId.isBlank()) {
                                 throw Status.INVALID_ARGUMENT
                                         .withDescription("conversationId is required")
                                         .asRuntimeException();
@@ -194,7 +196,7 @@ public class EntriesGrpcService extends AbstractGrpcService implements EntriesSe
                             SyncResult result =
                                     store().syncAgentEntries(
                                                     currentUserId(),
-                                                    request.getConversationId(),
+                                                    conversationId,
                                                     internal,
                                                     clientId);
                             SyncEntriesResponse.Builder builder =

--- a/memory-service/src/main/java/io/github/chirino/memory/grpc/GrpcDtoMapper.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/grpc/GrpcDtoMapper.java
@@ -1,5 +1,7 @@
 package io.github.chirino.memory.grpc;
 
+import static io.github.chirino.memory.grpc.UuidUtils.stringToByteString;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,7 +46,7 @@ public final class GrpcDtoMapper {
             return null;
         }
         return ConversationSummary.newBuilder()
-                .setId(dto.getId())
+                .setId(stringToByteString(dto.getId()))
                 .setTitle(dto.getTitle() == null ? "" : dto.getTitle())
                 .setOwnerUserId(dto.getOwnerUserId() == null ? "" : dto.getOwnerUserId())
                 .setCreatedAt(dto.getCreatedAt() == null ? "" : dto.getCreatedAt())
@@ -60,7 +62,7 @@ public final class GrpcDtoMapper {
             return null;
         }
         return Conversation.newBuilder()
-                .setId(dto.getId())
+                .setId(stringToByteString(dto.getId()))
                 .setTitle(dto.getTitle() == null ? "" : dto.getTitle())
                 .setOwnerUserId(dto.getOwnerUserId() == null ? "" : dto.getOwnerUserId())
                 .setCreatedAt(dto.getCreatedAt() == null ? "" : dto.getCreatedAt())
@@ -69,12 +71,8 @@ public final class GrpcDtoMapper {
                         dto.getLastMessagePreview() == null ? "" : dto.getLastMessagePreview())
                 .setAccessLevel(accessLevelToProto(dto.getAccessLevel()))
                 // conversation_group_id is not exposed in API responses
-                .setForkedAtEntryId(
-                        dto.getForkedAtEntryId() == null ? "" : dto.getForkedAtEntryId())
-                .setForkedAtConversationId(
-                        dto.getForkedAtConversationId() == null
-                                ? ""
-                                : dto.getForkedAtConversationId())
+                .setForkedAtEntryId(stringToByteString(dto.getForkedAtEntryId()))
+                .setForkedAtConversationId(stringToByteString(dto.getForkedAtConversationId()))
                 .build();
     }
 
@@ -84,7 +82,7 @@ public final class GrpcDtoMapper {
             return null;
         }
         return ConversationMembership.newBuilder()
-                .setConversationId(conversationId == null ? "" : conversationId)
+                .setConversationId(stringToByteString(conversationId))
                 .setUserId(dto.getUserId() == null ? "" : dto.getUserId())
                 .setAccessLevel(accessLevelToProto(dto.getAccessLevel()))
                 .setCreatedAt(dto.getCreatedAt() == null ? "" : dto.getCreatedAt())
@@ -96,14 +94,10 @@ public final class GrpcDtoMapper {
             return null;
         }
         return ConversationForkSummary.newBuilder()
-                .setConversationId(dto.getConversationId() == null ? "" : dto.getConversationId())
+                .setConversationId(stringToByteString(dto.getConversationId()))
                 // conversation_group_id is not exposed in API responses
-                .setForkedAtEntryId(
-                        dto.getForkedAtEntryId() == null ? "" : dto.getForkedAtEntryId())
-                .setForkedAtConversationId(
-                        dto.getForkedAtConversationId() == null
-                                ? ""
-                                : dto.getForkedAtConversationId())
+                .setForkedAtEntryId(stringToByteString(dto.getForkedAtEntryId()))
+                .setForkedAtConversationId(stringToByteString(dto.getForkedAtConversationId()))
                 .setTitle(dto.getTitle() == null ? "" : dto.getTitle())
                 .setCreatedAt(dto.getCreatedAt() == null ? "" : dto.getCreatedAt())
                 .build();
@@ -115,9 +109,8 @@ public final class GrpcDtoMapper {
         }
         Entry.Builder builder =
                 Entry.newBuilder()
-                        .setId(dto.getId() == null ? "" : dto.getId())
-                        .setConversationId(
-                                dto.getConversationId() == null ? "" : dto.getConversationId())
+                        .setId(stringToByteString(dto.getId()))
+                        .setConversationId(stringToByteString(dto.getConversationId()))
                         .setUserId(dto.getUserId() == null ? "" : dto.getUserId())
                         .setChannel(toProtoChannel(dto.getChannel()))
                         .setContentType(dto.getContentType() == null ? "" : dto.getContentType())

--- a/memory-service/src/main/java/io/github/chirino/memory/grpc/UuidUtils.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/grpc/UuidUtils.java
@@ -1,0 +1,107 @@
+package io.github.chirino.memory.grpc;
+
+import com.google.protobuf.ByteString;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+/**
+ * Utility class for converting between Java UUID and gRPC bytes representation.
+ *
+ * <p>UUIDs are represented as 16-byte big-endian binary values in the gRPC API. The most
+ * significant 64 bits come first, followed by the least significant 64 bits.
+ */
+public final class UuidUtils {
+
+    private static final int UUID_BYTE_LENGTH = 16;
+
+    private UuidUtils() {}
+
+    /**
+     * Converts a UUID to a 16-byte big-endian byte array.
+     *
+     * @param uuid the UUID to convert
+     * @return 16-byte array representation
+     */
+    public static byte[] toBytes(UUID uuid) {
+        if (uuid == null) {
+            return new byte[0];
+        }
+        ByteBuffer buffer = ByteBuffer.allocate(UUID_BYTE_LENGTH);
+        buffer.putLong(uuid.getMostSignificantBits());
+        buffer.putLong(uuid.getLeastSignificantBits());
+        return buffer.array();
+    }
+
+    /**
+     * Converts a 16-byte big-endian byte array to a UUID.
+     *
+     * @param bytes the byte array to convert
+     * @return the UUID, or null if bytes is null or empty
+     * @throws IllegalArgumentException if bytes is not 16 bytes
+     */
+    public static UUID fromBytes(byte[] bytes) {
+        if (bytes == null || bytes.length == 0) {
+            return null;
+        }
+        if (bytes.length != UUID_BYTE_LENGTH) {
+            throw new IllegalArgumentException("UUID bytes must be 16 bytes, got " + bytes.length);
+        }
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        long mostSig = buffer.getLong();
+        long leastSig = buffer.getLong();
+        return new UUID(mostSig, leastSig);
+    }
+
+    /**
+     * Converts a UUID to a gRPC ByteString.
+     *
+     * @param uuid the UUID to convert
+     * @return ByteString representation (empty if uuid is null)
+     */
+    public static ByteString toByteString(UUID uuid) {
+        if (uuid == null) {
+            return ByteString.EMPTY;
+        }
+        return ByteString.copyFrom(toBytes(uuid));
+    }
+
+    /**
+     * Converts a gRPC ByteString to a UUID.
+     *
+     * @param bytes the ByteString to convert
+     * @return the UUID, or null if bytes is null or empty
+     * @throws IllegalArgumentException if bytes is not 16 bytes
+     */
+    public static UUID fromByteString(ByteString bytes) {
+        if (bytes == null || bytes.isEmpty()) {
+            return null;
+        }
+        return fromBytes(bytes.toByteArray());
+    }
+
+    /**
+     * Converts a UUID string to a gRPC ByteString.
+     *
+     * @param uuidString the UUID string to convert
+     * @return ByteString representation (empty if uuidString is null or empty)
+     * @throws IllegalArgumentException if the string is not a valid UUID format
+     */
+    public static ByteString stringToByteString(String uuidString) {
+        if (uuidString == null || uuidString.isEmpty()) {
+            return ByteString.EMPTY;
+        }
+        return toByteString(UUID.fromString(uuidString));
+    }
+
+    /**
+     * Converts a gRPC ByteString to a UUID string.
+     *
+     * @param bytes the ByteString to convert
+     * @return the UUID string, or null if bytes is null or empty
+     * @throws IllegalArgumentException if bytes is not 16 bytes
+     */
+    public static String byteStringToString(ByteString bytes) {
+        UUID uuid = fromByteString(bytes);
+        return uuid == null ? null : uuid.toString();
+    }
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/store/impl/MongoMemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/impl/MongoMemoryStore.java
@@ -442,6 +442,14 @@ public class MongoMemoryStore implements MemoryStore {
         List<MongoConversation> candidates =
                 conversationRepository.find("conversationGroupId", groupId).stream()
                         .filter(c -> c.deletedAt == null)
+                        .sorted(
+                                Comparator.comparing(
+                                                (MongoConversation c) ->
+                                                        c.forkedAtEntryId != null ? 1 : 0)
+                                        .thenComparing(
+                                                Comparator.comparing(
+                                                        (MongoConversation c) -> c.updatedAt,
+                                                        Comparator.reverseOrder())))
                         .collect(Collectors.toList());
         List<ConversationForkSummaryDto> results = new ArrayList<>();
         for (MongoConversation candidate : candidates) {

--- a/memory-service/src/main/java/io/github/chirino/memory/store/impl/PostgresMemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/impl/PostgresMemoryStore.java
@@ -444,7 +444,8 @@ public class PostgresMemoryStore implements MemoryStore {
                 conversationRepository
                         .find(
                                 "conversationGroup.id = ?1 AND deletedAt IS NULL AND"
-                                        + " conversationGroup.deletedAt IS NULL",
+                                        + " conversationGroup.deletedAt IS NULL"
+                                        + " ORDER BY forkedAtEntryId NULLS FIRST, updatedAt DESC",
                                 groupId)
                         .list();
         List<ConversationForkSummaryDto> results = new ArrayList<>();

--- a/quarkus/examples/agent-quarkus/src/main/java/example/TranscriptIndexingResource.java
+++ b/quarkus/examples/agent-quarkus/src/main/java/example/TranscriptIndexingResource.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -79,7 +80,7 @@ public class TranscriptIndexingResource {
             LOG.infof("redactedTranscript: %s", redactedTranscript);
 
             IndexTranscriptRequest request = new IndexTranscriptRequest();
-            request.setConversationId(conversationId);
+            request.setConversationId(UUID.fromString(conversationId));
             request.setTitle(redactionPayload.title());
             request.setTranscript(redactedTranscript);
             request.setUntilEntryId(last.getId());
@@ -93,12 +94,16 @@ public class TranscriptIndexingResource {
 
     private List<Entry> fetchHistoryEntries(String conversationId) {
         List<Entry> all = new ArrayList<>();
-        String cursor = null;
+        UUID cursor = null;
         while (true) {
             ListConversationEntries200Response response =
                     conversationsApi()
                             .listConversationEntries(
-                                    conversationId, cursor, PAGE_SIZE, Channel.HISTORY, null);
+                                    UUID.fromString(conversationId),
+                                    cursor,
+                                    PAGE_SIZE,
+                                    Channel.HISTORY,
+                                    null);
             List<Entry> data = response != null ? response.getData() : null;
             if (data != null && !data.isEmpty()) {
                 all.addAll(data);
@@ -107,7 +112,7 @@ public class TranscriptIndexingResource {
             if (next == null || next.isBlank()) {
                 break;
             }
-            cursor = next;
+            cursor = UUID.fromString(next);
         }
         return all;
     }

--- a/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ConversationStore.java
+++ b/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ConversationStore.java
@@ -14,6 +14,7 @@ import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 @ApplicationScoped
 public class ConversationStore {
@@ -35,7 +36,7 @@ public class ConversationStore {
         block.put("role", "USER");
         request.setContent(List.of(block));
         conversationsApi(bearerToken(securityIdentity))
-                .appendConversationEntry(conversationId, request);
+                .appendConversationEntry(UUID.fromString(conversationId), request);
     }
 
     public void appendAgentMessage(String conversationId, String content, String bearerToken) {
@@ -54,7 +55,8 @@ public class ConversationStore {
         request.setContent(List.of(block));
         String effectiveToken;
         effectiveToken = bearerToken != null ? bearerToken : bearerToken(securityIdentity);
-        conversationsApi(effectiveToken).appendConversationEntry(conversationId, request);
+        conversationsApi(effectiveToken)
+                .appendConversationEntry(UUID.fromString(conversationId), request);
     }
 
     public void appendPartialAgentMessage(String conversationId, String delta) {}

--- a/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryServiceChatMemory.java
+++ b/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryServiceChatMemory.java
@@ -20,6 +20,7 @@ import jakarta.ws.rs.WebApplicationException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import org.jboss.logging.Logger;
 
 /**
@@ -68,7 +69,7 @@ public class MemoryServiceChatMemory implements ChatMemory {
         // LOG.infof("Encoding content block: [%s]", json);
         request.setContent(List.of(new RawValue(json)));
 
-        conversationsApi().appendConversationEntry(conversationId, request);
+        conversationsApi().appendConversationEntry(UUID.fromString(conversationId), request);
     }
 
     @Override
@@ -78,7 +79,11 @@ public class MemoryServiceChatMemory implements ChatMemory {
             context =
                     conversationsApi()
                             .listConversationEntries(
-                                    conversationId, null, 50, Channel.MEMORY, null);
+                                    UUID.fromString(conversationId),
+                                    null,
+                                    50,
+                                    Channel.MEMORY,
+                                    null);
         } catch (WebApplicationException e) {
             int status = e.getResponse() != null ? e.getResponse().getStatus() : -1;
             if (status == 404) {
@@ -106,7 +111,8 @@ public class MemoryServiceChatMemory implements ChatMemory {
                 if (block == null) {
                     continue;
                 }
-                var decoded = decodeContentBlock(block, entry.getId());
+                String entryIdStr = entry.getId() != null ? entry.getId().toString() : null;
+                var decoded = decodeContentBlock(block, entryIdStr);
                 result.addAll(decoded);
             }
         }

--- a/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryServiceChatMemoryStore.java
+++ b/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryServiceChatMemoryStore.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.jboss.logging.Logger;
 
@@ -62,7 +63,11 @@ public class MemoryServiceChatMemoryStore implements ChatMemoryStore {
             context =
                     conversationsApi()
                             .listConversationEntries(
-                                    memoryId.toString(), null, 50, Channel.MEMORY, null);
+                                    UUID.fromString(memoryId.toString()),
+                                    null,
+                                    50,
+                                    Channel.MEMORY,
+                                    null);
         } catch (WebApplicationException e) {
             int status = e.getResponse() != null ? e.getResponse().getStatus() : -1;
             if (status == 404) {
@@ -87,8 +92,9 @@ public class MemoryServiceChatMemoryStore implements ChatMemoryStore {
                 if (block == null) {
                     continue;
                 }
+                String entryIdStr = entry.getId() != null ? entry.getId().toString() : null;
                 List<ChatMessage> decoded =
-                        decodeContentBlock(block, memoryId.toString(), entry.getId());
+                        decodeContentBlock(block, memoryId.toString(), entryIdStr);
                 if (decoded != null && !decoded.isEmpty()) {
                     result.addAll(decoded);
                 }
@@ -137,7 +143,8 @@ public class MemoryServiceChatMemoryStore implements ChatMemoryStore {
             return;
         }
         syncRequest.setEntries(syncEntries);
-        conversationsApi().syncConversationMemory(memoryId.toString(), syncRequest);
+        conversationsApi()
+                .syncConversationMemory(UUID.fromString(memoryId.toString()), syncRequest);
     }
 
     @Override

--- a/site/src/pages/docs/api-contracts.md
+++ b/site/src/pages/docs/api-contracts.md
@@ -32,7 +32,55 @@ The gRPC API provides:
 - Bi-directional streaming for real-time updates
 - Strong typing with generated stubs
 
-<!-- 
+## ID Formats
+
+All resource identifiers in the Memory Service API are UUIDs (Universally Unique Identifiers). This applies to:
+- Conversation IDs
+- Entry IDs
+- Fork reference IDs
+
+**Note:** User IDs and client IDs are external identifiers and do not follow UUID format.
+
+### REST API (JSON)
+
+UUIDs are represented as strings in standard format:
+
+```
+xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+```
+
+Example: `"550e8400-e29b-41d4-a716-446655440000"`
+
+The OpenAPI specification uses `format: uuid` for these fields, which enables type-safe UUID handling in generated clients.
+
+### gRPC API (Protocol Buffers)
+
+UUIDs are represented as 16-byte binary values (big-endian). The most significant 64 bits come first, followed by the least significant 64 bits.
+
+**Java example:**
+```java
+// UUID to bytes
+ByteBuffer buffer = ByteBuffer.allocate(16);
+buffer.putLong(uuid.getMostSignificantBits());
+buffer.putLong(uuid.getLeastSignificantBits());
+byte[] bytes = buffer.array();
+
+// Bytes to UUID
+ByteBuffer buffer = ByteBuffer.wrap(bytes);
+UUID uuid = new UUID(buffer.getLong(), buffer.getLong());
+```
+
+**Go example:**
+```go
+// UUID to bytes - google/uuid package stores as [16]byte
+id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+bytes := id[:] // id is already [16]byte
+
+// Bytes to UUID
+id, err := uuid.FromBytes(bytes)
+```
+
+<!--
 ## Framework-Specific Clients
 
 For Quarkus and Spring applications, pre-built clients are available:

--- a/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationStore.java
+++ b/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationStore.java
@@ -7,6 +7,7 @@ import io.github.chirino.memoryservice.security.SecurityHelper;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;
@@ -53,7 +54,7 @@ public class ConversationStore {
             String conversationId, CreateEntryRequest request, @Nullable String bearerToken) {
         try {
             ConversationsApi api = apiFactory.create(bearerToken);
-            api.appendConversationEntry(conversationId, request).block();
+            api.appendConversationEntry(UUID.fromString(conversationId), request).block();
         } catch (Exception e) {
             LOG.warn(
                     "Failed to append conversation entry for conversationId={}, continuing"


### PR DESCRIPTION
Update OpenAPI specs to use `format: uuid` for all ID fields, ensuring type-safe UUID handling in generated clients. Update proto files to use `bytes` for UUID fields (16-byte big-endian binary representation) for efficient wire format.

Key changes:
- OpenAPI: Add format: uuid to conversationId, entryId, and related fields
- Proto: Change string ID fields to bytes with conversion documentation
- Add UuidUtils helper for ByteString/UUID conversions in gRPC services
- Add deterministic ordering to listForks (root first, then by updatedAt)
- Update all gRPC services and REST resources for new types
- Update test infrastructure to handle UUID bytes in Cucumber tests