### PR TITLE
feat: implement ownership transfer API with full lifecycle management

### DIFF
--- a/docs/enhancements/024-sharing-api-enhancements.md
+++ b/docs/enhancements/024-sharing-api-enhancements.md
@@ -1,0 +1,861 @@
+# Enhancement 024: Sharing API Enhancements
+
+## Overview
+
+This document designs API enhancements for conversation ownership transfer functionality. The current `transfer-ownership` endpoint initiates a transfer, but there are no endpoints for the recipient to accept/reject the transfer or for either party to view pending transfers.
+
+## Goals
+
+1. Allow users to view pending ownership transfers they're involved in
+2. Enable transfer recipients to accept or reject transfers
+3. Allow owners to cancel pending transfers before acceptance
+4. Prevent multiple concurrent transfers for the same conversation
+5. Provide clear transfer state visibility to all parties
+
+## Current State
+
+The existing API has a single transfer endpoint:
+
+```
+POST /v1/conversations/{conversationId}/transfer-ownership
+```
+
+This endpoint will be **replaced** by `POST /v1/ownership-transfers` to consolidate all transfer operations under a single resource path.
+
+The current API provides no mechanism for:
+- Viewing pending transfers
+- Accepting a transfer
+- Rejecting a transfer
+- Canceling a transfer
+
+## Proposed API Endpoints
+
+### 1. List Pending Transfers
+
+List all pending ownership transfers involving the current user (as sender or recipient).
+
+```yaml
+/v1/ownership-transfers:
+  get:
+    tags: [Sharing]
+    summary: List pending ownership transfers
+    description: |-
+      Returns all pending ownership transfers where the current user is either
+      the current owner (sender) or the proposed new owner (recipient).
+    operationId: listPendingTransfers
+    parameters:
+      - name: role
+        in: query
+        required: false
+        description: Filter by user's role in the transfer.
+        schema:
+          type: string
+          enum: [sender, recipient, all]
+          default: all
+    responses:
+      '200':
+        description: List of pending transfers.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/OwnershipTransfer'
+      default:
+        $ref: '#/components/responses/Error'
+    security:
+      - BearerAuth: []
+```
+
+### 2. Get Transfer Details
+
+Get details of a specific transfer.
+
+```yaml
+/v1/ownership-transfers/{transferId}:
+  get:
+    tags: [Sharing]
+    summary: Get transfer details
+    description: |-
+      Returns details of a specific ownership transfer. Only accessible to
+      the current owner (sender) or proposed new owner (recipient).
+    operationId: getTransfer
+    parameters:
+      - name: transferId
+        in: path
+        required: true
+        description: Transfer identifier (UUID format).
+        schema:
+          type: string
+          format: uuid
+    responses:
+      '200':
+        description: Transfer details.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OwnershipTransfer'
+      '404':
+        $ref: '#/components/responses/NotFound'
+      default:
+        $ref: '#/components/responses/Error'
+    security:
+      - BearerAuth: []
+```
+
+### 3. Accept Transfer
+
+Accept a pending ownership transfer (recipient only).
+
+```yaml
+/v1/ownership-transfers/{transferId}/accept:
+  post:
+    tags: [Sharing]
+    summary: Accept ownership transfer
+    description: |-
+      Accepts a pending ownership transfer. Only the proposed new owner
+      (recipient) can accept. Upon acceptance:
+      - The recipient becomes the new owner
+      - The previous owner becomes a manager
+      - The transfer record is marked as completed
+    operationId: acceptTransfer
+    parameters:
+      - name: transferId
+        in: path
+        required: true
+        description: Transfer identifier (UUID format).
+        schema:
+          type: string
+          format: uuid
+    responses:
+      '200':
+        description: Transfer accepted successfully.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OwnershipTransfer'
+      '403':
+        description: Not authorized (not the recipient).
+        $ref: '#/components/responses/Error'
+      '404':
+        $ref: '#/components/responses/NotFound'
+      '409':
+        description: Transfer already completed or cancelled.
+        $ref: '#/components/responses/Error'
+      default:
+        $ref: '#/components/responses/Error'
+    security:
+      - BearerAuth: []
+```
+
+### 4. Delete Transfer (Cancel or Reject)
+
+Cancel or reject a pending ownership transfer. Either the sender (owner) or recipient can delete.
+
+```yaml
+/v1/ownership-transfers/{transferId}:
+  delete:
+    tags: [Sharing]
+    summary: Cancel or reject ownership transfer
+    description: |-
+      Deletes a pending ownership transfer. Can be called by either:
+      - The current owner (sender) to cancel the transfer
+      - The proposed new owner (recipient) to reject the transfer
+
+      The transfer record is **hard deleted** from the database.
+      This action is recorded in the audit log.
+    operationId: deleteTransfer
+    parameters:
+      - name: transferId
+        in: path
+        required: true
+        description: Transfer identifier (UUID format).
+        schema:
+          type: string
+          format: uuid
+    responses:
+      '204':
+        description: Transfer deleted successfully.
+      '403':
+        description: Not authorized (not the sender or recipient).
+        $ref: '#/components/responses/Error'
+      '404':
+        $ref: '#/components/responses/NotFound'
+      '409':
+        description: Transfer already completed (accepted).
+        $ref: '#/components/responses/Error'
+      default:
+        $ref: '#/components/responses/Error'
+    security:
+      - BearerAuth: []
+```
+
+### 5. Create Ownership Transfer
+
+Create a new ownership transfer request.
+
+```yaml
+/v1/ownership-transfers:
+  post:
+    tags: [Sharing]
+    summary: Request ownership transfer
+    description: |-
+      Initiates a transfer of conversation ownership to another user.
+
+      **Constraints**:
+      - Only the current owner can initiate a transfer
+      - The recipient must be an existing member of the conversation
+      - Only one pending transfer can exist per conversation at a time
+      - If a pending transfer already exists, returns 409 Conflict
+
+      The recipient must accept the transfer via `POST /v1/ownership-transfers/{transferId}/accept`
+      for the transfer to complete. Either party can delete the pending transfer
+      via `DELETE /v1/ownership-transfers/{transferId}`.
+    operationId: createOwnershipTransfer
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CreateOwnershipTransferRequest'
+    responses:
+      '201':
+        description: Transfer initiated successfully.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OwnershipTransfer'
+      '403':
+        description: Not authorized (not the owner).
+        $ref: '#/components/responses/Error'
+      '404':
+        $ref: '#/components/responses/NotFound'
+      '409':
+        description: A pending transfer already exists for this conversation.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                error:
+                  type: string
+                  example: "A pending ownership transfer already exists for this conversation"
+                code:
+                  type: string
+                  example: "TRANSFER_ALREADY_PENDING"
+                existingTransferId:
+                  type: string
+                  format: uuid
+                  description: ID of the existing pending transfer
+      default:
+        $ref: '#/components/responses/Error'
+    security:
+      - BearerAuth: []
+```
+
+## New Schemas
+
+### OwnershipTransfer
+
+```yaml
+OwnershipTransfer:
+  type: object
+  required:
+    - id
+    - conversationId
+    - fromUserId
+    - toUserId
+    - status
+    - createdAt
+  properties:
+    id:
+      type: string
+      format: uuid
+      description: Unique identifier for the transfer.
+    conversationId:
+      type: string
+      format: uuid
+      description: The conversation being transferred.
+    conversationTitle:
+      type: string
+      nullable: true
+      description: Title of the conversation (for display purposes).
+    fromUserId:
+      type: string
+      description: Current owner initiating the transfer.
+    toUserId:
+      type: string
+      description: Proposed new owner (recipient).
+    status:
+      $ref: '#/components/schemas/TransferStatus'
+    createdAt:
+      type: string
+      format: date-time
+      description: When the transfer was initiated.
+    completedAt:
+      type: string
+      format: date-time
+      nullable: true
+      description: When the transfer was accepted (null while pending).
+  example:
+    id: "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+    conversationId: "550e8400-e29b-41d4-a716-446655440000"
+    conversationTitle: "Help with React hooks"
+    fromUserId: "user_john_doe"
+    toUserId: "user_jane_smith"
+    status: "pending"
+    createdAt: "2025-01-28T10:30:00Z"
+    completedAt: null
+```
+
+### TransferStatus
+
+```yaml
+TransferStatus:
+  type: string
+  description: |-
+    Status of an ownership transfer.
+    - `pending`: Transfer initiated, awaiting recipient action
+    - `accepted`: Transfer completed, ownership changed
+
+    Note: Rejected/cancelled transfers are hard deleted (no status needed).
+  enum:
+    - pending
+    - accepted
+```
+
+### CreateOwnershipTransferRequest
+
+```yaml
+CreateOwnershipTransferRequest:
+  type: object
+  required:
+    - conversationId
+    - newOwnerUserId
+  properties:
+    conversationId:
+      type: string
+      format: uuid
+      description: The conversation to transfer ownership of.
+    newOwnerUserId:
+      type: string
+      description: User ID of the proposed new owner. Must be an existing member.
+  example:
+    conversationId: "550e8400-e29b-41d4-a716-446655440000"
+    newOwnerUserId: "user_jane_smith"
+```
+
+## Business Rules
+
+### Transfer Lifecycle
+
+```
+┌─────────────┐
+│   Created   │
+│  (pending)  │
+└──────┬──────┘
+       │
+       ├──────────────────┐
+       │                  │
+       ▼                  ▼
+┌─────────────┐    ┌─────────────┐
+│  Accepted   │    │  Deleted    │
+│  (by recip) │    │ (by either) │
+│             │    │ HARD DELETE │
+│  Record     │    │             │
+│  preserved  │    │  No record  │
+└─────────────┘    └─────────────┘
+```
+
+### Permission Matrix
+
+| Action | Owner (Sender) | Recipient | Other Members |
+|--------|:--------------:|:---------:|:-------------:|
+| Create transfer | ✅ | ❌ | ❌ |
+| View transfer | ✅ | ✅ | ❌ |
+| Accept transfer | ❌ | ✅ | ❌ |
+| Delete transfer | ✅ | ✅ | ❌ |
+
+### Constraints
+
+1. **Single Pending Transfer**: Only one pending transfer can exist per conversation at a time. Attempting to create a second transfer returns `409 Conflict` with the existing transfer ID.
+
+2. **Recipient Must Be Member**: The proposed new owner must already be a member of the conversation (any access level: manager, writer, or reader).
+
+3. **Member Removal Cancels Transfer**: If a member is removed from the conversation while there is a pending ownership transfer to them, the transfer is automatically deleted. This ensures transfers cannot exist for non-members.
+
+4. **Hard Delete on Cancel/Reject**: When a transfer is deleted (cancelled by owner or rejected by recipient), the transfer record is **hard deleted** from the database. Only accepted transfers are preserved.
+
+5. **Owner Role on Acceptance**: When a transfer is accepted:
+   - The recipient becomes the new owner
+   - The previous owner is demoted to manager (not removed)
+
+6. **Transfer Expiration** (Optional): Transfers may optionally expire after a configurable period (e.g., 7 days). Expired transfers are automatically hard deleted.
+
+## Database Schema
+
+### ownership_transfers Table
+
+```sql
+CREATE TABLE ownership_transfers (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    conversation_id UUID NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    from_user_id VARCHAR(255) NOT NULL,
+    to_user_id VARCHAR(255) NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMP WITH TIME ZONE,
+
+    -- Only 'pending' and 'accepted' statuses exist
+    -- Rejected/cancelled transfers are hard deleted
+    CONSTRAINT valid_status CHECK (status IN ('pending', 'accepted')),
+    CONSTRAINT different_users CHECK (from_user_id != to_user_id)
+);
+
+-- Ensure only one pending transfer per conversation
+CREATE UNIQUE INDEX idx_one_pending_transfer_per_conversation
+    ON ownership_transfers(conversation_id)
+    WHERE status = 'pending';
+
+-- Index for listing user's transfers
+CREATE INDEX idx_transfers_by_user
+    ON ownership_transfers(from_user_id, to_user_id, status);
+
+-- Index for conversation lookup
+CREATE INDEX idx_transfers_by_conversation
+    ON ownership_transfers(conversation_id, status);
+```
+
+## Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| `TRANSFER_ALREADY_PENDING` | 409 | A pending transfer already exists for this conversation |
+| `TRANSFER_NOT_FOUND` | 404 | The specified transfer does not exist |
+| `TRANSFER_ALREADY_ACCEPTED` | 409 | The transfer has already been accepted |
+| `NOT_TRANSFER_RECIPIENT` | 403 | Only the recipient can accept a transfer |
+| `NOT_TRANSFER_PARTICIPANT` | 403 | Only the sender or recipient can delete a transfer |
+| `RECIPIENT_NOT_MEMBER` | 400 | The proposed new owner is not a member of the conversation |
+| `CANNOT_TRANSFER_TO_SELF` | 400 | Cannot transfer ownership to yourself |
+
+## Audit Logging
+
+All ownership transfer and sharing operations MUST be recorded in the audit log, similar to Admin operations. This provides accountability and traceability for sensitive access control changes.
+
+### Audited Operations
+
+| Operation | Event Type | Details Logged |
+|-----------|------------|----------------|
+| Create transfer | `TRANSFER_CREATED` | conversationId, fromUserId, toUserId |
+| Accept transfer | `TRANSFER_ACCEPTED` | transferId, conversationId, fromUserId, toUserId |
+| Delete transfer | `TRANSFER_DELETED` | transferId, conversationId, deletedBy, wasRecipient |
+| Add member | `MEMBER_ADDED` | conversationId, userId, accessLevel, addedBy |
+| Update member | `MEMBER_UPDATED` | conversationId, userId, oldAccessLevel, newAccessLevel, updatedBy |
+| Remove member | `MEMBER_REMOVED` | conversationId, userId, removedBy |
+
+### Audit Log Entry Schema
+
+```typescript
+interface AuditLogEntry {
+  id: string;
+  timestamp: Date;
+  eventType: string;
+  actorUserId: string;       // Who performed the action
+  conversationId?: string;
+  targetUserId?: string;     // Who was affected (for membership changes)
+  details: Record<string, unknown>;
+}
+```
+
+### Rationale
+
+1. **Compliance**: Audit logs support compliance requirements (SOC2, GDPR, etc.)
+2. **Security**: Detect unauthorized access attempts or suspicious patterns
+3. **Debugging**: Investigate issues with access control
+4. **Accountability**: Track who made what changes and when
+
+## Data Retention: Hard Deletes vs Soft Deletes
+
+### Ownership Transfers: Hard Delete
+
+Pending transfers that are cancelled/rejected are **hard deleted**:
+- No business value in keeping rejected transfer requests
+- Audit log captures the event for compliance/debugging
+- Simplifies queries (no need to filter out cancelled transfers)
+- Reduces storage requirements
+
+Only **accepted** transfers are preserved in the database as a historical record of ownership changes.
+
+### Memberships: Hard Delete (Recommended)
+
+Given that all membership operations are audit logged, **soft deletes are not recommended** for memberships:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **Soft delete** | Can "undo" removals, historical queries | Complexity, storage, query filters everywhere |
+| **Hard delete + audit log** | Simple, clean data, audit provides history | Cannot restore without re-adding |
+
+**Recommendation**: Use hard deletes for memberships because:
+1. The audit log captures the full history of who had access and when
+2. Restoring access is as simple as re-adding the member
+3. Simpler queries without `WHERE deleted_at IS NULL` everywhere
+4. The audit log is the authoritative source for "who had access when"
+
+If historical membership queries are needed (e.g., "who had access on date X"), query the audit log rather than maintaining soft-deleted records.
+
+## UI Integration
+
+The UI (Enhancement 025) will need to:
+
+1. **Check for pending transfers** when opening the share modal
+2. **Show transfer status** if a pending transfer exists:
+   - For sender: Show "Transfer pending" with cancel option (calls DELETE)
+   - For recipient: Show accept/decline buttons (accept calls POST, decline calls DELETE)
+3. **Disable new transfer** button if a transfer is already pending
+4. **Show incoming transfers** notification/badge (future enhancement)
+
+## Implementation Notes
+
+### Atomicity
+
+The accept operation must be atomic:
+1. Update transfer status to `accepted`
+2. Update conversation owner to new user
+3. Update previous owner's membership to `manager`
+
+Use a database transaction to ensure all-or-nothing.
+
+### Notifications (Future)
+
+Consider adding notification support:
+- Notify recipient when transfer is initiated
+- Notify sender when transfer is accepted/rejected
+- This could be via email, in-app notifications, or webhooks
+
+## Testing Plan
+
+### Existing Test Updates
+
+The following existing Cucumber feature files need updates to reflect API changes:
+
+| File | Changes Needed |
+|------|----------------|
+| `sharing-rest.feature` | Update membership tests for hard delete behavior; remove soft delete expectations |
+| `conversations-rest.feature` | May need updates if conversation delete behavior changes |
+
+### New Cucumber Feature Files
+
+#### `ownership-transfers-rest.feature`
+
+```gherkin
+Feature: Ownership Transfers API
+
+  Background:
+    Given I am authenticated as user "alice"
+    And I have a conversation with title "Test Conversation"
+    And I share the conversation with "bob" as "manager"
+
+  # ===== Create Transfer =====
+
+  Scenario: Owner can create ownership transfer
+    When I call POST "/v1/ownership-transfers" with body:
+      """
+      {
+        "conversationId": "${conversationId}",
+        "newOwnerUserId": "bob"
+      }
+      """
+    Then the response status should be 201
+    And the response body should contain:
+      | fromUserId | alice   |
+      | toUserId   | bob     |
+      | status     | pending |
+
+  Scenario: Cannot create transfer if not owner
+    Given I am authenticated as user "bob"
+    When I call POST "/v1/ownership-transfers" with body:
+      """
+      {
+        "conversationId": "${conversationId}",
+        "newOwnerUserId": "charlie"
+      }
+      """
+    Then the response status should be 403
+
+  Scenario: Cannot create second transfer while one is pending
+    Given I have a pending ownership transfer to "bob"
+    When I call POST "/v1/ownership-transfers" with body:
+      """
+      {
+        "conversationId": "${conversationId}",
+        "newOwnerUserId": "charlie"
+      }
+      """
+    Then the response status should be 409
+    And the response body should contain "existingTransferId"
+
+  Scenario: Cannot transfer to non-member
+    When I call POST "/v1/ownership-transfers" with body:
+      """
+      {
+        "conversationId": "${conversationId}",
+        "newOwnerUserId": "stranger"
+      }
+      """
+    Then the response status should be 400
+
+  Scenario: Cannot transfer to self
+    When I call POST "/v1/ownership-transfers" with body:
+      """
+      {
+        "conversationId": "${conversationId}",
+        "newOwnerUserId": "alice"
+      }
+      """
+    Then the response status should be 400
+
+  # ===== List Transfers =====
+
+  Scenario: List transfers as sender
+    Given I have a pending ownership transfer to "bob"
+    When I call GET "/v1/ownership-transfers?role=sender"
+    Then the response status should be 200
+    And the response body should contain 1 transfer
+
+  Scenario: List transfers as recipient
+    Given I am authenticated as user "bob"
+    And user "alice" has a pending transfer to me for conversation "${conversationId}"
+    When I call GET "/v1/ownership-transfers?role=recipient"
+    Then the response status should be 200
+    And the response body should contain 1 transfer
+
+  Scenario: Non-participant cannot see transfer
+    Given I have a pending ownership transfer to "bob"
+    And I am authenticated as user "charlie"
+    When I call GET "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 404
+
+  # ===== Accept Transfer =====
+
+  Scenario: Recipient can accept transfer
+    Given I have a pending ownership transfer to "bob"
+    And I am authenticated as user "bob"
+    When I call POST "/v1/ownership-transfers/${transferId}/accept"
+    Then the response status should be 200
+    And the response body should contain:
+      | status | accepted |
+    # Verify ownership changed
+    When I call GET "/v1/conversations/${conversationId}/memberships"
+    Then user "bob" should have access level "owner"
+    And user "alice" should have access level "manager"
+
+  Scenario: Sender cannot accept own transfer
+    Given I have a pending ownership transfer to "bob"
+    When I call POST "/v1/ownership-transfers/${transferId}/accept"
+    Then the response status should be 403
+
+  Scenario: Cannot accept already-accepted transfer
+    Given I have an accepted ownership transfer to "bob"
+    And I am authenticated as user "bob"
+    When I call POST "/v1/ownership-transfers/${transferId}/accept"
+    Then the response status should be 409
+
+  # ===== Delete Transfer =====
+
+  Scenario: Sender can cancel (delete) transfer
+    Given I have a pending ownership transfer to "bob"
+    When I call DELETE "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 204
+    # Verify hard deleted
+    When I call GET "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 404
+
+  Scenario: Recipient can decline (delete) transfer
+    Given I have a pending ownership transfer to "bob"
+    And I am authenticated as user "bob"
+    When I call DELETE "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 204
+
+  Scenario: Non-participant cannot delete transfer
+    Given I have a pending ownership transfer to "bob"
+    And I am authenticated as user "charlie"
+    When I call DELETE "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 403
+
+  Scenario: Cannot delete accepted transfer
+    Given I have an accepted ownership transfer to "bob"
+    When I call DELETE "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 409
+```
+
+#### `sharing-audit-rest.feature`
+
+```gherkin
+Feature: Sharing Audit Logging
+
+  Background:
+    Given I am authenticated as user "alice"
+    And I have a conversation with title "Audited Conversation"
+
+  Scenario: Member add is audit logged
+    When I call POST "/v1/conversations/${conversationId}/memberships" with body:
+      """
+      {"userId": "bob", "accessLevel": "writer"}
+      """
+    Then the audit log should contain:
+      | eventType   | MEMBER_ADDED |
+      | actorUserId | alice        |
+      | targetUserId| bob          |
+
+  Scenario: Member update is audit logged
+    Given I share the conversation with "bob" as "writer"
+    When I call PATCH "/v1/conversations/${conversationId}/memberships/bob" with body:
+      """
+      {"accessLevel": "reader"}
+      """
+    Then the audit log should contain:
+      | eventType       | MEMBER_UPDATED |
+      | actorUserId     | alice          |
+      | details.oldLevel| writer         |
+      | details.newLevel| reader         |
+
+  Scenario: Member remove is audit logged
+    Given I share the conversation with "bob" as "writer"
+    When I call DELETE "/v1/conversations/${conversationId}/memberships/bob"
+    Then the audit log should contain:
+      | eventType   | MEMBER_REMOVED |
+      | actorUserId | alice          |
+      | targetUserId| bob            |
+
+  Scenario: Transfer create is audit logged
+    Given I share the conversation with "bob" as "manager"
+    When I call POST "/v1/ownership-transfers" with body:
+      """
+      {"conversationId": "${conversationId}", "newOwnerUserId": "bob"}
+      """
+    Then the audit log should contain:
+      | eventType      | TRANSFER_CREATED |
+      | actorUserId    | alice            |
+      | details.toUserId| bob             |
+
+  Scenario: Transfer accept is audit logged
+    Given I share the conversation with "bob" as "manager"
+    And I have a pending ownership transfer to "bob"
+    And I am authenticated as user "bob"
+    When I call POST "/v1/ownership-transfers/${transferId}/accept"
+    Then the audit log should contain:
+      | eventType   | TRANSFER_ACCEPTED |
+      | actorUserId | bob               |
+
+  Scenario: Transfer delete is audit logged
+    Given I share the conversation with "bob" as "manager"
+    And I have a pending ownership transfer to "bob"
+    When I call DELETE "/v1/ownership-transfers/${transferId}"
+    Then the audit log should contain:
+      | eventType            | TRANSFER_DELETED |
+      | actorUserId          | alice            |
+      | details.wasRecipient | false            |
+```
+
+### Test Checklist
+
+#### Ownership Transfer API Tests
+
+- [ ] Create transfer - success
+- [ ] Create transfer - fails if not owner (403)
+- [ ] Create transfer - fails if pending transfer exists (409)
+- [ ] Create transfer - fails if recipient not a member (400)
+- [ ] Create transfer - fails if transferring to self (400)
+- [ ] List transfers - returns sender's pending transfers
+- [ ] List transfers - returns recipient's pending transfers
+- [ ] List transfers - filters by role parameter
+- [ ] Get transfer - success for sender
+- [ ] Get transfer - success for recipient
+- [ ] Get transfer - fails for non-participant (404)
+- [ ] Accept transfer - success (recipient)
+- [ ] Accept transfer - fails if not recipient (403)
+- [ ] Accept transfer - fails if already accepted (409)
+- [ ] Accept transfer - correctly updates ownership
+- [ ] Accept transfer - demotes previous owner to manager
+- [ ] Delete transfer - success by sender (cancel)
+- [ ] Delete transfer - success by recipient (decline)
+- [ ] Delete transfer - fails if not participant (403)
+- [ ] Delete transfer - fails if already accepted (409)
+- [ ] Delete transfer - hard deletes record from database
+
+#### Membership API Tests (Hard Delete)
+
+- [ ] Add member - success
+- [ ] Add member - fails if not owner/manager (403)
+- [ ] Update member access level - success
+- [ ] Update member - manager cannot update other managers
+- [ ] Remove member - success
+- [ ] Remove member - hard deletes (not soft delete)
+- [ ] Remove member - manager cannot remove other managers
+
+#### Audit Log Tests
+
+- [ ] Transfer create is logged with correct details
+- [ ] Transfer accept is logged with correct details
+- [ ] Transfer delete is logged (with who deleted and wasRecipient flag)
+- [ ] Member add is logged
+- [ ] Member update is logged with old/new access levels
+- [ ] Member remove is logged
+
+#### Concurrency Tests
+
+- [ ] Two simultaneous create requests - only one succeeds (unique index)
+- [ ] Accept during delete - proper conflict handling
+- [ ] Delete during accept - proper conflict handling
+- [ ] Accept after conversation deleted - proper error
+
+### Implementation Notes for Tests
+
+1. **Step Definitions**: Add new step definitions for ownership transfer operations
+2. **Test Data Setup**: Create helpers for setting up transfer scenarios
+3. **Audit Log Verification**: Add steps to query and verify audit log entries
+4. **Hard Delete Verification**: Add SQL verification steps to confirm records are truly deleted
+
+## Impact on Data Eviction (Enhancement 016)
+
+Since memberships will use **hard deletes** (not soft deletes), the eviction API and implementation need to be updated:
+
+### Changes Required
+
+1. **Remove `conversation_memberships` from evictable resource types**
+   - Memberships are hard deleted immediately, so there's nothing to evict
+   - The eviction endpoint should only accept `conversation_groups`
+
+2. **Update OpenAPI admin spec** (`openapi-admin.yml`):
+   ```yaml
+   resourceTypes:
+     type: array
+     items:
+       type: string
+       enum:
+         - conversation_groups
+         # Remove: conversation_memberships
+   ```
+
+3. **Simplify eviction implementation**:
+   - Remove `countEvictableMemberships()` method
+   - Remove `hardDeleteMembershipsBatch()` method
+   - Update `EvictionService` to only handle conversation groups
+
+4. **Update eviction tests**:
+   - Remove test scenarios for membership eviction
+   - Update documentation to reflect simplified scope
+
+### Rationale
+
+- With audit logging capturing all membership changes, soft deletes provide no additional value
+- Hard deletes simplify the data model and queries
+- Eviction becomes simpler with only one resource type to handle
+
+## References
+
+- Sharing UI: [Enhancement 025](./025-sharing-ui.md)
+- API Spec: `memory-service-contracts/src/main/resources/openapi.yml`

