### PR TITLE
feat: remove includeDeleted parameter from admin endpoints

### DIFF
--- a/memory-service-contracts/src/main/resources/openapi-admin.yml
+++ b/memory-service-contracts/src/main/resources/openapi-admin.yml
@@ -121,8 +121,8 @@ paths:
       tags: [Admin]
       summary: Get any conversation (admin/auditor)
       description: |-
-        Retrieves a conversation by ID, including soft-deleted conversations
-        if includeDeleted=true. Requires auditor or admin role.
+        Retrieves a conversation by ID, including soft-deleted conversations.
+        Requires auditor or admin role.
       operationId: adminGetConversation
       parameters:
         - name: id
@@ -132,13 +132,6 @@ paths:
           schema:
             type: string
             format: uuid
-        - name: includeDeleted
-          in: query
-          required: false
-          description: Include soft-deleted conversations.
-          schema:
-            type: boolean
-            default: false
         - name: justification
           in: query
           required: false
@@ -237,7 +230,7 @@ paths:
       summary: Get entries from any conversation (admin/auditor)
       description: |-
         Retrieves entries from a conversation, including soft-deleted
-        conversations if includeDeleted=true. Requires auditor or admin role.
+        conversations. Requires auditor or admin role.
       operationId: adminGetEntries
       parameters:
         - name: id
@@ -267,13 +260,6 @@ paths:
           description: Filter by entry channel.
           schema:
             $ref: '#/components/schemas/Channel'
-        - name: includeDeleted
-          in: query
-          required: false
-          description: Include entries from soft-deleted conversations.
-          schema:
-            type: boolean
-            default: false
         - name: justification
           in: query
           required: false
@@ -317,13 +303,6 @@ paths:
           schema:
             type: string
             format: uuid
-        - name: includeDeleted
-          in: query
-          required: false
-          description: Include memberships from soft-deleted conversations.
-          schema:
-            type: boolean
-            default: false
         - name: justification
           in: query
           required: false

--- a/memory-service/src/main/java/io/github/chirino/memory/api/AdminResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/AdminResource.java
@@ -132,18 +132,14 @@ public class AdminResource {
     @GET
     @Path("/conversations/{id}")
     public Response getConversation(
-            @PathParam("id") String id,
-            @QueryParam("includeDeleted") @jakarta.ws.rs.DefaultValue("false")
-                    boolean includeDeleted,
-            @QueryParam("justification") String justification) {
+            @PathParam("id") String id, @QueryParam("justification") String justification) {
         try {
             roleResolver.requireAuditor(identity, apiKeyContext);
             Map<String, Object> params = new HashMap<>();
             params.put("id", id);
-            params.put("includeDeleted", includeDeleted);
             auditLogger.logRead("getConversation", params, justification, identity, apiKeyContext);
 
-            Optional<ConversationDto> dto = store().adminGetConversation(id, includeDeleted);
+            Optional<ConversationDto> dto = store().adminGetConversation(id);
             if (dto.isEmpty()) {
                 return notFound(new ResourceNotFoundException("conversation", id));
             }
@@ -187,7 +183,7 @@ public class AdminResource {
             auditLogger.logWrite("restoreConversation", id, justification, identity, apiKeyContext);
 
             store().adminRestoreConversation(id);
-            Optional<ConversationDto> dto = store().adminGetConversation(id, true);
+            Optional<ConversationDto> dto = store().adminGetConversation(id);
             return Response.ok(dto.orElse(null)).build();
         } catch (AccessDeniedException e) {
             return forbidden(e);
@@ -209,14 +205,11 @@ public class AdminResource {
             @QueryParam("after") String after,
             @QueryParam("limit") Integer limit,
             @QueryParam("channel") String channel,
-            @QueryParam("includeDeleted") @jakarta.ws.rs.DefaultValue("false")
-                    boolean includeDeleted,
             @QueryParam("justification") String justification) {
         try {
             roleResolver.requireAuditor(identity, apiKeyContext);
             Map<String, Object> params = new HashMap<>();
             params.put("id", id);
-            params.put("includeDeleted", includeDeleted);
             auditLogger.logRead("getMessages", params, justification, identity, apiKeyContext);
 
             AdminMessageQuery query = new AdminMessageQuery();
@@ -225,7 +218,6 @@ public class AdminResource {
             if (channel != null && !channel.isBlank()) {
                 query.setChannel(Channel.fromString(channel));
             }
-            query.setIncludeDeleted(includeDeleted);
 
             PagedEntries result = store().adminGetEntries(id, query);
             Map<String, Object> response = new HashMap<>();
@@ -246,19 +238,14 @@ public class AdminResource {
     @GET
     @Path("/conversations/{id}/memberships")
     public Response getMemberships(
-            @PathParam("id") String id,
-            @QueryParam("includeDeleted") @jakarta.ws.rs.DefaultValue("false")
-                    boolean includeDeleted,
-            @QueryParam("justification") String justification) {
+            @PathParam("id") String id, @QueryParam("justification") String justification) {
         try {
             roleResolver.requireAuditor(identity, apiKeyContext);
             Map<String, Object> params = new HashMap<>();
             params.put("id", id);
-            params.put("includeDeleted", includeDeleted);
             auditLogger.logRead("getMemberships", params, justification, identity, apiKeyContext);
 
-            List<ConversationMembershipDto> memberships =
-                    store().adminListMemberships(id, includeDeleted);
+            List<ConversationMembershipDto> memberships = store().adminListMemberships(id);
             List<ConversationMembership> data =
                     memberships.stream()
                             .map(

--- a/memory-service/src/main/java/io/github/chirino/memory/model/AdminMessageQuery.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/model/AdminMessageQuery.java
@@ -5,7 +5,6 @@ public class AdminMessageQuery {
     private String afterEntryId;
     private int limit;
     private Channel channel;
-    private boolean includeDeleted;
 
     public String getAfterEntryId() {
         return afterEntryId;
@@ -29,13 +28,5 @@ public class AdminMessageQuery {
 
     public void setChannel(Channel channel) {
         this.channel = channel;
-    }
-
-    public boolean isIncludeDeleted() {
-        return includeDeleted;
-    }
-
-    public void setIncludeDeleted(boolean includeDeleted) {
-        this.includeDeleted = includeDeleted;
     }
 }

--- a/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
@@ -85,7 +85,7 @@ public interface MemoryStore {
     // Admin methods — no userId scoping, configurable deleted-resource visibility
     List<ConversationSummaryDto> adminListConversations(AdminConversationQuery query);
 
-    Optional<ConversationDto> adminGetConversation(String conversationId, boolean includeDeleted);
+    Optional<ConversationDto> adminGetConversation(String conversationId);
 
     void adminDeleteConversation(String conversationId);
 
@@ -93,8 +93,7 @@ public interface MemoryStore {
 
     PagedEntries adminGetEntries(String conversationId, AdminMessageQuery query);
 
-    List<ConversationMembershipDto> adminListMemberships(
-            String conversationId, boolean includeDeleted);
+    List<ConversationMembershipDto> adminListMemberships(String conversationId);
 
     List<SearchResultDto> adminSearchEntries(AdminSearchQuery query);
 


### PR DESCRIPTION
Admin endpoints now always include soft-deleted resources, simplifying the API. The includeDeleted parameter has been removed from:
- GET /v1/admin/conversations/{id}
- GET /v1/admin/conversations/{id}/entries
- GET /v1/admin/conversations/{id}/memberships