--- a/docs/enhancements/025-sharing-ui.md
+++ b/docs/enhancements/025-sharing-ui.md
@@ -1,0 +1,620 @@
+# Enhancement 024: Conversation Sharing UI
+
+## Overview
+
+This document outlines the design for adding conversation sharing capabilities to the chat application. Users will be able to share conversations with other users, view current members, manage access levels, and transfer ownership.
+
+## Goals
+
+1. Allow users to share conversations with other users at different access levels
+2. Display current conversation members and their permissions
+3. Provide intuitive access level management
+4. Enable ownership transfer with appropriate safeguards
+5. Maintain visual consistency with the Minimal Light design system
+
+## Limitations
+
+This initial implementation has the following constraints:
+
+- **User IDs only**: Members are identified by user ID strings. Display names and email addresses are not currently available from the API.
+- **No user search/autocomplete**: Users must know the exact user ID to share with.
+- **No invitation flow**: Users must already exist in the system to be added as members.
+
+## API Endpoints
+
+The following endpoints from the Memory Service API will be used:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v1/conversations/{conversationId}/memberships` | GET | List all members with access |
+| `/v1/conversations/{conversationId}/memberships` | POST | Share with a new user |
+| `/v1/conversations/{conversationId}/memberships/{userId}` | PATCH | Update access level |
+| `/v1/conversations/{conversationId}/memberships/{userId}` | DELETE | Remove member |
+| `/v1/ownership-transfers` | GET | List pending transfers |
+| `/v1/ownership-transfers` | POST | Create ownership transfer |
+| `/v1/ownership-transfers/{transferId}` | GET | Get transfer details |
+| `/v1/ownership-transfers/{transferId}/accept` | POST | Accept transfer |
+| `/v1/ownership-transfers/{transferId}` | DELETE | Cancel/decline transfer |
+
+### Access Levels
+
+| Level | Permissions |
+|-------|-------------|
+| `owner` | Full control, can delete, transfer ownership, manage all members |
+| `manager` | Can share with others, manage writer/reader access |
+| `writer` | Can send messages and create forks |
+| `reader` | View-only access |
+
+### Permission Rules
+
+| Action | Owner | Manager | Writer | Reader |
+|--------|:-----:|:-------:|:------:|:------:|
+| View members | ✅ | ✅ | ✅ | ✅ |
+| Add members | ✅ | ✅ | ❌ | ❌ |
+| Change access levels | ✅ | ✅* | ❌ | ❌ |
+| Remove members | ✅ | ✅* | ❌ | ❌ |
+| Transfer ownership | ✅ | ❌ | ❌ | ❌ |
+
+*Managers can only manage writer/reader access, not other managers or the owner.
+
+## Design Inspiration
+
+Drawing from established sharing patterns in popular applications:
+
+### Google Docs/Drive
+- "Share" button prominently placed in header
+- Modal with email input and permission dropdown
+- List of current collaborators with roles
+- "Transfer ownership" as advanced option
+
+### Notion
+- Clean sharing popover
+- Role indicators with icons
+- Guest vs member distinction
+
+### Figma
+- Share button triggers modal
+- Permission dropdown per user
+- Copy link for easy sharing
+- Owner crown indicator
+
+### Slack
+- Channel membership management
+- Clear role hierarchy
+- Invite via email or username
+
+## UI Design
+
+### 1. Share Button Placement
+
+Add a "Share" button to the chat panel header. All members can click this button to view who has access to the conversation. Only owners and managers will see the controls to add/remove members.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Chat with your agent                              [👥 Share]    │
+│ Conversation about React hooks                                   │
+├─────────────────────────────────────────────────────────────────┤
+```
+
+**Button Styling** (Minimal Light design):
+- Icon: Users icon (`👥` or Lucide `Users`)
+- Background: `bg-mist` on hover
+- Border: `border border-stone/20 rounded-lg`
+- Text: `text-sm text-stone hover:text-ink`
+
+**Tooltip**:
+- Owner/Manager: "Share conversation"
+- Writer/Reader: "View members"
+
+### 2. Share Modal
+
+A modal dialog for viewing and managing conversation sharing. The UI adapts based on the current user's access level.
+
+#### Owner/Manager View (Can Manage)
+
+Owners and managers see the full sharing controls:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                              ✕  │
+│  Share "Help with React hooks"                                  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 👤 Enter user ID                                         │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  People with access                                             │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 👤 user_john_doe                            Owner    👑   │  │
+│  │    Added Jan 15, 2025                                     │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 👤 user_jane_smith                     [Manager ▾]   🗑   │  │
+│  │    Added Jan 20, 2025                                     │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 👤 user_bob_wilson                      [Reader ▾]   🗑   │  │
+│  │    Added Jan 22, 2025                                     │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ⚙️ Advanced                          (Owner only)              │
+│     Transfer ownership →                                        │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Note**: Managers see dropdowns and remove buttons for writers/readers only. They cannot modify other managers or the owner. The "Advanced" section with ownership transfer is only visible to owners.
+
+#### Writer/Reader View (Read-Only)
+
+Writers and readers see a simplified view without editing controls:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                              ✕  │
+│  "Help with React hooks"                                        │
+│                                                                 │
+│  People with access                                             │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 👤 user_john_doe                            Owner    👑   │  │
+│  │    Added Jan 15, 2025                                     │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 👤 user_jane_smith                          Manager  🔧   │  │
+│  │    Added Jan 20, 2025                                     │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 👤 user_bob_wilson                          Reader   👁   │  │
+│  │    Added Jan 22, 2025                           (you)     │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Differences from manager view**:
+- No "Add people" input field
+- No access level dropdowns (static text instead)
+- No remove buttons
+- No "Advanced" section
+- "(you)" indicator shows which entry is the current user
+
+### 3. Add Member Section
+
+**Only visible to owners and managers.** When adding a new member:
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ 👤 user_alice                                 [Writer ▾]      │
+└───────────────────────────────────────────────────────────────┘
+                                                    [  Add  ]
+```
+
+**Interaction Flow**:
+1. User types user ID in input field
+2. Selects access level from dropdown (defaults to "Reader")
+3. Clicks "Add" button
+4. New member appears in list with success feedback
+
+**Access Level Dropdown Options**:
+- Manager - Can share with others
+- Writer - Can send messages
+- Reader - View only
+
+### 4. Member List Item States
+
+**Owner Row**:
+- Crown icon (`👑`) indicates ownership
+- No dropdown or remove button (owner cannot be removed)
+- "Owner" text is static, not a dropdown
+- Transfer ownership available only to current owner (in Advanced section)
+
+**Manager Row** (when current user is owner):
+- Wrench icon (`🔧`)
+- Access level dropdown (can demote to writer/reader)
+- Remove button available
+
+**Manager Row** (when current user is also a manager):
+- Wrench icon visible
+- No dropdown or remove button (managers cannot modify other managers)
+
+**Writer/Reader Row** (when current user is owner or manager):
+- Pencil (`✏️`) or Eye (`👁`) icon
+- Access level dropdown
+- Remove button (trash icon)
+- Hover state: `bg-mist rounded-lg`
+
+**Any Row** (when current user is writer or reader):
+- Icon for access level
+- Static text for access level (no dropdown)
+- No remove button
+- "(you)" indicator if this is the current user
+
+**Pending/Processing State**:
+- Subtle spinner replacing action buttons
+- Disabled dropdown during update
+
+### 5. Transfer Ownership Flow
+
+**Only available to the conversation owner.** Ownership transfer requires acceptance by the recipient. See [Enhancement 024](./024-sharing-api-enhancements.md) for API details.
+
+#### Initiating a Transfer (Owner)
+
+Triggered from the "Advanced" section. Opens a confirmation modal.
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                              ✕  │
+│  Transfer ownership                                             │
+│                                                                 │
+│  The new owner will need to accept the transfer.                │
+│  You will become a Manager after they accept.                   │
+│                                                                 │
+│  Transfer to:                                                   │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ Select a member...                                     ▾  │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│                            [ Cancel ]  [ Request Transfer ]     │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Interaction Flow (Owner)**:
+1. User clicks "Transfer ownership" in advanced section
+2. Confirmation modal opens
+3. User selects new owner from dropdown (existing members only)
+4. User confirms with "Request Transfer" button
+5. On success: Transfer created as "pending", UI shows pending state
+
+#### Pending Transfer State (Owner View)
+
+When a pending transfer exists, the Advanced section shows:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  ⚙️ Advanced                                                    │
+│                                                                 │
+│  ⏳ Transfer pending                                            │
+│     Waiting for user_jane_smith to accept                       │
+│                                    [ Cancel Transfer ]          │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+#### Incoming Transfer (Recipient View)
+
+When the recipient opens the share modal, they see a banner:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                              ✕  │
+│  "Help with React hooks"                                        │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 👑 Ownership transfer request                             │  │
+│  │    user_john_doe wants to transfer ownership to you       │  │
+│  │                                                           │  │
+│  │                    [ Decline ]  [ Accept Ownership ]      │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│  People with access                                             │
+│  ...                                                            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**Interaction Flow (Recipient)**:
+1. Recipient opens share modal and sees transfer request banner
+2. Recipient clicks "Accept Ownership" or "Decline"
+3. On accept: Recipient becomes owner, previous owner becomes manager
+4. On decline: Transfer is deleted (hard delete), ownership unchanged
+
+#### Constraints
+
+- Only one pending transfer can exist per conversation
+- Owner cannot initiate a new transfer while one is pending
+- Either party can delete a pending transfer (owner cancels, recipient declines)
+- Both cancel and decline use `DELETE /v1/transfers/{transferId}`
+
+### 6. Access Level Indicators
+
+Visual indicators for different access levels throughout the UI:
+
+| Level | Icon | Color | Description |
+|-------|------|-------|-------------|
+| Owner | 👑 Crown | `text-terracotta` | Full control |
+| Manager | 🔧 Wrench | `text-sage` | Can manage sharing |
+| Writer | ✏️ Pencil | `text-ink` | Can contribute |
+| Reader | 👁 Eye | `text-stone` | View only |
+
+### 7. Empty State (No Additional Members)
+
+When conversation has no shared members:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│  People with access                                             │
+│  ─────────────────────────────────────────────────────────────  │
+│                                                                 │
+│  ┌───────────────────────────────────────────────────────────┐  │
+│  │ 👤 user_john_doe                            Owner    👑   │  │
+│  └───────────────────────────────────────────────────────────┘  │
+│                                                                 │
+│           ┌─────────────────────────────────────────┐           │
+│           │   This conversation is private.         │           │
+│           │   Add people above to collaborate.      │           │
+│           └─────────────────────────────────────────┘           │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Component Architecture
+
+### New Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| `ShareButton` | `share-button.tsx` | Header button triggering share modal |
+| `ShareModal` | `share-modal.tsx` | Main sharing dialog |
+| `MemberList` | `member-list.tsx` | List of conversation members |
+| `MemberListItem` | `member-list-item.tsx` | Individual member row |
+| `AddMemberForm` | `add-member-form.tsx` | Input for adding new members |
+| `AccessLevelSelect` | `access-level-select.tsx` | Dropdown for access levels |
+| `TransferRequestModal` | `transfer-request-modal.tsx` | Request ownership transfer (owner) |
+| `TransferPendingBanner` | `transfer-pending-banner.tsx` | Shows pending transfer status |
+| `IncomingTransferBanner` | `incoming-transfer-banner.tsx` | Accept/decline transfer (recipient) |
+
+### Component Hierarchy
+
+```
+ChatPanel
+├── ChatHeader
+│   └── ShareButton → triggers ShareModal
+│       └── ShareModal
+│           ├── IncomingTransferBanner (if recipient of pending transfer)
+│           ├── AddMemberForm (owner/manager only)
+│           │   └── AccessLevelSelect
+│           ├── MemberList
+│           │   └── MemberListItem
+│           │       └── AccessLevelSelect
+│           └── Advanced Section (owner only)
+│               ├── TransferPendingBanner (if pending transfer exists)
+│               └── TransferRequestModal (if no pending transfer)
+```
+
+### State Management
+
+```typescript
+// React Query hooks for data fetching
+useMemberships(conversationId)      // GET memberships
+useShareConversation()              // POST new member
+useUpdateMembership()               // PATCH access level
+useRemoveMembership()               // DELETE member
+
+// Transfer-related hooks (see Enhancement 024)
+usePendingTransfer(conversationId)  // GET pending transfer for conversation
+useRequestTransfer()                // POST create transfer
+useAcceptTransfer()                 // POST accept transfer
+useDeleteTransfer()                 // DELETE transfer (cancel or decline)
+
+// Derived state from memberships
+currentUserAccessLevel: AccessLevel // Determines UI capabilities
+canManageMembers: boolean           // owner or manager
+canTransferOwnership: boolean       // owner only
+
+// Derived state from pending transfer
+hasPendingTransfer: boolean         // Is there a pending transfer?
+isTransferRecipient: boolean        // Is current user the recipient?
+isTransferSender: boolean           // Is current user the sender?
+
+// Local state
+isShareModalOpen: boolean
+isTransferModalOpen: boolean
+pendingMemberId: string | null      // For optimistic updates
+```
+
+## Design Tokens
+
+Following the Minimal Light design system from Enhancement 022/023:
+
+### Colors
+```css
+/* Backgrounds */
+--modal-bg: #FDFBF7;          /* cream */
+--modal-overlay: rgba(26, 26, 26, 0.4);
+--member-hover: #f5f3ef;      /* mist */
+
+/* Text */
+--text-primary: #1a1a1a;      /* ink */
+--text-secondary: #8a8580;    /* stone */
+
+/* Accents */
+--owner-color: #c67a5c;       /* terracotta */
+--manager-color: #7d9a8c;     /* sage */
+--danger-color: #c67a5c;      /* terracotta - for remove */
+```
+
+### Typography
+```css
+/* Modal title */
+font-family: 'Instrument Serif', Georgia, serif;
+font-size: 1.25rem; /* text-xl */
+
+/* Member user IDs */
+font-family: 'DM Sans', system-ui, sans-serif;
+font-size: 0.9375rem; /* text-base */
+font-weight: 500;
+
+/* Secondary text */
+font-size: 0.75rem; /* text-xs */
+color: var(--text-secondary);
+```
+
+### Spacing
+```css
+/* Modal */
+--modal-padding: 1.5rem;      /* p-6 */
+--modal-max-width: 28rem;     /* max-w-md */
+--modal-radius: 1rem;         /* rounded-2xl */
+
+/* Member items */
+--member-padding: 0.75rem;    /* p-3 */
+--member-gap: 0.5rem;         /* gap-2 */
+```
+
+## Interaction Patterns
+
+### Keyboard Navigation
+- `Escape` closes modal
+- `Tab` navigates between focusable elements
+- `Enter` submits forms
+- Arrow keys navigate dropdown options
+
+### Loading States
+- Skeleton placeholders while loading memberships
+- Spinner on action buttons during mutations
+- Disabled state for buttons during processing
+
+### Error Handling
+- Toast notifications for errors
+- Inline validation for user ID input (non-empty)
+- Server-side validation for user existence
+- Retry option for failed requests
+
+### Success Feedback
+- Brief success toast on member added/removed
+- Smooth list animation when members change
+- Modal stays open for multiple additions
+
+## Mobile Considerations
+
+For smaller screens:
+- Modal becomes full-screen sheet sliding from bottom
+- Member list scrollable with sticky header
+- Touch-friendly tap targets (44px minimum)
+- Swipe to dismiss modal
+
+## Accessibility
+
+- ARIA labels on all interactive elements
+- Focus trap within modal
+- Screen reader announcements for state changes
+- High contrast mode support
+- Reduced motion preference respected
+
+## Implementation Phases
+
+### Phase 1: Read-Only Sharing View
+1. Add ShareButton to header (visible to all members)
+2. Implement ShareModal with MemberList
+3. Fetch and display current memberships
+4. Show owner badge and access levels
+5. Determine current user's access level from memberships
+
+### Phase 2: Permission-Aware UI
+1. Show/hide AddMemberForm based on access level (owner/manager only)
+2. Show/hide action controls based on permissions
+3. Implement read-only view for writers/readers
+4. Add "(you)" indicator for current user
+
+### Phase 3: Add/Remove Members
+1. Implement AddMemberForm (owner/manager)
+2. Add member with selected access level
+3. Remove member functionality
+4. Managers restricted to managing writers/readers only
+5. Error handling and validation
+
+### Phase 4: Access Level Management
+1. AccessLevelSelect dropdown
+2. Update membership access level
+3. Managers can only change writer/reader levels
+4. Optimistic updates with rollback
+
+### Phase 5: Ownership Transfer
+1. Fetch pending transfer when opening share modal
+2. TransferRequestModal (owner only, if no pending transfer)
+3. Pending transfer state UI (owner view with cancel option)
+4. Incoming transfer banner (recipient view with accept/decline)
+5. Handle accept/reject/cancel actions
+6. Post-acceptance: UI updates to reflect new owner
+
+### Phase 6: Polish
+1. Animations and transitions
+2. Mobile responsive adjustments
+3. Accessibility audit
+
+## Testing Checklist
+
+### Visual
+- [ ] Modal matches Minimal Light design
+- [ ] Correct icons and colors for access levels
+- [ ] Hover and focus states work
+- [ ] Animations are smooth
+
+### Functional
+- [ ] Can add member with correct access level (owner/manager only)
+- [ ] Can change existing member's access level
+- [ ] Can remove member
+- [ ] Owner can manage all members
+- [ ] Manager can only manage writers/readers
+- [ ] Manager cannot modify other managers or owner
+- [ ] Writer/reader see read-only view
+- [ ] Writer/reader can view all members
+
+### Transfer Flow
+- [ ] Owner can request transfer (transfer option hidden for non-owners)
+- [ ] Cannot request transfer if one is already pending
+- [ ] Owner sees pending transfer state with cancel option
+- [ ] Owner can cancel (delete) pending transfer
+- [ ] Recipient sees incoming transfer banner
+- [ ] Recipient can accept transfer
+- [ ] Recipient can decline (delete) transfer
+- [ ] After acceptance: recipient is owner, former owner is manager
+- [ ] Deleted transfers are hard deleted (not visible after delete)
+
+### Edge Cases
+- [ ] Empty state displays correctly
+- [ ] Long user IDs truncate properly
+- [ ] Invalid user ID shows error
+- [ ] Network error shows retry option
+- [ ] User can't share with themselves
+- [ ] Pending transfer UI updates after accept/delete
+
+### Accessibility
+- [ ] Keyboard navigation works
+- [ ] Screen reader announces actions
+- [ ] Focus management in modal
+- [ ] Color contrast meets WCAG AA
+
+## API Client Updates
+
+The generated TypeScript client needs these services:
+
+```typescript
+// From OpenAPI spec
+SharingService.listConversationMemberships({ conversationId })
+SharingService.shareConversation({ conversationId, requestBody })
+SharingService.updateConversationMembership({ conversationId, userId, requestBody })
+SharingService.deleteConversationMembership({ conversationId, userId })
+SharingService.transferConversationOwnership({ conversationId, requestBody })
+```
+
+Verify the client is regenerated with sharing endpoints included.
+
+## References
+
+- Sharing API: [Enhancement 024](./024-sharing-api-enhancements.md)
+- Design system: [Enhancement 022](./022-chat-app-design.md)
+- Implementation patterns: [Enhancement 023](./023-chat-app-implementation.md)
+- API Spec: `memory-service-contracts/src/main/resources/openapi.yml`
+- Current implementation: `common/agent-webui/src/`

--- a/memory-service-contracts/src/main/resources/memory/v1/memory_service.proto
+++ b/memory-service-contracts/src/main/resources/memory/v1/memory_service.proto
@@ -137,12 +137,6 @@ message ListForksResponse {
   repeated ConversationForkSummary forks = 1;
 }
 
-message TransferOwnershipRequest {
-  // Conversation identifier (UUID as 16-byte big-endian binary)
-  bytes conversation_id = 1;
-  string new_owner_user_id = 2;
-}
-
 message CreateEntryRequest {
   string user_id = 1;
   Channel channel = 2;
@@ -225,6 +219,53 @@ message DeleteMembershipRequest {
   string member_user_id = 2;
 }
 
+// Ownership Transfer messages
+message OwnershipTransfer {
+  // Transfer identifier (UUID as 16-byte big-endian binary)
+  bytes id = 1;
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 2;
+  string conversation_title = 3;
+  string from_user_id = 4;
+  string to_user_id = 5;
+  string created_at = 6;
+}
+
+enum TransferRole {
+  TRANSFER_ROLE_UNSPECIFIED = 0;
+  SENDER = 1;
+  RECIPIENT = 2;
+}
+
+message ListOwnershipTransfersRequest {
+  TransferRole role = 1;
+}
+
+message ListOwnershipTransfersResponse {
+  repeated OwnershipTransfer transfers = 1;
+}
+
+message GetOwnershipTransferRequest {
+  // Transfer identifier (UUID as 16-byte big-endian binary)
+  bytes transfer_id = 1;
+}
+
+message CreateOwnershipTransferRequest {
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
+  string new_owner_user_id = 2;
+}
+
+message AcceptOwnershipTransferRequest {
+  // Transfer identifier (UUID as 16-byte big-endian binary)
+  bytes transfer_id = 1;
+}
+
+message DeleteOwnershipTransferRequest {
+  // Transfer identifier (UUID as 16-byte big-endian binary)
+  bytes transfer_id = 1;
+}
+
 message SearchEntriesRequest {
   string query = 1;
   int32 top_k = 2;
@@ -269,7 +310,6 @@ service ConversationsService {
   rpc DeleteConversation(DeleteConversationRequest) returns (google.protobuf.Empty);
   rpc ForkConversation(ForkConversationRequest) returns (Conversation);
   rpc ListForks(ListForksRequest) returns (ListForksResponse);
-  rpc TransferOwnership(TransferOwnershipRequest) returns (google.protobuf.Empty);
 }
 
 service ConversationMembershipsService {
@@ -277,6 +317,19 @@ service ConversationMembershipsService {
   rpc ShareConversation(ShareConversationRequest) returns (ConversationMembership);
   rpc UpdateMembership(UpdateMembershipRequest) returns (ConversationMembership);
   rpc DeleteMembership(DeleteMembershipRequest) returns (google.protobuf.Empty);
+}
+
+service OwnershipTransfersService {
+  // List pending ownership transfers for the current user
+  rpc ListOwnershipTransfers(ListOwnershipTransfersRequest) returns (ListOwnershipTransfersResponse);
+  // Get a specific ownership transfer
+  rpc GetOwnershipTransfer(GetOwnershipTransferRequest) returns (OwnershipTransfer);
+  // Create a new ownership transfer (initiates transfer to another user)
+  rpc CreateOwnershipTransfer(CreateOwnershipTransferRequest) returns (OwnershipTransfer);
+  // Accept an ownership transfer (recipient becomes owner, sender becomes manager)
+  rpc AcceptOwnershipTransfer(AcceptOwnershipTransferRequest) returns (google.protobuf.Empty);
+  // Delete/cancel an ownership transfer
+  rpc DeleteOwnershipTransfer(DeleteOwnershipTransferRequest) returns (google.protobuf.Empty);
 }
 
 service EntriesService {

--- a/memory-service-contracts/src/main/resources/openapi.yml
+++ b/memory-service-contracts/src/main/resources/openapi.yml
@@ -439,36 +439,183 @@ paths:
   ############################################################
   # Sharing
   ############################################################
-  /v1/conversations/{conversationId}/transfer-ownership:
+  /v1/ownership-transfers:
+    get:
+      tags: [Sharing]
+      summary: List pending ownership transfers
+      description: |-
+        Returns all pending ownership transfers where the current user is either
+        the current owner (sender) or the proposed new owner (recipient).
+      operationId: listPendingTransfers
+      parameters:
+        - name: role
+          in: query
+          required: false
+          description: Filter by user's role in the transfer.
+          schema:
+            type: string
+            enum: [sender, recipient, all]
+            default: all
+      responses:
+        '200':
+          description: List of pending transfers.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/OwnershipTransfer'
+        default:
+          $ref: '#/components/responses/Error'
+      security:
+        - BearerAuth: []
     post:
       tags: [Sharing]
       summary: Request ownership transfer
       description: |-
-        Initiates a transfer of conversation ownership to another user. The other
-        user must accept the transfer via a separate API or out-of-band process.
-      operationId: transferConversationOwnership
-      parameters:
-        - name: conversationId
-          in: path
-          required: true
-          description: Conversation identifier (UUID format).
-          schema:
-            type: string
-            format: uuid
+        Initiates a transfer of conversation ownership to another user.
+
+        **Constraints**:
+        - Only the current owner can initiate a transfer
+        - The recipient must be an existing member of the conversation
+        - Only one pending transfer can exist per conversation at a time
+        - If a pending transfer already exists, returns 409 Conflict
+
+        The recipient must accept the transfer via `POST /v1/ownership-transfers/{transferId}/accept`
+        for the transfer to complete. Either party can delete the pending transfer
+        via `DELETE /v1/ownership-transfers/{transferId}`.
+      operationId: createOwnershipTransfer
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              type: object
-              required:
-                - newOwnerUserId
-              properties:
-                newOwnerUserId:
-                  type: string
+              $ref: '#/components/schemas/CreateOwnershipTransferRequest'
       responses:
-        '202':
-          description: Ownership transfer requested.
+        '201':
+          description: Transfer initiated successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OwnershipTransfer'
+        '400':
+          description: Invalid request (recipient not a member, transfer to self).
+          $ref: '#/components/responses/Error'
+        '403':
+          description: Not authorized (not the owner).
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          description: A pending transfer already exists for this conversation.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: "A pending ownership transfer already exists for this conversation"
+                  code:
+                    type: string
+                    example: "TRANSFER_ALREADY_PENDING"
+                  existingTransferId:
+                    type: string
+                    format: uuid
+                    description: ID of the existing pending transfer
+        default:
+          $ref: '#/components/responses/Error'
+      security:
+        - BearerAuth: []
+
+  /v1/ownership-transfers/{transferId}:
+    get:
+      tags: [Sharing]
+      summary: Get transfer details
+      description: |-
+        Returns details of a specific ownership transfer. Only accessible to
+        the current owner (sender) or proposed new owner (recipient).
+      operationId: getTransfer
+      parameters:
+        - name: transferId
+          in: path
+          required: true
+          description: Transfer identifier (UUID format).
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Transfer details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OwnershipTransfer'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/Error'
+      security:
+        - BearerAuth: []
+    delete:
+      tags: [Sharing]
+      summary: Cancel or reject ownership transfer
+      description: |-
+        Deletes a pending ownership transfer. Can be called by either:
+        - The current owner (sender) to cancel the transfer
+        - The proposed new owner (recipient) to reject the transfer
+
+        The transfer record is **hard deleted** from the database.
+      operationId: deleteTransfer
+      parameters:
+        - name: transferId
+          in: path
+          required: true
+          description: Transfer identifier (UUID format).
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Transfer deleted successfully.
+        '403':
+          description: Not authorized (not the sender or recipient).
+          $ref: '#/components/responses/Error'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/Error'
+      security:
+        - BearerAuth: []
+
+  /v1/ownership-transfers/{transferId}/accept:
+    post:
+      tags: [Sharing]
+      summary: Accept ownership transfer
+      description: |-
+        Accepts a pending ownership transfer. Only the proposed new owner
+        (recipient) can accept. Upon acceptance:
+        - The recipient becomes the new owner
+        - The previous owner becomes a manager
+        - The transfer record is deleted (transfers are always pending while they exist)
+      operationId: acceptTransfer
+      parameters:
+        - name: transferId
+          in: path
+          required: true
+          description: Transfer identifier (UUID format).
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Transfer accepted successfully. Ownership has been transferred.
+        '403':
+          description: Not authorized (not the recipient).
+          $ref: '#/components/responses/Error'
         '404':
           $ref: '#/components/responses/NotFound'
         default:
@@ -1111,3 +1258,63 @@ components:
           createdAt: "2025-01-10T14:32:05Z"
         score: 0.93
         highlights: "design a memory service for my agent"
+
+    OwnershipTransfer:
+      type: object
+      description: |-
+        Represents a pending ownership transfer request.
+        Transfers are always "pending" while they exist; accepted/rejected transfers
+        are hard deleted from the database.
+      required:
+        - id
+        - conversationId
+        - fromUserId
+        - toUserId
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the transfer.
+        conversationId:
+          type: string
+          format: uuid
+          description: The conversation being transferred.
+        conversationTitle:
+          type: string
+          nullable: true
+          description: Title of the conversation (for display purposes).
+        fromUserId:
+          type: string
+          description: Current owner initiating the transfer.
+        toUserId:
+          type: string
+          description: Proposed new owner (recipient).
+        createdAt:
+          type: string
+          format: date-time
+          description: When the transfer was initiated.
+      example:
+        id: "7c9e6679-7425-40de-944b-e07fc1f90ae7"
+        conversationId: "550e8400-e29b-41d4-a716-446655440000"
+        conversationTitle: "Help with React hooks"
+        fromUserId: "user_john_doe"
+        toUserId: "user_jane_smith"
+        createdAt: "2025-01-28T10:30:00Z"
+
+    CreateOwnershipTransferRequest:
+      type: object
+      required:
+        - conversationId
+        - newOwnerUserId
+      properties:
+        conversationId:
+          type: string
+          format: uuid
+          description: The conversation to transfer ownership of.
+        newOwnerUserId:
+          type: string
+          description: User ID of the proposed new owner. Must be an existing member.
+      example:
+        conversationId: "550e8400-e29b-41d4-a716-446655440000"
+        newOwnerUserId: "user_jane_smith"

--- a/memory-service/src/main/java/io/github/chirino/memory/api/ConversationsResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/ConversationsResource.java
@@ -458,21 +458,6 @@ public class ConversationsResource {
     }
 
     @POST
-    @Path("/conversations/{conversationId}/transfer-ownership")
-    public Response transferOwnership(
-            @PathParam("conversationId") String conversationId, Map<String, String> body) {
-        try {
-            String newOwnerUserId = body.get("newOwnerUserId");
-            store().requestOwnershipTransfer(currentUserId(), conversationId, newOwnerUserId);
-            return Response.status(Response.Status.ACCEPTED).build();
-        } catch (ResourceNotFoundException e) {
-            return notFound(e);
-        } catch (AccessDeniedException e) {
-            return forbidden(e);
-        }
-    }
-
-    @POST
     @Path("/conversations/index")
     public Response indexConversationTranscript(IndexTranscriptRequest request) {
         if (apiKeyContext == null || !apiKeyContext.hasValidApiKey()) {

--- a/memory-service/src/main/java/io/github/chirino/memory/api/OwnershipTransfersResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/OwnershipTransfersResource.java
@@ -1,0 +1,156 @@
+package io.github.chirino.memory.api;
+
+import io.github.chirino.memory.api.dto.CreateOwnershipTransferRequest;
+import io.github.chirino.memory.api.dto.OwnershipTransferDto;
+import io.github.chirino.memory.client.model.ErrorResponse;
+import io.github.chirino.memory.config.MemoryStoreSelector;
+import io.github.chirino.memory.store.AccessDeniedException;
+import io.github.chirino.memory.store.MemoryStore;
+import io.github.chirino.memory.store.ResourceConflictException;
+import io.github.chirino.memory.store.ResourceNotFoundException;
+import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.jboss.logging.Logger;
+
+@Path("/v1/ownership-transfers")
+@Authenticated
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class OwnershipTransfersResource {
+
+    private static final Logger LOG = Logger.getLogger(OwnershipTransfersResource.class);
+
+    @Inject MemoryStoreSelector storeSelector;
+
+    @Inject SecurityIdentity identity;
+
+    private MemoryStore store() {
+        return storeSelector.getStore();
+    }
+
+    private String currentUserId() {
+        return identity.getPrincipal().getName();
+    }
+
+    @GET
+    public Response listPendingTransfers(@QueryParam("role") @DefaultValue("all") String role) {
+        List<OwnershipTransferDto> transfers = store().listPendingTransfers(currentUserId(), role);
+        Map<String, Object> response = new HashMap<>();
+        response.put("data", transfers);
+        return Response.ok(response).build();
+    }
+
+    @GET
+    @Path("/{transferId}")
+    public Response getTransfer(@PathParam("transferId") String transferId) {
+        Optional<OwnershipTransferDto> transfer = store().getTransfer(currentUserId(), transferId);
+        if (transfer.isEmpty()) {
+            return notFound("transfer", transferId);
+        }
+        return Response.ok(transfer.get()).build();
+    }
+
+    @POST
+    public Response createOwnershipTransfer(CreateOwnershipTransferRequest request) {
+        try {
+            OwnershipTransferDto transfer =
+                    store().createOwnershipTransfer(currentUserId(), request);
+            return Response.status(Response.Status.CREATED).entity(transfer).build();
+        } catch (ResourceNotFoundException e) {
+            return notFound(e);
+        } catch (AccessDeniedException e) {
+            return forbidden(e);
+        } catch (ResourceConflictException e) {
+            return conflictWithExistingTransfer(e);
+        } catch (IllegalArgumentException e) {
+            return badRequest(e.getMessage());
+        }
+    }
+
+    @POST
+    @Path("/{transferId}/accept")
+    public Response acceptTransfer(@PathParam("transferId") String transferId) {
+        try {
+            store().acceptTransfer(currentUserId(), transferId);
+            return Response.noContent().build();
+        } catch (ResourceNotFoundException e) {
+            return notFound(e);
+        } catch (AccessDeniedException e) {
+            return forbidden(e);
+        }
+    }
+
+    @DELETE
+    @Path("/{transferId}")
+    public Response deleteTransfer(@PathParam("transferId") String transferId) {
+        try {
+            store().deleteTransfer(currentUserId(), transferId);
+            return Response.noContent().build();
+        } catch (ResourceNotFoundException e) {
+            return notFound(e);
+        } catch (AccessDeniedException e) {
+            return forbidden(e);
+        }
+    }
+
+    private Response notFound(String resource, String id) {
+        ErrorResponse error = new ErrorResponse();
+        error.setError("Not found");
+        error.setCode("not_found");
+        error.setDetails(Map.of("resource", resource, "id", id));
+        return Response.status(Response.Status.NOT_FOUND).entity(error).build();
+    }
+
+    private Response notFound(ResourceNotFoundException e) {
+        return notFound(e.getResource(), e.getId());
+    }
+
+    private Response forbidden(AccessDeniedException e) {
+        LOG.infof("Access denied for user=%s: %s", currentUserId(), e.getMessage());
+        ErrorResponse error = new ErrorResponse();
+        error.setError("Forbidden");
+        error.setCode("forbidden");
+        error.setDetails(Map.of("message", e.getMessage()));
+        return Response.status(Response.Status.FORBIDDEN).entity(error).build();
+    }
+
+    private Response conflict(String message) {
+        ErrorResponse error = new ErrorResponse();
+        error.setError("Conflict");
+        error.setCode("conflict");
+        error.setDetails(Map.of("message", message));
+        return Response.status(Response.Status.CONFLICT).entity(error).build();
+    }
+
+    private Response conflictWithExistingTransfer(ResourceConflictException e) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("error", e.getMessage());
+        body.put("code", "TRANSFER_ALREADY_PENDING");
+        body.put("existingTransferId", e.getId());
+        return Response.status(Response.Status.CONFLICT).entity(body).build();
+    }
+
+    private Response badRequest(String message) {
+        ErrorResponse error = new ErrorResponse();
+        error.setError("Bad request");
+        error.setCode("bad_request");
+        error.setDetails(Map.of("message", message));
+        return Response.status(Response.Status.BAD_REQUEST).entity(error).build();
+    }
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/api/dto/CreateOwnershipTransferRequest.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/dto/CreateOwnershipTransferRequest.java
@@ -1,0 +1,23 @@
+package io.github.chirino.memory.api.dto;
+
+public class CreateOwnershipTransferRequest {
+
+    private String conversationId;
+    private String newOwnerUserId;
+
+    public String getConversationId() {
+        return conversationId;
+    }
+
+    public void setConversationId(String conversationId) {
+        this.conversationId = conversationId;
+    }
+
+    public String getNewOwnerUserId() {
+        return newOwnerUserId;
+    }
+
+    public void setNewOwnerUserId(String newOwnerUserId) {
+        this.newOwnerUserId = newOwnerUserId;
+    }
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/api/dto/OwnershipTransferDto.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/dto/OwnershipTransferDto.java
@@ -1,0 +1,63 @@
+package io.github.chirino.memory.api.dto;
+
+/**
+ * Represents a pending ownership transfer request.
+ * Transfers are always "pending" while they exist; accepted/rejected transfers are hard deleted.
+ */
+public class OwnershipTransferDto {
+
+    private String id;
+    private String conversationId;
+    private String conversationTitle;
+    private String fromUserId;
+    private String toUserId;
+    private String createdAt;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getConversationId() {
+        return conversationId;
+    }
+
+    public void setConversationId(String conversationId) {
+        this.conversationId = conversationId;
+    }
+
+    public String getConversationTitle() {
+        return conversationTitle;
+    }
+
+    public void setConversationTitle(String conversationTitle) {
+        this.conversationTitle = conversationTitle;
+    }
+
+    public String getFromUserId() {
+        return fromUserId;
+    }
+
+    public void setFromUserId(String fromUserId) {
+        this.fromUserId = fromUserId;
+    }
+
+    public String getToUserId() {
+        return toUserId;
+    }
+
+    public void setToUserId(String toUserId) {
+        this.toUserId = toUserId;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/grpc/ConversationsGrpcService.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/grpc/ConversationsGrpcService.java
@@ -18,7 +18,6 @@ import io.github.chirino.memory.grpc.v1.ListConversationsRequest;
 import io.github.chirino.memory.grpc.v1.ListConversationsResponse;
 import io.github.chirino.memory.grpc.v1.ListForksRequest;
 import io.github.chirino.memory.grpc.v1.ListForksResponse;
-import io.github.chirino.memory.grpc.v1.TransferOwnershipRequest;
 import io.quarkus.grpc.GrpcService;
 import io.smallrye.common.annotation.Blocking;
 import io.smallrye.mutiny.Uni;
@@ -146,22 +145,6 @@ public class ConversationsGrpcService extends AbstractGrpcService implements Con
                                                     .map(GrpcDtoMapper::toProto)
                                                     .collect(Collectors.toList()))
                                     .build();
-                        })
-                .onFailure()
-                .transform(GrpcStatusMapper::map);
-    }
-
-    @Override
-    public Uni<Empty> transferOwnership(TransferOwnershipRequest request) {
-        return Uni.createFrom()
-                .item(
-                        () -> {
-                            String conversationId = byteStringToString(request.getConversationId());
-                            store().requestOwnershipTransfer(
-                                            currentUserId(),
-                                            conversationId,
-                                            request.getNewOwnerUserId());
-                            return Empty.getDefaultInstance();
                         })
                 .onFailure()
                 .transform(GrpcStatusMapper::map);

--- a/memory-service/src/main/java/io/github/chirino/memory/grpc/GrpcDtoMapper.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/grpc/GrpcDtoMapper.java
@@ -19,6 +19,7 @@ import io.github.chirino.memory.api.dto.ConversationForkSummaryDto;
 import io.github.chirino.memory.api.dto.ConversationMembershipDto;
 import io.github.chirino.memory.api.dto.ConversationSummaryDto;
 import io.github.chirino.memory.api.dto.EntryDto;
+import io.github.chirino.memory.api.dto.OwnershipTransferDto;
 import io.github.chirino.memory.api.dto.SearchResultDto;
 import io.github.chirino.memory.client.model.CreateEntryRequest;
 import io.github.chirino.memory.grpc.v1.Conversation;
@@ -26,7 +27,9 @@ import io.github.chirino.memory.grpc.v1.ConversationForkSummary;
 import io.github.chirino.memory.grpc.v1.ConversationMembership;
 import io.github.chirino.memory.grpc.v1.ConversationSummary;
 import io.github.chirino.memory.grpc.v1.Entry;
+import io.github.chirino.memory.grpc.v1.OwnershipTransfer;
 import io.github.chirino.memory.grpc.v1.SearchResult;
+import io.github.chirino.memory.grpc.v1.TransferRole;
 import io.github.chirino.memory.model.AccessLevel;
 import io.github.chirino.memory.model.Channel;
 import java.util.Collections;
@@ -131,6 +134,32 @@ public final class GrpcDtoMapper {
                 .setScore((float) dto.getScore())
                 .setHighlights(dto.getHighlights() == null ? "" : dto.getHighlights())
                 .build();
+    }
+
+    public static OwnershipTransfer toProto(OwnershipTransferDto dto) {
+        if (dto == null) {
+            return null;
+        }
+        return OwnershipTransfer.newBuilder()
+                .setId(stringToByteString(dto.getId()))
+                .setConversationId(stringToByteString(dto.getConversationId()))
+                .setConversationTitle(
+                        dto.getConversationTitle() == null ? "" : dto.getConversationTitle())
+                .setFromUserId(dto.getFromUserId() == null ? "" : dto.getFromUserId())
+                .setToUserId(dto.getToUserId() == null ? "" : dto.getToUserId())
+                .setCreatedAt(dto.getCreatedAt() == null ? "" : dto.getCreatedAt())
+                .build();
+    }
+
+    public static String transferRoleFromProto(TransferRole role) {
+        if (role == null) {
+            return "all";
+        }
+        return switch (role) {
+            case SENDER -> "sender";
+            case RECIPIENT -> "recipient";
+            default -> "all";
+        };
     }
 
     public static List<Value> toValues(List<Object> objects) {

--- a/memory-service/src/main/java/io/github/chirino/memory/grpc/GrpcStatusMapper.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/grpc/GrpcStatusMapper.java
@@ -1,6 +1,7 @@
 package io.github.chirino.memory.grpc;
 
 import io.github.chirino.memory.store.AccessDeniedException;
+import io.github.chirino.memory.store.ResourceConflictException;
 import io.github.chirino.memory.store.ResourceNotFoundException;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -19,6 +20,11 @@ public final class GrpcStatusMapper {
         if (throwable instanceof AccessDeniedException accessDenied) {
             return Status.PERMISSION_DENIED
                     .withDescription(accessDenied.getMessage())
+                    .asRuntimeException();
+        }
+        if (throwable instanceof ResourceConflictException conflict) {
+            return Status.ALREADY_EXISTS
+                    .withDescription(conflict.getMessage())
                     .asRuntimeException();
         }
         if (throwable instanceof IllegalArgumentException illegalArgument) {

--- a/memory-service/src/main/java/io/github/chirino/memory/grpc/OwnershipTransfersGrpcService.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/grpc/OwnershipTransfersGrpcService.java
@@ -1,0 +1,109 @@
+package io.github.chirino.memory.grpc;
+
+import static io.github.chirino.memory.grpc.UuidUtils.byteStringToString;
+
+import com.google.protobuf.Empty;
+import io.github.chirino.memory.api.dto.CreateOwnershipTransferRequest;
+import io.github.chirino.memory.api.dto.OwnershipTransferDto;
+import io.github.chirino.memory.grpc.v1.AcceptOwnershipTransferRequest;
+import io.github.chirino.memory.grpc.v1.DeleteOwnershipTransferRequest;
+import io.github.chirino.memory.grpc.v1.GetOwnershipTransferRequest;
+import io.github.chirino.memory.grpc.v1.ListOwnershipTransfersRequest;
+import io.github.chirino.memory.grpc.v1.ListOwnershipTransfersResponse;
+import io.github.chirino.memory.grpc.v1.OwnershipTransfer;
+import io.github.chirino.memory.grpc.v1.OwnershipTransfersService;
+import io.github.chirino.memory.store.ResourceNotFoundException;
+import io.quarkus.grpc.GrpcService;
+import io.smallrye.common.annotation.Blocking;
+import io.smallrye.mutiny.Uni;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@GrpcService
+@Blocking
+public class OwnershipTransfersGrpcService extends AbstractGrpcService
+        implements OwnershipTransfersService {
+
+    @Override
+    public Uni<ListOwnershipTransfersResponse> listOwnershipTransfers(
+            ListOwnershipTransfersRequest request) {
+        return Uni.createFrom()
+                .item(
+                        () -> {
+                            String role = GrpcDtoMapper.transferRoleFromProto(request.getRole());
+                            List<OwnershipTransferDto> transfers =
+                                    store().listPendingTransfers(currentUserId(), role);
+                            return ListOwnershipTransfersResponse.newBuilder()
+                                    .addAllTransfers(
+                                            transfers.stream()
+                                                    .map(GrpcDtoMapper::toProto)
+                                                    .collect(Collectors.toList()))
+                                    .build();
+                        })
+                .onFailure()
+                .transform(GrpcStatusMapper::map);
+    }
+
+    @Override
+    public Uni<OwnershipTransfer> getOwnershipTransfer(GetOwnershipTransferRequest request) {
+        return Uni.createFrom()
+                .item(
+                        () -> {
+                            String transferId = byteStringToString(request.getTransferId());
+                            Optional<OwnershipTransferDto> transfer =
+                                    store().getTransfer(currentUserId(), transferId);
+                            if (transfer.isEmpty()) {
+                                throw new ResourceNotFoundException("transfer", transferId);
+                            }
+                            return GrpcDtoMapper.toProto(transfer.get());
+                        })
+                .onFailure()
+                .transform(GrpcStatusMapper::map);
+    }
+
+    @Override
+    public Uni<OwnershipTransfer> createOwnershipTransfer(
+            io.github.chirino.memory.grpc.v1.CreateOwnershipTransferRequest request) {
+        return Uni.createFrom()
+                .item(
+                        () -> {
+                            CreateOwnershipTransferRequest internal =
+                                    new CreateOwnershipTransferRequest();
+                            internal.setConversationId(
+                                    byteStringToString(request.getConversationId()));
+                            internal.setNewOwnerUserId(request.getNewOwnerUserId());
+                            OwnershipTransferDto transfer =
+                                    store().createOwnershipTransfer(currentUserId(), internal);
+                            return GrpcDtoMapper.toProto(transfer);
+                        })
+                .onFailure()
+                .transform(GrpcStatusMapper::map);
+    }
+
+    @Override
+    public Uni<Empty> acceptOwnershipTransfer(AcceptOwnershipTransferRequest request) {
+        return Uni.createFrom()
+                .item(
+                        () -> {
+                            String transferId = byteStringToString(request.getTransferId());
+                            store().acceptTransfer(currentUserId(), transferId);
+                            return Empty.getDefaultInstance();
+                        })
+                .onFailure()
+                .transform(GrpcStatusMapper::map);
+    }
+
+    @Override
+    public Uni<Empty> deleteOwnershipTransfer(DeleteOwnershipTransferRequest request) {
+        return Uni.createFrom()
+                .item(
+                        () -> {
+                            String transferId = byteStringToString(request.getTransferId());
+                            store().deleteTransfer(currentUserId(), transferId);
+                            return Empty.getDefaultInstance();
+                        })
+                .onFailure()
+                .transform(GrpcStatusMapper::map);
+    }
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/mongo/model/MongoConversationOwnershipTransfer.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/mongo/model/MongoConversationOwnershipTransfer.java
@@ -1,10 +1,13 @@
 package io.github.chirino.memory.mongo.model;
 
-import io.github.chirino.memory.persistence.entity.ConversationOwnershipTransferEntity.TransferStatus;
 import io.quarkus.mongodb.panache.common.MongoEntity;
 import java.time.Instant;
 import org.bson.codecs.pojo.annotations.BsonId;
 
+/**
+ * Represents a pending ownership transfer request.
+ * Transfers are always "pending" while they exist; accepted/rejected transfers are hard deleted.
+ */
 @MongoEntity(collection = "conversation_ownership_transfers")
 public class MongoConversationOwnershipTransfer {
 
@@ -13,7 +16,5 @@ public class MongoConversationOwnershipTransfer {
     public String conversationGroupId;
     public String fromUserId;
     public String toUserId;
-    public TransferStatus status;
     public Instant createdAt;
-    public Instant updatedAt;
 }

--- a/memory-service/src/main/java/io/github/chirino/memory/mongo/repo/MongoConversationOwnershipTransferRepository.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/mongo/repo/MongoConversationOwnershipTransferRepository.java
@@ -3,7 +3,51 @@ package io.github.chirino.memory.mongo.repo;
 import io.github.chirino.memory.mongo.model.MongoConversationOwnershipTransfer;
 import io.quarkus.mongodb.panache.PanacheMongoRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import java.util.Optional;
 
+/**
+ * Repository for ownership transfers.
+ * All transfers in the database are implicitly "pending" - accepted/rejected transfers are deleted.
+ */
 @ApplicationScoped
 public class MongoConversationOwnershipTransferRepository
-        implements PanacheMongoRepositoryBase<MongoConversationOwnershipTransfer, String> {}
+        implements PanacheMongoRepositoryBase<MongoConversationOwnershipTransfer, String> {
+
+    /** Find transfer for a conversation group (only one can exist at a time). */
+    public Optional<MongoConversationOwnershipTransfer> findByConversationGroup(String groupId) {
+        return find("conversationGroupId = ?1", groupId).firstResultOptional();
+    }
+
+    /** Find by ID if user is sender or recipient. */
+    public Optional<MongoConversationOwnershipTransfer> findByIdAndParticipant(
+            String id, String userId) {
+        return find("_id = ?1 and (fromUserId = ?2 or toUserId = ?2)", id, userId)
+                .firstResultOptional();
+    }
+
+    /** List transfers where user is sender. */
+    public List<MongoConversationOwnershipTransfer> listByFromUser(String userId) {
+        return find("fromUserId = ?1", userId).list();
+    }
+
+    /** List transfers where user is recipient. */
+    public List<MongoConversationOwnershipTransfer> listByToUser(String userId) {
+        return find("toUserId = ?1", userId).list();
+    }
+
+    /** List all transfers for user (sender or recipient). */
+    public List<MongoConversationOwnershipTransfer> listByUser(String userId) {
+        return find("fromUserId = ?1 or toUserId = ?1", userId).list();
+    }
+
+    /** Delete all transfers for a conversation group. */
+    public long deleteByConversationGroup(String groupId) {
+        return delete("conversationGroupId = ?1", groupId);
+    }
+
+    /** Delete transfer for a conversation group where the given user is the recipient. */
+    public long deleteByConversationGroupAndToUser(String groupId, String toUserId) {
+        return delete("conversationGroupId = ?1 and toUserId = ?2", groupId, toUserId);
+    }
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/persistence/entity/ConversationOwnershipTransferEntity.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/persistence/entity/ConversationOwnershipTransferEntity.java
@@ -2,27 +2,21 @@ package io.github.chirino.memory.persistence.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
+/**
+ * Represents a pending ownership transfer request.
+ * Transfers are always "pending" while they exist; accepted/rejected transfers are hard deleted.
+ */
 @Entity
 @Table(name = "conversation_ownership_transfers")
 public class ConversationOwnershipTransferEntity {
-
-    public enum TransferStatus {
-        PENDING,
-        ACCEPTED,
-        REJECTED,
-        EXPIRED
-    }
 
     @Id
     @Column(name = "id", nullable = false, updatable = false)
@@ -38,15 +32,8 @@ public class ConversationOwnershipTransferEntity {
     @Column(name = "to_user_id", nullable = false)
     private String toUserId;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "status", nullable = false)
-    private TransferStatus status;
-
     @Column(name = "created_at", nullable = false)
     private OffsetDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private OffsetDateTime updatedAt;
 
     public UUID getId() {
         return id;
@@ -80,28 +67,12 @@ public class ConversationOwnershipTransferEntity {
         this.toUserId = toUserId;
     }
 
-    public TransferStatus getStatus() {
-        return status;
-    }
-
-    public void setStatus(TransferStatus status) {
-        this.status = status;
-    }
-
     public OffsetDateTime getCreatedAt() {
         return createdAt;
     }
 
     public void setCreatedAt(OffsetDateTime createdAt) {
         this.createdAt = createdAt;
-    }
-
-    public OffsetDateTime getUpdatedAt() {
-        return updatedAt;
-    }
-
-    public void setUpdatedAt(OffsetDateTime updatedAt) {
-        this.updatedAt = updatedAt;
     }
 
     @PrePersist
@@ -113,16 +84,5 @@ public class ConversationOwnershipTransferEntity {
         if (createdAt == null) {
             createdAt = now;
         }
-        if (updatedAt == null) {
-            updatedAt = now;
-        }
-        if (status == null) {
-            status = TransferStatus.PENDING;
-        }
-    }
-
-    @PreUpdate
-    public void preUpdate() {
-        updatedAt = OffsetDateTime.now();
     }
 }

--- a/memory-service/src/main/java/io/github/chirino/memory/persistence/repo/ConversationOwnershipTransferRepository.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/persistence/repo/ConversationOwnershipTransferRepository.java
@@ -3,8 +3,52 @@ package io.github.chirino.memory.persistence.repo;
 import io.github.chirino.memory.persistence.entity.ConversationOwnershipTransferEntity;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import jakarta.enterprise.context.ApplicationScoped;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * Repository for ownership transfers.
+ * All transfers in the database are implicitly "pending" - accepted/rejected transfers are deleted.
+ */
 @ApplicationScoped
 public class ConversationOwnershipTransferRepository
-        implements PanacheRepositoryBase<ConversationOwnershipTransferEntity, UUID> {}
+        implements PanacheRepositoryBase<ConversationOwnershipTransferEntity, UUID> {
+
+    /** Find transfer for a conversation group (only one can exist at a time). */
+    public Optional<ConversationOwnershipTransferEntity> findByConversationGroup(UUID groupId) {
+        return find("conversationGroup.id = ?1", groupId).firstResultOptional();
+    }
+
+    /** Find by ID if user is sender or recipient. */
+    public Optional<ConversationOwnershipTransferEntity> findByIdAndParticipant(
+            UUID id, String userId) {
+        return find("id = ?1 AND (fromUserId = ?2 OR toUserId = ?2)", id, userId)
+                .firstResultOptional();
+    }
+
+    /** List transfers where user is sender. */
+    public List<ConversationOwnershipTransferEntity> listByFromUser(String userId) {
+        return find("fromUserId = ?1", userId).list();
+    }
+
+    /** List transfers where user is recipient. */
+    public List<ConversationOwnershipTransferEntity> listByToUser(String userId) {
+        return find("toUserId = ?1", userId).list();
+    }
+
+    /** List all transfers for user (sender or recipient). */
+    public List<ConversationOwnershipTransferEntity> listByUser(String userId) {
+        return find("fromUserId = ?1 OR toUserId = ?1", userId).list();
+    }
+
+    /** Delete all transfers for a conversation group. */
+    public long deleteByConversationGroup(UUID groupId) {
+        return delete("conversationGroup.id = ?1", groupId);
+    }
+
+    /** Delete transfer for a conversation group where the given user is the recipient. */
+    public long deleteByConversationGroupAndToUser(UUID groupId, String toUserId) {
+        return delete("conversationGroup.id = ?1 AND toUserId = ?2", groupId, toUserId);
+    }
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
@@ -6,10 +6,12 @@ import io.github.chirino.memory.api.dto.ConversationForkSummaryDto;
 import io.github.chirino.memory.api.dto.ConversationMembershipDto;
 import io.github.chirino.memory.api.dto.ConversationSummaryDto;
 import io.github.chirino.memory.api.dto.CreateConversationRequest;
+import io.github.chirino.memory.api.dto.CreateOwnershipTransferRequest;
 import io.github.chirino.memory.api.dto.CreateUserEntryRequest;
 import io.github.chirino.memory.api.dto.EntryDto;
 import io.github.chirino.memory.api.dto.ForkFromEntryRequest;
 import io.github.chirino.memory.api.dto.IndexTranscriptRequest;
+import io.github.chirino.memory.api.dto.OwnershipTransferDto;
 import io.github.chirino.memory.api.dto.PagedEntries;
 import io.github.chirino.memory.api.dto.SearchEntriesRequest;
 import io.github.chirino.memory.api.dto.SearchResultDto;
@@ -55,7 +57,18 @@ public interface MemoryStore {
 
     List<ConversationForkSummaryDto> listForks(String userId, String conversationId);
 
-    void requestOwnershipTransfer(String userId, String conversationId, String newOwnerUserId);
+    // Ownership transfer methods (transfers are always "pending" while they exist)
+    List<OwnershipTransferDto> listPendingTransfers(String userId, String role);
+
+    Optional<OwnershipTransferDto> getTransfer(String userId, String transferId);
+
+    OwnershipTransferDto createOwnershipTransfer(
+            String userId, CreateOwnershipTransferRequest request);
+
+    /** Accept transfer - performs ownership swap and deletes the transfer record. */
+    void acceptTransfer(String userId, String transferId);
+
+    void deleteTransfer(String userId, String transferId);
 
     PagedEntries getEntries(
             String userId,

--- a/memory-service/src/test/java/io/github/chirino/memory/AbstractMemoryServiceTest.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/AbstractMemoryServiceTest.java
@@ -303,14 +303,29 @@ abstract class AbstractMemoryServiceTest {
                         .extract()
                         .path("id");
 
-        Map<String, Object> body = Map.of("newOwnerUserId", "new-owner");
+        // Share conversation with new-owner (required before transfer)
+        Map<String, Object> shareRequest =
+                Map.of(
+                        "userId", "new-owner",
+                        "accessLevel", "MANAGER");
+
+        given().contentType(MediaType.APPLICATION_JSON)
+                .body(shareRequest)
+                .when()
+                .post("/v1/conversations/{id}/memberships", conversationId)
+                .then()
+                .statusCode(201);
+
+        // Now create ownership transfer
+        Map<String, Object> body =
+                Map.of("conversationId", conversationId, "newOwnerUserId", "new-owner");
 
         given().contentType(MediaType.APPLICATION_JSON)
                 .body(body)
                 .when()
-                .post("/v1/conversations/{id}/transfer-ownership", conversationId)
+                .post("/v1/ownership-transfers")
                 .then()
-                .statusCode(202);
+                .statusCode(201);
 
         verifyOwnershipTransferPersisted(conversationId, "owner-transfer", "new-owner");
     }

--- a/memory-service/src/test/java/io/github/chirino/memory/MongoMemoryServiceTest.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/MongoMemoryServiceTest.java
@@ -34,12 +34,7 @@ class MongoMemoryServiceTest extends AbstractMemoryServiceTest {
                                 t ->
                                         t.conversationGroupId.equals(conversationId)
                                                 && t.fromUserId.equals(fromUserId)
-                                                && t.toUserId.equals(toUserId)
-                                                && t.status
-                                                        == io.github.chirino.memory.persistence
-                                                                .entity
-                                                                .ConversationOwnershipTransferEntity
-                                                                .TransferStatus.PENDING);
+                                                && t.toUserId.equals(toUserId));
         assertThat(found, is(true));
     }
 

--- a/memory-service/src/test/java/io/github/chirino/memory/PostgresqlMemoryServiceTest.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/PostgresqlMemoryServiceTest.java
@@ -37,10 +37,7 @@ class PostgresqlMemoryServiceTest extends AbstractMemoryServiceTest {
                                                         .toString()
                                                         .equals(conversationId)
                                                 && t.getFromUserId().equals(fromUserId)
-                                                && t.getToUserId().equals(toUserId)
-                                                && t.getStatus()
-                                                        == ConversationOwnershipTransferEntity
-                                                                .TransferStatus.PENDING);
+                                                && t.getToUserId().equals(toUserId));
         assertThat(found, is(true));
     }
 

--- a/memory-service/src/test/resources/features/ownership-transfers-grpc.feature
+++ b/memory-service/src/test/resources/features/ownership-transfers-grpc.feature
@@ -1,0 +1,270 @@
+Feature: Ownership Transfers gRPC API
+  As a conversation owner
+  I want to transfer ownership to other users via gRPC API
+  So that I can delegate conversation management
+
+  Background:
+    Given I am authenticated as user "alice"
+    And I have a conversation with title "Transfer Test Conversation"
+    And I share the conversation with user "bob" with request:
+    """
+    {
+      "userId": "bob",
+      "accessLevel": "manager"
+    }
+    """
+
+  # ===== Create Transfer =====
+
+  Scenario: Owner can create ownership transfer via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    And the gRPC response field "fromUserId" should be "alice"
+    And the gRPC response field "toUserId" should be "bob"
+    And the gRPC response field "conversationId" should be "${conversationId}"
+
+  Scenario: Cannot create transfer if not owner via gRPC
+    Given I am authenticated as user "bob"
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "charlie"
+    """
+    Then the gRPC response should have status "PERMISSION_DENIED"
+
+  Scenario: Cannot create second transfer while one is pending via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should have status "ALREADY_EXISTS"
+
+  Scenario: Cannot transfer to non-member via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "stranger"
+    """
+    Then the gRPC response should have status "INVALID_ARGUMENT"
+
+  Scenario: Cannot transfer to self via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "alice"
+    """
+    Then the gRPC response should have status "INVALID_ARGUMENT"
+
+  # ===== List Transfers =====
+
+  Scenario: List transfers as sender via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    When I send gRPC request "OwnershipTransfersService/ListOwnershipTransfers" with body:
+    """
+    role: SENDER
+    """
+    Then the gRPC response should not have an error
+    And the gRPC response field "transfers" should not be null
+
+  Scenario: List transfers as recipient via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    And set "transferId" to the gRPC response field "id"
+    Given I am authenticated as user "bob"
+    When I send gRPC request "OwnershipTransfersService/ListOwnershipTransfers" with body:
+    """
+    role: RECIPIENT
+    """
+    Then the gRPC response should not have an error
+    And the gRPC response field "transfers" should not be null
+
+  Scenario: List all transfers via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    When I send gRPC request "OwnershipTransfersService/ListOwnershipTransfers" with body:
+    """
+    """
+    Then the gRPC response should not have an error
+    And the gRPC response field "transfers" should not be null
+
+  # ===== Get Transfer =====
+
+  Scenario: Sender can get transfer details via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    And set "transferId" to the gRPC response field "id"
+    When I send gRPC request "OwnershipTransfersService/GetOwnershipTransfer" with body:
+    """
+    transfer_id: "${transferId}"
+    """
+    Then the gRPC response should not have an error
+    And the gRPC response field "id" should be "${transferId}"
+
+  Scenario: Recipient can get transfer details via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    And set "transferId" to the gRPC response field "id"
+    Given I am authenticated as user "bob"
+    When I send gRPC request "OwnershipTransfersService/GetOwnershipTransfer" with body:
+    """
+    transfer_id: "${transferId}"
+    """
+    Then the gRPC response should not have an error
+    And the gRPC response field "id" should be "${transferId}"
+
+  Scenario: Non-participant cannot see transfer via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    And set "transferId" to the gRPC response field "id"
+    Given I am authenticated as user "charlie"
+    When I send gRPC request "OwnershipTransfersService/GetOwnershipTransfer" with body:
+    """
+    transfer_id: "${transferId}"
+    """
+    Then the gRPC response should have status "NOT_FOUND"
+
+  # ===== Accept Transfer =====
+
+  Scenario: Recipient can accept transfer via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    And set "transferId" to the gRPC response field "id"
+    Given I am authenticated as user "bob"
+    When I send gRPC request "OwnershipTransfersService/AcceptOwnershipTransfer" with body:
+    """
+    transfer_id: "${transferId}"
+    """
+    Then the gRPC response should not have an error
+    # Verify ownership changed
+    When I send gRPC request "ConversationMembershipsService/ListMemberships" with body:
+    """
+    conversation_id: "${conversationId}"
+    """
+    Then the gRPC response should not have an error
+
+  Scenario: Sender cannot accept own transfer via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    And set "transferId" to the gRPC response field "id"
+    When I send gRPC request "OwnershipTransfersService/AcceptOwnershipTransfer" with body:
+    """
+    transfer_id: "${transferId}"
+    """
+    Then the gRPC response should have status "PERMISSION_DENIED"
+
+  Scenario: Cannot accept already-accepted transfer via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    And set "transferId" to the gRPC response field "id"
+    Given I am authenticated as user "bob"
+    When I send gRPC request "OwnershipTransfersService/AcceptOwnershipTransfer" with body:
+    """
+    transfer_id: "${transferId}"
+    """
+    Then the gRPC response should not have an error
+    # Transfer is deleted after acceptance, so second accept returns NOT_FOUND
+    When I send gRPC request "OwnershipTransfersService/AcceptOwnershipTransfer" with body:
+    """
+    transfer_id: "${transferId}"
+    """
+    Then the gRPC response should have status "NOT_FOUND"
+
+  # ===== Delete Transfer =====
+
+  Scenario: Sender can cancel (delete) transfer via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    And set "transferId" to the gRPC response field "id"
+    When I send gRPC request "OwnershipTransfersService/DeleteOwnershipTransfer" with body:
+    """
+    transfer_id: "${transferId}"
+    """
+    Then the gRPC response should not have an error
+    # Verify hard deleted
+    When I send gRPC request "OwnershipTransfersService/GetOwnershipTransfer" with body:
+    """
+    transfer_id: "${transferId}"
+    """
+    Then the gRPC response should have status "NOT_FOUND"
+
+  Scenario: Recipient can decline (delete) transfer via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    And set "transferId" to the gRPC response field "id"
+    Given I am authenticated as user "bob"
+    When I send gRPC request "OwnershipTransfersService/DeleteOwnershipTransfer" with body:
+    """
+    transfer_id: "${transferId}"
+    """
+    Then the gRPC response should not have an error
+
+  Scenario: Non-participant cannot delete transfer via gRPC
+    When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
+    """
+    conversation_id: "${conversationId}"
+    new_owner_user_id: "bob"
+    """
+    Then the gRPC response should not have an error
+    And set "transferId" to the gRPC response field "id"
+    Given I am authenticated as user "charlie"
+    When I send gRPC request "OwnershipTransfersService/DeleteOwnershipTransfer" with body:
+    """
+    transfer_id: "${transferId}"
+    """
+    Then the gRPC response should have status "PERMISSION_DENIED"

--- a/memory-service/src/test/resources/features/ownership-transfers-rest.feature
+++ b/memory-service/src/test/resources/features/ownership-transfers-rest.feature
@@ -1,0 +1,294 @@
+Feature: Ownership Transfers REST API
+  As a conversation owner
+  I want to transfer ownership to other users via REST API
+  So that I can delegate conversation management
+
+  Background:
+    Given I am authenticated as user "alice"
+    And I have a conversation with title "Transfer Test Conversation"
+    And I share the conversation with user "bob" with request:
+    """
+    {
+      "userId": "bob",
+      "accessLevel": "manager"
+    }
+    """
+
+  # ===== Create Transfer =====
+
+  Scenario: Owner can create ownership transfer
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And the response body "fromUserId" should be "alice"
+    And the response body "toUserId" should be "bob"
+    And the response body "conversationId" should be "${conversationId}"
+
+  Scenario: Cannot create transfer if not owner
+    Given I am authenticated as user "bob"
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "charlie"
+    }
+    """
+    Then the response status should be 403
+    And the response should contain error code "forbidden"
+
+  Scenario: Cannot create second transfer while one is pending
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "existingTransferId" to "${response.body.id}"
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 409
+    And the response body should contain "existingTransferId"
+    And the response body "code" should be "TRANSFER_ALREADY_PENDING"
+
+  Scenario: Cannot transfer to non-member
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "stranger"
+    }
+    """
+    Then the response status should be 400
+    And the response should contain error code "bad_request"
+
+  Scenario: Cannot transfer to self
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "alice"
+    }
+    """
+    Then the response status should be 400
+    And the response should contain error code "bad_request"
+
+  # ===== List Transfers =====
+
+  Scenario: List transfers as sender
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    When I call GET "/v1/ownership-transfers?role=sender"
+    Then the response status should be 200
+    And the response body "data" should have at least 1 item
+
+  Scenario: List transfers as recipient
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "transferId" to "${response.body.id}"
+    Given I am authenticated as user "bob"
+    When I call GET "/v1/ownership-transfers?role=recipient"
+    Then the response status should be 200
+    And the response body "data" should have at least 1 item
+
+  Scenario: List all transfers
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    When I call GET "/v1/ownership-transfers"
+    Then the response status should be 200
+    And the response body "data" should have at least 1 item
+
+  # ===== Get Transfer =====
+
+  Scenario: Sender can get transfer details
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "transferId" to "${response.body.id}"
+    When I call GET "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 200
+    And the response body "id" should be "${transferId}"
+
+  Scenario: Recipient can get transfer details
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "transferId" to "${response.body.id}"
+    Given I am authenticated as user "bob"
+    When I call GET "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 200
+    And the response body "id" should be "${transferId}"
+
+  Scenario: Non-participant cannot see transfer
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "transferId" to "${response.body.id}"
+    Given I am authenticated as user "charlie"
+    When I call GET "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 404
+
+  # ===== Accept Transfer =====
+
+  Scenario: Recipient can accept transfer
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "transferId" to "${response.body.id}"
+    Given I am authenticated as user "bob"
+    When I call POST "/v1/ownership-transfers/${transferId}/accept"
+    Then the response status should be 204
+    # Verify ownership changed
+    When I list memberships for the conversation
+    Then the response status should be 200
+    And the response should contain a membership for user "bob" with access level "owner"
+    And the response should contain a membership for user "alice" with access level "manager"
+
+  Scenario: Sender cannot accept own transfer
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "transferId" to "${response.body.id}"
+    When I call POST "/v1/ownership-transfers/${transferId}/accept"
+    Then the response status should be 403
+    And the response should contain error code "forbidden"
+
+  Scenario: Cannot accept already-accepted transfer
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "transferId" to "${response.body.id}"
+    Given I am authenticated as user "bob"
+    When I call POST "/v1/ownership-transfers/${transferId}/accept"
+    Then the response status should be 204
+    # Transfer is deleted after acceptance, so second accept returns 404
+    When I call POST "/v1/ownership-transfers/${transferId}/accept"
+    Then the response status should be 404
+
+  # ===== Delete Transfer =====
+
+  Scenario: Sender can cancel (delete) transfer
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "transferId" to "${response.body.id}"
+    When I call DELETE "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 204
+    # Verify hard deleted
+    When I call GET "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 404
+
+  Scenario: Recipient can decline (delete) transfer
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "transferId" to "${response.body.id}"
+    Given I am authenticated as user "bob"
+    When I call DELETE "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 204
+
+  Scenario: Non-participant cannot delete transfer
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "transferId" to "${response.body.id}"
+    Given I am authenticated as user "charlie"
+    When I call DELETE "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 403
+    And the response should contain error code "forbidden"
+
+  # ===== Member Removal Cancels Transfer =====
+
+  Scenario: Removing transfer recipient deletes pending transfer
+    When I call POST "/v1/ownership-transfers" with body:
+    """
+    {
+      "conversationId": "${conversationId}",
+      "newOwnerUserId": "bob"
+    }
+    """
+    Then the response status should be 201
+    And set "transferId" to "${response.body.id}"
+    # Verify transfer exists
+    When I call GET "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 200
+    # Remove bob from the conversation
+    When I delete membership for user "bob"
+    Then the response status should be 204
+    # Verify transfer was automatically deleted
+    When I call GET "/v1/ownership-transfers/${transferId}"
+    Then the response status should be 404

--- a/memory-service/src/test/resources/features/sharing-grpc.feature
+++ b/memory-service/src/test/resources/features/sharing-grpc.feature
@@ -159,32 +159,6 @@ Feature: Conversation Sharing gRPC API
     """
     Then the gRPC response should have status "PERMISSION_DENIED"
 
-  Scenario: Transfer conversation ownership via gRPC
-    Given I have a conversation with title "Ownership Transfer Test"
-    When I send gRPC request "ConversationsService/TransferOwnership" with body:
-    """
-    conversation_id: "${conversationId}"
-    new_owner_user_id: "bob"
-    """
-    Then the gRPC response should not have an error
-
-  Scenario: Transfer ownership of non-existent conversation via gRPC
-    When I send gRPC request "ConversationsService/TransferOwnership" with body:
-    """
-    conversation_id: "00000000-0000-0000-0000-000000000000"
-    new_owner_user_id: "bob"
-    """
-    Then the gRPC response should have status "NOT_FOUND"
-
-  Scenario: Transfer ownership without access via gRPC
-    Given there is a conversation owned by "bob"
-    When I send gRPC request "ConversationsService/TransferOwnership" with body:
-    """
-    conversation_id: "${conversationId}"
-    new_owner_user_id: "charlie"
-    """
-    Then the gRPC response should have status "PERMISSION_DENIED"
-
   Scenario: Membership response contains conversation_id instead of conversation_group_id via gRPC
     When I send gRPC request "ConversationMembershipsService/ShareConversation" with body:
     """

--- a/memory-service/src/test/resources/features/sharing-rest.feature
+++ b/memory-service/src/test/resources/features/sharing-rest.feature
@@ -188,37 +188,6 @@ Feature: Conversation Sharing REST API
     Then the response status should be 403
     And the response should contain error code "forbidden"
 
-  Scenario: Transfer conversation ownership
-    Given I have a conversation with title "Ownership Transfer Test"
-    When I transfer ownership of the conversation to "bob" with request:
-    """
-    {
-      "newOwnerUserId": "bob"
-    }
-    """
-    Then the response status should be 202
-
-  Scenario: Transfer ownership of non-existent conversation
-    When I transfer ownership of conversation "00000000-0000-0000-0000-000000000000" to "bob" with request:
-    """
-    {
-      "newOwnerUserId": "bob"
-    }
-    """
-    Then the response status should be 404
-    And the response should contain error code "not_found"
-
-  Scenario: Transfer ownership without access
-    Given there is a conversation owned by "bob"
-    When I transfer ownership of that conversation to "charlie" with request:
-    """
-    {
-      "newOwnerUserId": "charlie"
-    }
-    """
-    Then the response status should be 403
-    And the response should contain error code "forbidden"
-
   Scenario: Membership response contains conversationId instead of conversationGroupId
     When I share the conversation with user "bob" with request:
     """

--- a/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/runtime/MemoryServiceProxy.java
+++ b/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/runtime/MemoryServiceProxy.java
@@ -15,7 +15,6 @@ import io.github.chirino.memory.client.model.CreateEntryRequest;
 import io.github.chirino.memory.client.model.ForkFromEntryRequest;
 import io.github.chirino.memory.client.model.IndexTranscriptRequest;
 import io.github.chirino.memory.client.model.ShareConversationRequest;
-import io.github.chirino.memory.client.model.TransferConversationOwnershipRequest;
 import io.github.chirino.memory.client.model.UpdateConversationMembershipRequest;
 import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.inject.Inject;
@@ -186,23 +185,6 @@ public class MemoryServiceProxy {
                     userId);
         } catch (Exception e) {
             LOG.errorf(e, "Error parsing update membership request body");
-            return handleException(e);
-        }
-    }
-
-    public Response transferConversationOwnership(String conversationId, String body) {
-        try {
-            TransferConversationOwnershipRequest request =
-                    OBJECT_MAPPER.readValue(body, TransferConversationOwnershipRequest.class);
-            return executeVoid(
-                    () ->
-                            sharingApi()
-                                    .transferConversationOwnership(toUuid(conversationId), request),
-                    Response.Status.ACCEPTED,
-                    "Error transferring ownership of history %s",
-                    conversationId);
-        } catch (Exception e) {
-            LOG.errorf(e, "Error parsing transfer ownership request body");
             return handleException(e);
         }
     }

--- a/spring/memory-service-rest-spring/src/main/java/io/github/chirino/memoryservice/client/MemoryServiceProxy.java
+++ b/spring/memory-service-rest-spring/src/main/java/io/github/chirino/memoryservice/client/MemoryServiceProxy.java
@@ -7,7 +7,6 @@ import io.github.chirino.memoryservice.client.invoker.ApiClient;
 import io.github.chirino.memoryservice.client.model.Channel;
 import io.github.chirino.memoryservice.client.model.ForkFromEntryRequest;
 import io.github.chirino.memoryservice.client.model.ShareConversationRequest;
-import io.github.chirino.memoryservice.client.model.TransferConversationOwnershipRequest;
 import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
@@ -130,22 +129,6 @@ public class MemoryServiceProxy {
         return execute(
                 api -> api.deleteConversationResponseWithHttpInfo(toUuid(conversationId)),
                 HttpStatus.OK);
-    }
-
-    public ResponseEntity<?> transferConversationOwnership(String conversationId, String body) {
-        try {
-            TransferConversationOwnershipRequest request =
-                    OBJECT_MAPPER.readValue(body, TransferConversationOwnershipRequest.class);
-            return executeSharingApi(
-                    api ->
-                            api.transferConversationOwnershipWithHttpInfo(
-                                    toUuid(conversationId), request),
-                    HttpStatus.ACCEPTED);
-        } catch (Exception e) {
-            LOG.error("Error parsing transfer ownership request", e);
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(Map.of("error", "Invalid request body"));
-        }
     }
 
     private ConversationsApi conversationsApi(@Nullable String explicitBearerToken) {


### PR DESCRIPTION
                                                                                                                                                                              
Add REST endpoints for conversation ownership transfers:                                                                                                                      
- POST /v1/ownership-transfers - Create pending transfer request                                                                                                              
- GET /v1/ownership-transfers - List pending transfers (filter by sender/recipient)                                                                                           
- GET /v1/ownership-transfers/{id} - Get transfer details                                                                                                                     
- POST /v1/ownership-transfers/{id}/accept - Accept and complete transfer                                                                                                     
- DELETE /v1/ownership-transfers/{id} - Cancel/reject transfer                                                                                                                
                                                                                                                                                                              
Key features:                                                                                                                                                                 
- Only one pending transfer allowed per conversation at a time                                                                                                                
- Recipient must be an existing conversation member                                                                                                                           
- Both sender and recipient can cancel pending transfers                                                                                                                      
- Transfer completion atomically updates ownership and membership                                                                                                             
                                                                                                                                                                              
Includes Postgres and MongoDB implementations with Cucumber BDD tests.                                                                                                         Removes deprecated gRPC transfer methods and old sharing tests.