### PR TITLE
feat: add sharing UI and allow any member to list memberships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ nb-configuration.xml
 /*.log
 vendor
 .claude
+.playwright-mcp

--- a/common/agent-webui/src/App.tsx
+++ b/common/agent-webui/src/App.tsx
@@ -5,7 +5,9 @@ import type { ConversationSummary } from "@/client";
 import { ApiError, ConversationsService, OpenAPI } from "@/client";
 import { ChatPanel } from "@/components/chat-panel";
 import { ChatSidebar } from "@/components/chat-sidebar";
+import { PendingTransfersPanel } from "@/components/sharing";
 import { useResumeCheck } from "@/hooks/useResumeCheck";
+import { useCurrentUser } from "@/hooks/useCurrentUser";
 
 type ListUserConversationsResponse = {
   data?: ConversationSummary[];
@@ -116,6 +118,10 @@ function App() {
   const conversationIds = conversations.map((conv) => conv.id).filter((id): id is string => !!id);
   const resumeCheckQuery = useResumeCheck(conversationIds);
   const resumableConversationIds = new Set(resumeCheckQuery.data ?? []);
+
+  // Get current user ID from the backend
+  const currentUserQuery = useCurrentUser();
+  const currentUserId = currentUserQuery.data ?? null;
 
   useEffect(() => {
     const interceptor = (response: Response) => {
@@ -350,14 +356,20 @@ function App() {
   return (
     <div className="flex h-screen">
       {sidebarContent}
-      <ChatPanel
-        conversationId={selectedConversationId}
-        onSelectConversationId={handleSelectConversationId}
-        knownConversationIds={resolvedConversationIds}
-        resumableConversationIds={resumableConversationIds}
-        onIndexConversation={handleIndexConversationById}
-        onDeleteConversation={handleDeleteConversationById}
-      />
+      <div className="flex flex-1 flex-col">
+        <PendingTransfersPanel
+          onNavigateToConversation={handleSelectConversationId}
+        />
+        <ChatPanel
+          conversationId={selectedConversationId}
+          onSelectConversationId={handleSelectConversationId}
+          knownConversationIds={resolvedConversationIds}
+          resumableConversationIds={resumableConversationIds}
+          onIndexConversation={handleIndexConversationById}
+          onDeleteConversation={handleDeleteConversationById}
+          currentUserId={currentUserId}
+        />
+      </div>
     </div>
   );
 }

--- a/common/agent-webui/src/client/schemas.gen.ts
+++ b/common/agent-webui/src/client/schemas.gen.ts
@@ -27,6 +27,8 @@ export const $ConversationSummary = {
   properties: {
     id: {
       type: "string",
+      format: "uuid",
+      description: "Unique identifier for the conversation.",
     },
     title: {
       type: "string",
@@ -52,12 +54,12 @@ export const $ConversationSummary = {
     },
   },
   example: {
-    id: "conv_01HF8XH1XABCD1234EFGH5678",
+    id: "550e8400-e29b-41d4-a716-446655440000",
     title: "Brainstorming UI for memory service",
     ownerUserId: "user_1234",
     createdAt: "2025-01-10T14:32:05Z",
     updatedAt: "2025-01-10T14:45:12Z",
-    lastMessagePreview: "Let’s try modeling forks as separate conversations…",
+    lastMessagePreview: "Let's try modeling forks as separate conversations…",
     accessLevel: "owner",
   },
 } as const;
@@ -72,15 +74,19 @@ export const $Conversation = {
       properties: {
         forkedAtEntryId: {
           type: "string",
+          format: "uuid",
           nullable: true,
+          description: "Entry ID where this conversation forked from its parent.",
         },
         forkedAtConversationId: {
           type: "string",
+          format: "uuid",
           nullable: true,
+          description: "Conversation ID from which this conversation was forked.",
         },
       },
       example: {
-        id: "conv_01HF8XH1XABCD1234EFGH5678",
+        id: "550e8400-e29b-41d4-a716-446655440000",
         title: "Brainstorming UI for memory service",
         ownerUserId: "user_1234",
         createdAt: "2025-01-10T14:32:05Z",
@@ -120,6 +126,8 @@ export const $ConversationMembership = {
   properties: {
     conversationId: {
       type: "string",
+      format: "uuid",
+      description: "Unique identifier for the conversation.",
     },
     userId: {
       type: "string",
@@ -140,15 +148,19 @@ export const $ConversationForkSummary = {
   properties: {
     conversationId: {
       type: "string",
+      format: "uuid",
+      description: "Unique identifier for the forked conversation.",
     },
     forkedAtEntryId: {
       type: "string",
-      description: "Entry id at which this forked conversation diverged.",
+      format: "uuid",
+      description: "Entry ID at which this forked conversation diverged.",
     },
     forkedAtConversationId: {
       type: "string",
+      format: "uuid",
       nullable: true,
-      description: "Conversation id where the fork occurred.",
+      description: "Conversation ID where the fork occurred.",
     },
     title: {
       type: "string",
@@ -201,9 +213,13 @@ export const $Entry = {
   properties: {
     id: {
       type: "string",
+      format: "uuid",
+      description: "Unique identifier for the entry.",
     },
     conversationId: {
       type: "string",
+      format: "uuid",
+      description: "Unique identifier for the conversation this entry belongs to.",
     },
     userId: {
       type: "string",
@@ -241,8 +257,8 @@ stores and returns them without interpretation.`,
     },
   },
   example: {
-    id: "entry_01HF8XJQWXYZ9876ABCD5432",
-    conversationId: "conv_01HF8XH1XABCD1234EFGH5678",
+    id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+    conversationId: "550e8400-e29b-41d4-a716-446655440000",
     userId: "user_1234",
     channel: "history",
     epoch: null,
@@ -374,8 +390,8 @@ export const $SyncEntriesResponse = {
     epochIncremented: true,
     entries: [
       {
-        id: "entry_01HF8XJQWXYZ9876ABCD5432",
-        conversationId: "conv_01HF8XH1XABCD1234EFGH5678",
+        id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+        conversationId: "550e8400-e29b-41d4-a716-446655440000",
         userId: "agent_memory",
         channel: "memory",
         epoch: 5,
@@ -398,6 +414,7 @@ export const $IndexTranscriptRequest = {
   properties: {
     conversationId: {
       type: "string",
+      format: "uuid",
       description: "The conversation to index.",
     },
     title: {
@@ -411,15 +428,16 @@ export const $IndexTranscriptRequest = {
     },
     untilEntryId: {
       type: "string",
-      description: "Highest entry id covered by the index (inclusive).",
+      format: "uuid",
+      description: "Highest entry ID covered by the index (inclusive).",
     },
   },
   example: {
-    conversationId: "conv_01HF8XH1XABCD1234EFGH5678",
+    conversationId: "550e8400-e29b-41d4-a716-446655440000",
     title: "Conversation forking design",
     transcript:
       "User asked several questions about conversation forking. They want to support branching at any message with independent access control per branch.",
-    untilEntryId: "entry_01HF8XJQWXYZ9876ABCD5431",
+    untilEntryId: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
   },
 } as const;
 
@@ -439,20 +457,23 @@ export const $SearchConversationsRequest = {
       type: "array",
       items: {
         type: "string",
+        format: "uuid",
       },
       nullable: true,
+      description: "Filter search to specific conversations (UUID format).",
     },
     before: {
       type: "string",
+      format: "uuid",
       nullable: true,
-      description: "Optional upper bound entry id for temporal filtering.",
+      description: "Optional upper bound entry ID for temporal filtering.",
     },
   },
   example: {
     query: "summary of memory service design decisions",
     topK: 5,
-    conversationIds: ["conv_01HF8XH1XABCD1234EFGH5678", "conv_01HF8XH1XABCD1234EFGH5679"],
-    before: "entry_01HF8XJQWXYZ9876ABCD5431",
+    conversationIds: ["550e8400-e29b-41d4-a716-446655440000", "550e8400-e29b-41d4-a716-446655440001"],
+    before: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
   },
 } as const;
 
@@ -473,8 +494,8 @@ export const $SearchResult = {
   },
   example: {
     entry: {
-      id: "entry_01HF8XJQWXYZ9876ABCD5430",
-      conversationId: "conv_01HF8XH1XABCD1234EFGH5678",
+      id: "6ba7b810-9dad-11d1-80b4-00c04fd430c9",
+      conversationId: "550e8400-e29b-41d4-a716-446655440000",
       userId: "user_1234",
       channel: "history",
       contentType: "message",
@@ -488,5 +509,71 @@ export const $SearchResult = {
     },
     score: 0.93,
     highlights: "design a memory service for my agent",
+  },
+} as const;
+
+export const $OwnershipTransfer = {
+  type: "object",
+  description: `Represents a pending ownership transfer request.
+Transfers are always "pending" while they exist; accepted/rejected transfers
+are hard deleted from the database.`,
+  required: ["id", "conversationId", "fromUserId", "toUserId", "createdAt"],
+  properties: {
+    id: {
+      type: "string",
+      format: "uuid",
+      description: "Unique identifier for the transfer.",
+    },
+    conversationId: {
+      type: "string",
+      format: "uuid",
+      description: "The conversation being transferred.",
+    },
+    conversationTitle: {
+      type: "string",
+      nullable: true,
+      description: "Title of the conversation (for display purposes).",
+    },
+    fromUserId: {
+      type: "string",
+      description: "Current owner initiating the transfer.",
+    },
+    toUserId: {
+      type: "string",
+      description: "Proposed new owner (recipient).",
+    },
+    createdAt: {
+      type: "string",
+      format: "date-time",
+      description: "When the transfer was initiated.",
+    },
+  },
+  example: {
+    id: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+    conversationId: "550e8400-e29b-41d4-a716-446655440000",
+    conversationTitle: "Help with React hooks",
+    fromUserId: "user_john_doe",
+    toUserId: "user_jane_smith",
+    createdAt: "2025-01-28T10:30:00Z",
+  },
+} as const;
+
+export const $CreateOwnershipTransferRequest = {
+  type: "object",
+  required: ["conversationId", "newOwnerUserId"],
+  properties: {
+    conversationId: {
+      type: "string",
+      format: "uuid",
+      description: "The conversation to transfer ownership of.",
+    },
+    newOwnerUserId: {
+      type: "string",
+      description: "User ID of the proposed new owner. Must be an existing member.",
+    },
+  },
+  example: {
+    conversationId: "550e8400-e29b-41d4-a716-446655440000",
+    newOwnerUserId: "user_jane_smith",
   },
 } as const;

--- a/common/agent-webui/src/components/chat-sidebar.tsx
+++ b/common/agent-webui/src/components/chat-sidebar.tsx
@@ -91,20 +91,16 @@ export function ChatSidebar({
             placeholder="Search conversations..."
             value={search}
             onChange={(event) => onSearchChange(event.target.value)}
-            className="w-full rounded-xl border border-transparent bg-mist py-2.5 pl-10 pr-4 text-sm placeholder:text-stone/60 transition-colors focus:border-stone/20 focus:outline-none"
+            className="w-full rounded-xl border border-transparent bg-mist py-2.5 pl-10 pr-4 text-sm transition-colors placeholder:text-stone/60 focus:border-stone/20 focus:outline-none"
           />
         </div>
       </div>
 
-      {statusMessage && (
-        <div className="px-5 py-2 text-xs text-terracotta">{statusMessage}</div>
-      )}
+      {statusMessage && <div className="px-5 py-2 text-xs text-terracotta">{statusMessage}</div>}
 
       {/* Conversation List */}
       <nav className="flex-1 overflow-y-auto px-3 pb-4">
-        {filteredConversations.length === 0 && (
-          <p className="px-4 text-sm text-stone">No conversations yet.</p>
-        )}
+        {filteredConversations.length === 0 && <p className="px-4 text-sm text-stone">No conversations yet.</p>}
 
         <div className="space-y-1">
           {filteredConversations.map((conversation, index) => {
@@ -113,29 +109,19 @@ export function ChatSidebar({
             const animationDelay = `${index * 0.05}s`;
 
             return (
-              <div
-                key={conversation.id}
-                className="animate-fade-in"
-                style={{ animationDelay }}
-              >
+              <div key={conversation.id} className="animate-fade-in" style={{ animationDelay }}>
                 <button
                   type="button"
                   onClick={() => onSelectConversation(conversation)}
                   className={`w-full rounded-xl px-4 py-3.5 text-left transition-all ${
-                    isSelected
-                      ? "border border-stone/10 bg-mist"
-                      : "border border-transparent hover:bg-mist/60"
+                    isSelected ? "border border-stone/10 bg-mist" : "border border-transparent hover:bg-mist/60"
                   }`}
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">
-                      <h3 className="truncate font-medium text-ink">
-                        {conversation.title || "Untitled conversation"}
-                      </h3>
+                      <h3 className="truncate font-medium text-ink">{conversation.title || "Untitled conversation"}</h3>
                       {conversation.lastMessagePreview && (
-                        <p className="mt-1 line-clamp-2 text-sm text-stone">
-                          {conversation.lastMessagePreview}
-                        </p>
+                        <p className="mt-1 line-clamp-2 text-sm text-stone">{conversation.lastMessagePreview}</p>
                       )}
                     </div>
                     {isResumable ? (

--- a/common/agent-webui/src/components/conversations-ui.tsx
+++ b/common/agent-webui/src/components/conversations-ui.tsx
@@ -86,9 +86,7 @@ function ConversationsUIMessageRow({
         <div className={`relative flex flex-col gap-1 ${isUser ? "max-w-[75%] items-end" : "max-w-[85%] items-start"}`}>
           <div
             className={`group relative px-5 py-3.5 text-[15px] leading-relaxed ${
-              isUser
-                ? "rounded-2xl rounded-tr-md bg-ink text-cream"
-                : "rounded-2xl rounded-tl-md bg-mist text-ink"
+              isUser ? "rounded-2xl rounded-tr-md bg-ink text-cream" : "rounded-2xl rounded-tl-md bg-mist text-ink"
             }`}
           >
             {children ?? (
@@ -176,7 +174,9 @@ function ConversationsUIEmptyState({
                 className="group w-full rounded-xl border border-transparent bg-mist px-5 py-4 text-left transition-all hover:border-stone/20"
               >
                 <div className="flex items-center gap-3">
-                  <div className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${suggestion.iconBg}`}>
+                  <div
+                    className={`flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg ${suggestion.iconBg}`}
+                  >
                     <Icon className={`h-4 w-4 ${suggestion.iconColor}`} />
                   </div>
                   <div className="min-w-0 flex-1">
@@ -240,7 +240,7 @@ function ConversationsUIComposer({
             placeholder={placeholder}
             rows={3}
             disabled={disabled}
-            className={`w-full resize-none rounded-2xl border border-transparent bg-mist px-5 py-4 pr-24 text-[15px] placeholder:text-stone/60 transition-colors focus:border-stone/20 focus:outline-none disabled:opacity-50 ${inputClassName ?? ""}`}
+            className={`w-full resize-none rounded-2xl border border-transparent bg-mist px-5 py-4 pr-24 text-[15px] transition-colors placeholder:text-stone/60 focus:border-stone/20 focus:outline-none disabled:opacity-50 ${inputClassName ?? ""}`}
           />
           <div className="absolute bottom-3 right-3 flex items-center gap-2">
             {isBusy && (

--- a/common/agent-webui/src/components/sharing/access-level-select.tsx
+++ b/common/agent-webui/src/components/sharing/access-level-select.tsx
@@ -1,0 +1,208 @@
+import { useState, useRef, useEffect } from "react";
+import { ChevronDown, Crown, Wrench, Pencil, Eye } from "lucide-react";
+import type { AccessLevel } from "@/client";
+
+type AccessLevelSelectProps = {
+  value: AccessLevel;
+  onChange: (level: AccessLevel) => void;
+  allowedLevels: AccessLevel[];
+  disabled?: boolean;
+  /** Direction to open the dropdown. Defaults to "up" */
+  openDirection?: "up" | "down";
+};
+
+const ACCESS_LEVEL_CONFIG: Record<
+  AccessLevel,
+  { label: string; description: string; icon: typeof Crown }
+> = {
+  owner: {
+    label: "Owner",
+    description: "Full control",
+    icon: Crown,
+  },
+  manager: {
+    label: "Manager",
+    description: "Can share with others",
+    icon: Wrench,
+  },
+  writer: {
+    label: "Writer",
+    description: "Can send messages",
+    icon: Pencil,
+  },
+  reader: {
+    label: "Reader",
+    description: "View only",
+    icon: Eye,
+  },
+};
+
+export function AccessLevelSelect({
+  value,
+  onChange,
+  allowedLevels,
+  disabled = false,
+  openDirection = "up",
+}: AccessLevelSelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }
+  }, [isOpen]);
+
+  // Close on escape key
+  useEffect(() => {
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+      return () => {
+        document.removeEventListener("keydown", handleEscape);
+      };
+    }
+  }, [isOpen]);
+
+  const currentConfig = ACCESS_LEVEL_CONFIG[value];
+
+  // If no allowed levels or only the current level, show as static text
+  if (allowedLevels.length === 0 || disabled) {
+    return (
+      <span className="flex items-center gap-1.5 text-sm text-stone">
+        {currentConfig.label}
+      </span>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-1 rounded-lg border border-stone/20 bg-cream px-2.5 py-1.5 text-sm text-ink transition-colors hover:border-stone/40 hover:bg-mist"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+      >
+        <span>{currentConfig.label}</span>
+        <ChevronDown
+          className={`h-3.5 w-3.5 text-stone transition-transform ${isOpen ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {isOpen && (
+        <div
+          className={`absolute right-0 z-50 w-48 overflow-hidden rounded-xl border border-stone/20 bg-cream shadow-xl ${
+            openDirection === "up" ? "bottom-full mb-1" : "top-full mt-1"
+          }`}
+        >
+          <div className="py-1" role="listbox">
+            {allowedLevels.map((level) => {
+              const config = ACCESS_LEVEL_CONFIG[level];
+              const Icon = config.icon;
+              const isSelected = level === value;
+
+              return (
+                <button
+                  key={level}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => {
+                    onChange(level);
+                    setIsOpen(false);
+                  }}
+                  className={`flex w-full items-center gap-3 px-3 py-2.5 text-left transition-colors ${
+                    isSelected
+                      ? "bg-mist/50"
+                      : "hover:bg-mist/50"
+                  }`}
+                >
+                  <Icon
+                    className={`h-4 w-4 ${
+                      level === "owner"
+                        ? "text-terracotta"
+                        : level === "manager"
+                          ? "text-sage"
+                          : "text-stone"
+                    }`}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-ink">
+                      {config.label}
+                    </p>
+                    <p className="text-xs text-stone">{config.description}</p>
+                  </div>
+                  {isSelected && (
+                    <span className="text-sage">
+                      <svg
+                        className="h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M5 13l4 4L19 7"
+                        />
+                      </svg>
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Static display of an access level (for read-only views)
+ */
+export function AccessLevelBadge({
+  level,
+  showIcon = true,
+}: {
+  level: AccessLevel;
+  showIcon?: boolean;
+}) {
+  const config = ACCESS_LEVEL_CONFIG[level];
+  const Icon = config.icon;
+
+  return (
+    <span
+      className={`flex items-center gap-1.5 text-sm ${
+        level === "owner"
+          ? "text-terracotta"
+          : level === "manager"
+            ? "text-sage"
+            : "text-stone"
+      }`}
+    >
+      {showIcon && <Icon className="h-4 w-4" />}
+      <span>{config.label}</span>
+    </span>
+  );
+}

--- a/common/agent-webui/src/components/sharing/add-member-form.tsx
+++ b/common/agent-webui/src/components/sharing/add-member-form.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { UserPlus } from "lucide-react";
+import type { AccessLevel } from "@/client";
+import { AccessLevelSelect } from "./access-level-select";
+
+type AddMemberFormProps = {
+  onAdd: (userId: string, accessLevel: AccessLevel) => void;
+  allowedLevels: AccessLevel[];
+  isAdding?: boolean;
+  existingUserIds: string[];
+  currentUserId: string;
+};
+
+export function AddMemberForm({
+  onAdd,
+  allowedLevels,
+  isAdding = false,
+  existingUserIds,
+  currentUserId,
+}: AddMemberFormProps) {
+  const [userId, setUserId] = useState("");
+  const [accessLevel, setAccessLevel] = useState<AccessLevel>(
+    allowedLevels.includes("reader") ? "reader" : allowedLevels[0],
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    const trimmedUserId = userId.trim();
+
+    if (!trimmedUserId) {
+      setError("Please enter a user ID");
+      return;
+    }
+
+    if (trimmedUserId === currentUserId) {
+      setError("You cannot add yourself");
+      return;
+    }
+
+    if (existingUserIds.includes(trimmedUserId)) {
+      setError("This user already has access");
+      return;
+    }
+
+    onAdd(trimmedUserId, accessLevel);
+    setUserId("");
+    setError(null);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <div className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2">
+            <UserPlus className="h-4 w-4 text-stone" />
+          </div>
+          <input
+            type="text"
+            value={userId}
+            onChange={(e) => {
+              setUserId(e.target.value);
+              setError(null);
+            }}
+            placeholder="Enter user ID"
+            disabled={isAdding}
+            className="w-full rounded-lg border border-stone/20 bg-cream py-2.5 pl-10 pr-3 text-sm text-ink placeholder-stone transition-colors focus:border-sage focus:outline-none focus:ring-1 focus:ring-sage disabled:opacity-50"
+          />
+        </div>
+
+        <AccessLevelSelect
+          value={accessLevel}
+          onChange={setAccessLevel}
+          allowedLevels={allowedLevels}
+          disabled={isAdding}
+          openDirection="down"
+        />
+
+        <button
+          type="submit"
+          disabled={isAdding || !userId.trim()}
+          className="rounded-lg bg-ink px-4 py-2.5 text-sm font-medium text-cream transition-colors hover:bg-ink/90 disabled:opacity-50"
+        >
+          {isAdding ? "Adding..." : "Add"}
+        </button>
+      </div>
+
+      {error && <p className="text-xs text-terracotta">{error}</p>}
+    </form>
+  );
+}

--- a/common/agent-webui/src/components/sharing/incoming-transfer-banner.tsx
+++ b/common/agent-webui/src/components/sharing/incoming-transfer-banner.tsx
@@ -1,0 +1,59 @@
+import { Crown } from "lucide-react";
+import type { OwnershipTransfer } from "@/client";
+
+type IncomingTransferBannerProps = {
+  transfer: OwnershipTransfer;
+  onAccept: () => void;
+  onDecline: () => void;
+  isAccepting?: boolean;
+  isDeclining?: boolean;
+};
+
+export function IncomingTransferBanner({
+  transfer,
+  onAccept,
+  onDecline,
+  isAccepting = false,
+  isDeclining = false,
+}: IncomingTransferBannerProps) {
+  const isLoading = isAccepting || isDeclining;
+
+  return (
+    <div className="rounded-xl border border-terracotta/30 bg-terracotta/5 p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-terracotta/10">
+          <Crown className="h-5 w-5 text-terracotta" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-medium text-ink">
+            Ownership transfer request
+          </h3>
+          <p className="mt-1 text-sm text-stone">
+            <span className="font-medium text-ink">{transfer.fromUserId}</span>{" "}
+            wants to transfer ownership to you
+          </p>
+
+          <div className="mt-4 flex items-center gap-3">
+            <button
+              type="button"
+              onClick={onDecline}
+              disabled={isLoading}
+              className="rounded-lg border border-stone/20 px-3 py-2 text-sm font-medium text-stone transition-colors hover:bg-mist hover:text-ink disabled:opacity-50"
+            >
+              {isDeclining ? "Declining..." : "Decline"}
+            </button>
+            <button
+              type="button"
+              onClick={onAccept}
+              disabled={isLoading}
+              className="rounded-lg bg-terracotta px-3 py-2 text-sm font-medium text-cream transition-colors hover:bg-terracotta/90 disabled:opacity-50"
+            >
+              {isAccepting ? "Accepting..." : "Accept Ownership"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/common/agent-webui/src/components/sharing/index.ts
+++ b/common/agent-webui/src/components/sharing/index.ts
@@ -1,0 +1,8 @@
+export { ShareButton } from "./share-button";
+export { ShareModal } from "./share-modal";
+export { MemberListItem } from "./member-list-item";
+export { AddMemberForm } from "./add-member-form";
+export { AccessLevelSelect, AccessLevelBadge } from "./access-level-select";
+export { TransferConfirmModal } from "./transfer-confirm-modal";
+export { IncomingTransferBanner } from "./incoming-transfer-banner";
+export { PendingTransfersPanel } from "./pending-transfers-panel";

--- a/common/agent-webui/src/components/sharing/member-list-item.tsx
+++ b/common/agent-webui/src/components/sharing/member-list-item.tsx
@@ -1,0 +1,216 @@
+import { useState, useRef, useEffect } from "react";
+import { MoreVertical, Trash2, Crown, User, Clock } from "lucide-react";
+import type { AccessLevel, ConversationMembership, OwnershipTransfer } from "@/client";
+import { AccessLevelSelect, AccessLevelBadge } from "./access-level-select";
+import {
+  canModifyMember,
+  canTransferOwnership,
+  getAssignableAccessLevels,
+} from "@/hooks/useSharing";
+
+type MemberListItemProps = {
+  membership: ConversationMembership;
+  currentUserId: string;
+  currentUserAccessLevel: AccessLevel;
+  pendingTransfer: OwnershipTransfer | null;
+  onAccessLevelChange: (userId: string, level: AccessLevel) => void;
+  onRemove: (userId: string) => void;
+  onTransferOwnership: (userId: string) => void;
+  onCancelTransfer: () => void;
+  isUpdating?: boolean;
+};
+
+function formatDate(dateString?: string): string {
+  if (!dateString) return "";
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return "";
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+}
+
+export function MemberListItem({
+  membership,
+  currentUserId,
+  currentUserAccessLevel,
+  pendingTransfer,
+  onAccessLevelChange,
+  onRemove,
+  onTransferOwnership,
+  onCancelTransfer,
+  isUpdating = false,
+}: MemberListItemProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const isOwner = membership.accessLevel === "owner";
+  const isCurrentUser = membership.userId === currentUserId;
+  const canModify = canModifyMember(currentUserAccessLevel, membership.accessLevel);
+  const canTransfer = canTransferOwnership(currentUserAccessLevel);
+  const assignableLevels = getAssignableAccessLevels(currentUserAccessLevel);
+
+  // Check if this member is the recipient of a pending transfer
+  const isPendingTransferRecipient =
+    pendingTransfer && pendingTransfer.toUserId === membership.userId;
+
+  // Close menu when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    }
+
+    if (menuOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }
+  }, [menuOpen]);
+
+  // Close on escape key
+  useEffect(() => {
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setMenuOpen(false);
+      }
+    }
+
+    if (menuOpen) {
+      document.addEventListener("keydown", handleEscape);
+      return () => {
+        document.removeEventListener("keydown", handleEscape);
+      };
+    }
+  }, [menuOpen]);
+
+  const showOverflowMenu = !isOwner && (canModify || (canTransfer && !isCurrentUser));
+
+  return (
+    <div
+      className={`rounded-lg p-3 transition-colors ${
+        isUpdating ? "opacity-60" : "hover:bg-mist/50"
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        {/* Avatar placeholder */}
+        <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-mist">
+          <User className="h-5 w-5 text-stone" />
+        </div>
+
+        {/* User info */}
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <p className="truncate text-sm font-medium text-ink">
+              {membership.userId}
+            </p>
+            {isCurrentUser && (
+              <span className="rounded-full bg-mist px-2 py-0.5 text-xs text-stone">
+                you
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 text-xs text-stone">
+            Added {formatDate(membership.createdAt)}
+          </p>
+
+          {/* Pending transfer banner for this member */}
+          {isPendingTransferRecipient && (
+            <div className="mt-2 rounded-lg border border-terracotta/30 bg-terracotta/5 px-3 py-2">
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4 text-terracotta" />
+                <span className="text-xs font-medium text-terracotta">
+                  Transfer pending
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-stone">
+                Waiting for acceptance
+              </p>
+              {canTransfer && (
+                <button
+                  type="button"
+                  onClick={onCancelTransfer}
+                  className="mt-2 rounded-lg border border-stone/20 px-2.5 py-1 text-xs font-medium text-stone transition-colors hover:bg-mist hover:text-ink"
+                >
+                  Cancel Transfer
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Access level and actions */}
+        <div className="flex items-center gap-2">
+          {/* Access level display or dropdown */}
+          {isOwner ? (
+            <div className="flex items-center gap-1.5">
+              <span className="text-sm text-terracotta">Owner</span>
+              <Crown className="h-4 w-4 text-terracotta" />
+            </div>
+          ) : canModify && !isPendingTransferRecipient ? (
+            <AccessLevelSelect
+              value={membership.accessLevel!}
+              onChange={(level) =>
+                onAccessLevelChange(membership.userId!, level)
+              }
+              allowedLevels={assignableLevels}
+              disabled={isUpdating}
+            />
+          ) : (
+            <AccessLevelBadge level={membership.accessLevel!} />
+          )}
+
+          {/* Overflow menu */}
+          {showOverflowMenu && !isPendingTransferRecipient && (
+            <div ref={menuRef} className="relative">
+              <button
+                type="button"
+                onClick={() => setMenuOpen(!menuOpen)}
+                className="rounded p-1 text-stone transition-colors hover:bg-mist hover:text-ink"
+                aria-label="Member options"
+              >
+                <MoreVertical className="h-4 w-4" />
+              </button>
+
+              {menuOpen && (
+                <div className="absolute bottom-full right-0 z-50 mb-1 w-48 overflow-hidden rounded-xl border border-stone/20 bg-cream shadow-xl">
+                  <div className="py-1">
+                    {canModify && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onRemove(membership.userId!);
+                          setMenuOpen(false);
+                        }}
+                        className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm text-ink transition-colors hover:bg-mist"
+                      >
+                        <Trash2 className="h-4 w-4 text-terracotta" />
+                        Remove
+                      </button>
+                    )}
+                    {canTransfer && !isCurrentUser && !pendingTransfer && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onTransferOwnership(membership.userId!);
+                          setMenuOpen(false);
+                        }}
+                        className="flex w-full items-center gap-3 px-3 py-2.5 text-left text-sm text-ink transition-colors hover:bg-mist"
+                      >
+                        <Crown className="h-4 w-4 text-terracotta" />
+                        Transfer ownership
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/common/agent-webui/src/components/sharing/pending-transfers-panel.tsx
+++ b/common/agent-webui/src/components/sharing/pending-transfers-panel.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+import { Crown, ChevronDown, ChevronUp, ExternalLink, X } from "lucide-react";
+import type { OwnershipTransfer } from "@/client";
+import {
+  usePendingTransfers,
+  useAcceptTransfer,
+  useDeleteTransfer,
+} from "@/hooks/useSharing";
+
+type PendingTransfersPanelProps = {
+  onNavigateToConversation?: (conversationId: string) => void;
+};
+
+type TransferItemProps = {
+  transfer: OwnershipTransfer;
+  onAccept: () => void;
+  onDecline: () => void;
+  onNavigate?: () => void;
+  isAccepting: boolean;
+  isDeclining: boolean;
+};
+
+function TransferItem({
+  transfer,
+  onAccept,
+  onDecline,
+  onNavigate,
+  isAccepting,
+  isDeclining,
+}: TransferItemProps) {
+  const isLoading = isAccepting || isDeclining;
+
+  return (
+    <div className="rounded-lg border border-stone/20 bg-cream p-3">
+      <div className="flex items-start gap-3">
+        <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-terracotta/10">
+          <Crown className="h-4 w-4 text-terracotta" />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium text-ink">
+              From {transfer.fromUserId}
+            </p>
+            {onNavigate && (
+              <button
+                type="button"
+                onClick={onNavigate}
+                className="rounded p-0.5 text-stone transition-colors hover:bg-mist hover:text-ink"
+                title="Go to conversation"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </button>
+            )}
+          </div>
+          <p className="mt-0.5 truncate text-xs text-stone">
+            Conversation: {transfer.conversationId?.slice(0, 8)}...
+          </p>
+
+          <div className="mt-2 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onDecline}
+              disabled={isLoading}
+              className="rounded-md border border-stone/20 px-2 py-1 text-xs font-medium text-stone transition-colors hover:bg-mist hover:text-ink disabled:opacity-50"
+            >
+              {isDeclining ? "..." : "Decline"}
+            </button>
+            <button
+              type="button"
+              onClick={onAccept}
+              disabled={isLoading}
+              className="rounded-md bg-terracotta px-2 py-1 text-xs font-medium text-cream transition-colors hover:bg-terracotta/90 disabled:opacity-50"
+            >
+              {isAccepting ? "..." : "Accept"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function PendingTransfersPanel({
+  onNavigateToConversation,
+}: PendingTransfersPanelProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const [isDismissed, setIsDismissed] = useState(false);
+  const [processingTransferId, setProcessingTransferId] = useState<
+    string | null
+  >(null);
+
+  const transfersQuery = usePendingTransfers("recipient");
+  const acceptTransfer = useAcceptTransfer();
+  const deleteTransfer = useDeleteTransfer();
+
+  const pendingTransfers = transfersQuery.data ?? [];
+
+  // Don't render if dismissed or no transfers
+  if (isDismissed || pendingTransfers.length === 0) {
+    return null;
+  }
+
+  const handleAccept = async (transferId: string) => {
+    setProcessingTransferId(transferId);
+    try {
+      await acceptTransfer.mutateAsync({ transferId });
+    } finally {
+      setProcessingTransferId(null);
+    }
+  };
+
+  const handleDecline = async (transferId: string) => {
+    setProcessingTransferId(transferId);
+    try {
+      await deleteTransfer.mutateAsync({ transferId });
+    } finally {
+      setProcessingTransferId(null);
+    }
+  };
+
+  return (
+    <div className="border-b border-stone/10 bg-terracotta/5">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2">
+        <button
+          type="button"
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="flex flex-1 items-center gap-2 text-left"
+        >
+          <Crown className="h-4 w-4 text-terracotta" />
+          <span className="text-sm font-medium text-ink">
+            Pending transfers ({pendingTransfers.length})
+          </span>
+          {isExpanded ? (
+            <ChevronUp className="h-4 w-4 text-stone" />
+          ) : (
+            <ChevronDown className="h-4 w-4 text-stone" />
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => setIsDismissed(true)}
+          className="rounded p-1 text-stone transition-colors hover:bg-mist hover:text-ink"
+          title="Dismiss"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Content */}
+      {isExpanded && (
+        <div className="space-y-2 px-4 pb-3">
+          {pendingTransfers.map((transfer) => (
+            <TransferItem
+              key={transfer.id}
+              transfer={transfer}
+              onAccept={() => handleAccept(transfer.id!)}
+              onDecline={() => handleDecline(transfer.id!)}
+              onNavigate={
+                onNavigateToConversation && transfer.conversationId
+                  ? () => onNavigateToConversation(transfer.conversationId!)
+                  : undefined
+              }
+              isAccepting={
+                processingTransferId === transfer.id && acceptTransfer.isPending
+              }
+              isDeclining={
+                processingTransferId === transfer.id && deleteTransfer.isPending
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/common/agent-webui/src/components/sharing/share-button.tsx
+++ b/common/agent-webui/src/components/sharing/share-button.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { Users } from "lucide-react";
+import { ShareModal } from "./share-modal";
+
+type ShareButtonProps = {
+  conversationId: string | null;
+  conversationTitle?: string | null;
+  currentUserId: string;
+  disabled?: boolean;
+};
+
+export function ShareButton({
+  conversationId,
+  conversationTitle,
+  currentUserId,
+  disabled = false,
+}: ShareButtonProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const handleClick = () => {
+    if (conversationId) {
+      setIsModalOpen(true);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={disabled || !conversationId}
+        className="flex items-center gap-2 rounded-lg border border-stone/20 px-3 py-2 text-sm text-stone transition-colors hover:bg-mist hover:text-ink disabled:opacity-50"
+        title="Share conversation"
+      >
+        <Users className="h-4 w-4" />
+        <span>Share</span>
+      </button>
+
+      {conversationId && (
+        <ShareModal
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+          conversationId={conversationId}
+          conversationTitle={conversationTitle}
+          currentUserId={currentUserId}
+        />
+      )}
+    </>
+  );
+}

--- a/common/agent-webui/src/components/sharing/share-modal.tsx
+++ b/common/agent-webui/src/components/sharing/share-modal.tsx
@@ -1,0 +1,389 @@
+import { useState, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { X, Users } from "lucide-react";
+import type { AccessLevel } from "@/client";
+import {
+  useMemberships,
+  useShareConversation,
+  useUpdateMembership,
+  useRemoveMembership,
+  usePendingTransferForConversation,
+  useCreateTransfer,
+  useAcceptTransfer,
+  useDeleteTransfer,
+  canManageMembers,
+  getAssignableAccessLevels,
+} from "@/hooks/useSharing";
+import { MemberListItem } from "./member-list-item";
+import { AddMemberForm } from "./add-member-form";
+import { TransferConfirmModal } from "./transfer-confirm-modal";
+import { IncomingTransferBanner } from "./incoming-transfer-banner";
+
+type ShareModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  conversationId: string;
+  conversationTitle?: string | null;
+  currentUserId: string;
+};
+
+export function ShareModal({
+  isOpen,
+  onClose,
+  conversationId,
+  conversationTitle,
+  currentUserId,
+}: ShareModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const [transferTargetUserId, setTransferTargetUserId] = useState<
+    string | null
+  >(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Queries
+  const membershipsQuery = useMemberships(conversationId);
+  const pendingTransferQuery = usePendingTransferForConversation(conversationId);
+
+  // Mutations
+  const shareConversation = useShareConversation();
+  const updateMembership = useUpdateMembership();
+  const removeMembership = useRemoveMembership();
+  const createTransfer = useCreateTransfer();
+  const acceptTransfer = useAcceptTransfer();
+  const deleteTransfer = useDeleteTransfer();
+
+  // Derive current user's access level
+  const currentUserMembership = membershipsQuery.data?.find(
+    (m) => m.userId === currentUserId,
+  );
+  const currentUserAccessLevel = currentUserMembership?.accessLevel;
+  const canManage = canManageMembers(currentUserAccessLevel);
+  const assignableLevels = getAssignableAccessLevels(currentUserAccessLevel);
+
+  // Check if current user is recipient of pending transfer
+  const pendingTransfer = pendingTransferQuery.data;
+  const isTransferRecipient =
+    pendingTransfer && pendingTransfer.toUserId === currentUserId;
+
+  // Existing user IDs for validation
+  const existingUserIds = membershipsQuery.data?.map((m) => m.userId!) ?? [];
+
+  // Close on escape key (but not when transfer confirm modal is open)
+  useEffect(() => {
+    function handleEscape(event: KeyboardEvent) {
+      // Don't close if the transfer confirm modal is open
+      if (transferTargetUserId !== null) {
+        return;
+      }
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+      return () => {
+        document.removeEventListener("keydown", handleEscape);
+      };
+    }
+  }, [isOpen, onClose, transferTargetUserId]);
+
+  // Close when clicking outside (but not when transfer confirm modal is open)
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      // Don't close if the transfer confirm modal is open
+      if (transferTargetUserId !== null) {
+        return;
+      }
+      if (
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node)
+      ) {
+        onClose();
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }
+  }, [isOpen, onClose, transferTargetUserId]);
+
+  // Reset state when modal closes
+  // Note: This effect syncs UI state (error/transfer state) with modal visibility
+  useEffect(() => {
+    if (!isOpen) {
+      setTransferTargetUserId(null); // eslint-disable-line react-hooks/set-state-in-effect
+      setError(null);
+    }
+  }, [isOpen]);
+
+  // Handlers
+  const handleAddMember = async (userId: string, accessLevel: AccessLevel) => {
+    setError(null);
+    try {
+      await shareConversation.mutateAsync({
+        conversationId,
+        userId,
+        accessLevel,
+      });
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to add member";
+      setError(errorMessage);
+    }
+  };
+
+  const handleAccessLevelChange = async (
+    userId: string,
+    accessLevel: AccessLevel,
+  ) => {
+    setError(null);
+    try {
+      await updateMembership.mutateAsync({
+        conversationId,
+        userId,
+        accessLevel,
+      });
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to update access level";
+      setError(errorMessage);
+    }
+  };
+
+  const handleRemoveMember = async (userId: string) => {
+    setError(null);
+    try {
+      await removeMembership.mutateAsync({
+        conversationId,
+        userId,
+      });
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to remove member";
+      setError(errorMessage);
+    }
+  };
+
+  const handleTransferOwnership = (userId: string) => {
+    setTransferTargetUserId(userId);
+  };
+
+  const handleConfirmTransfer = async () => {
+    if (!transferTargetUserId) return;
+    setError(null);
+    try {
+      await createTransfer.mutateAsync({
+        conversationId,
+        newOwnerUserId: transferTargetUserId,
+      });
+      setTransferTargetUserId(null);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to initiate transfer";
+      setError(errorMessage);
+    }
+  };
+
+  const handleAcceptTransfer = async () => {
+    if (!pendingTransfer) return;
+    setError(null);
+    try {
+      await acceptTransfer.mutateAsync({ transferId: pendingTransfer.id });
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to accept transfer";
+      setError(errorMessage);
+    }
+  };
+
+  const handleDeclineTransfer = async () => {
+    if (!pendingTransfer) return;
+    setError(null);
+    try {
+      await deleteTransfer.mutateAsync({ transferId: pendingTransfer.id });
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to decline transfer";
+      setError(errorMessage);
+    }
+  };
+
+  const handleCancelTransfer = async () => {
+    if (!pendingTransfer) return;
+    setError(null);
+    try {
+      await deleteTransfer.mutateAsync({ transferId: pendingTransfer.id });
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : "Failed to cancel transfer";
+      setError(errorMessage);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  // Sort members: owner first, then by access level, then alphabetically
+  const sortedMembers = [...(membershipsQuery.data ?? [])].sort((a, b) => {
+    const levelOrder: Record<AccessLevel, number> = {
+      owner: 0,
+      manager: 1,
+      writer: 2,
+      reader: 3,
+    };
+    const aOrder = levelOrder[a.accessLevel!] ?? 4;
+    const bOrder = levelOrder[b.accessLevel!] ?? 4;
+    if (aOrder !== bOrder) return aOrder - bOrder;
+    return (a.userId ?? "").localeCompare(b.userId ?? "");
+  });
+
+  const memberCount = membershipsQuery.data?.length ?? 0;
+  const hasOtherMembers = memberCount > 1;
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-50 flex items-center justify-center">
+        {/* Backdrop */}
+        <div className="absolute inset-0 bg-ink/40" aria-hidden="true" />
+
+        {/* Modal */}
+        <div
+          ref={modalRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="share-modal-title"
+          className="relative z-10 flex max-h-[85vh] w-full max-w-md flex-col rounded-2xl border border-stone/20 bg-cream shadow-2xl"
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-stone/10 px-6 py-4">
+            <div>
+              <h2
+                id="share-modal-title"
+                className="font-serif text-xl text-ink"
+              >
+                {canManage ? "Share" : "Members"}
+              </h2>
+              {conversationTitle && (
+                <p className="mt-0.5 truncate text-sm text-stone">
+                  "{conversationTitle}"
+                </p>
+              )}
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded p-1 text-stone transition-colors hover:bg-mist hover:text-ink"
+              aria-label="Close"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 overflow-y-auto px-6 py-4">
+            {/* Error message */}
+            {error && (
+              <div className="mb-4 rounded-lg bg-terracotta/10 px-3 py-2 text-sm text-terracotta">
+                {error}
+              </div>
+            )}
+
+            {/* Incoming transfer banner (for recipient) */}
+            {isTransferRecipient && pendingTransfer && (
+              <div className="mb-4">
+                <IncomingTransferBanner
+                  transfer={pendingTransfer}
+                  onAccept={handleAcceptTransfer}
+                  onDecline={handleDeclineTransfer}
+                  isAccepting={acceptTransfer.isPending}
+                  isDeclining={deleteTransfer.isPending}
+                />
+              </div>
+            )}
+
+            {/* Add member form (for owners/managers) */}
+            {canManage && (
+              <div className="mb-6">
+                <AddMemberForm
+                  onAdd={handleAddMember}
+                  allowedLevels={assignableLevels}
+                  isAdding={shareConversation.isPending}
+                  existingUserIds={existingUserIds}
+                  currentUserId={currentUserId}
+                />
+              </div>
+            )}
+
+            {/* Section header */}
+            <div className="mb-3 flex items-center gap-2">
+              <Users className="h-4 w-4 text-stone" />
+              <span className="text-sm font-medium text-stone">
+                People with access
+              </span>
+            </div>
+
+            {/* Member list */}
+            {membershipsQuery.isLoading ? (
+              <div className="space-y-3">
+                {[1, 2, 3].map((i) => (
+                  <div
+                    key={i}
+                    className="h-16 animate-pulse rounded-lg bg-mist"
+                  />
+                ))}
+              </div>
+            ) : sortedMembers.length === 0 ? (
+              <p className="py-4 text-center text-sm text-stone">
+                No members found
+              </p>
+            ) : (
+              <div className="space-y-1">
+                {sortedMembers.map((membership) => (
+                  <MemberListItem
+                    key={membership.userId}
+                    membership={membership}
+                    currentUserId={currentUserId}
+                    currentUserAccessLevel={currentUserAccessLevel!}
+                    pendingTransfer={pendingTransfer}
+                    onAccessLevelChange={handleAccessLevelChange}
+                    onRemove={handleRemoveMember}
+                    onTransferOwnership={handleTransferOwnership}
+                    onCancelTransfer={handleCancelTransfer}
+                    isUpdating={
+                      updateMembership.isPending || removeMembership.isPending
+                    }
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* Empty state message */}
+            {!hasOtherMembers && !membershipsQuery.isLoading && canManage && (
+              <div className="mt-4 rounded-lg border border-stone/10 bg-mist/30 px-4 py-3 text-center">
+                <p className="text-sm text-stone">
+                  This conversation is private.
+                </p>
+                <p className="mt-0.5 text-sm text-stone">
+                  Add people above to collaborate.
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Transfer confirmation modal */}
+      <TransferConfirmModal
+        isOpen={transferTargetUserId !== null}
+        onClose={() => setTransferTargetUserId(null)}
+        onConfirm={handleConfirmTransfer}
+        recipientUserId={transferTargetUserId ?? ""}
+        isLoading={createTransfer.isPending}
+      />
+    </>,
+    document.body,
+  );
+}

--- a/common/agent-webui/src/components/sharing/transfer-confirm-modal.tsx
+++ b/common/agent-webui/src/components/sharing/transfer-confirm-modal.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef } from "react";
+import { X, Crown } from "lucide-react";
+
+type TransferConfirmModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  recipientUserId: string;
+  isLoading?: boolean;
+};
+
+export function TransferConfirmModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  recipientUserId,
+  isLoading = false,
+}: TransferConfirmModalProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // Close on escape key
+  useEffect(() => {
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === "Escape" && !isLoading) {
+        onClose();
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+      return () => {
+        document.removeEventListener("keydown", handleEscape);
+      };
+    }
+  }, [isOpen, isLoading, onClose]);
+
+  // Close when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node) &&
+        !isLoading
+      ) {
+        onClose();
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+      };
+    }
+  }, [isOpen, isLoading, onClose]);
+
+  // Focus trap
+  useEffect(() => {
+    if (isOpen && modalRef.current) {
+      const focusableElements = modalRef.current.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      const firstElement = focusableElements[0] as HTMLElement;
+      firstElement?.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-ink/40" aria-hidden="true" />
+
+      {/* Modal */}
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="transfer-modal-title"
+        className="relative z-10 w-full max-w-md animate-slide-up rounded-2xl border border-stone/20 bg-cream p-6 shadow-2xl"
+      >
+        {/* Close button */}
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={isLoading}
+          className="absolute right-4 top-4 rounded p-1 text-stone transition-colors hover:bg-mist hover:text-ink disabled:opacity-50"
+          aria-label="Close"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        {/* Icon */}
+        <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-terracotta/10">
+          <Crown className="h-6 w-6 text-terracotta" />
+        </div>
+
+        {/* Content */}
+        <h2
+          id="transfer-modal-title"
+          className="font-serif text-xl text-ink"
+        >
+          Transfer ownership
+        </h2>
+
+        <p className="mt-3 text-sm text-stone">
+          Transfer ownership to{" "}
+          <span className="font-medium text-ink">{recipientUserId}</span>?
+        </p>
+
+        <div className="mt-4 rounded-lg bg-mist/50 p-3">
+          <ul className="space-y-1.5 text-xs text-stone">
+            <li>They will need to accept the transfer.</li>
+            <li>You will become a Manager after they accept.</li>
+          </ul>
+        </div>
+
+        {/* Actions */}
+        <div className="mt-6 flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isLoading}
+            className="rounded-lg px-4 py-2.5 text-sm font-medium text-stone transition-colors hover:bg-mist hover:text-ink disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="rounded-lg bg-terracotta px-4 py-2.5 text-sm font-medium text-cream transition-colors hover:bg-terracotta/90 disabled:opacity-50"
+          >
+            {isLoading ? "Requesting..." : "Request Transfer"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/common/agent-webui/src/hooks/useCurrentUser.ts
+++ b/common/agent-webui/src/hooks/useCurrentUser.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+
+type CurrentUserResponse = {
+  userId: string;
+};
+
+/**
+ * Hook to get the current authenticated user's ID.
+ * Uses the /v1/me endpoint to retrieve the user ID from the backend.
+ */
+export function useCurrentUser() {
+  return useQuery({
+    queryKey: ["current-user"],
+    staleTime: Infinity, // User ID won't change during session
+    queryFn: async (): Promise<string | null> => {
+      try {
+        const response = await fetch("/v1/me", {
+          credentials: "include",
+        });
+        if (!response.ok) {
+          return null;
+        }
+        const data: CurrentUserResponse = await response.json();
+        return data.userId ?? null;
+      } catch {
+        return null;
+      }
+    },
+  });
+}

--- a/common/agent-webui/src/hooks/useSharing.ts
+++ b/common/agent-webui/src/hooks/useSharing.ts
@@ -1,0 +1,281 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { SharingService } from "@/client";
+import type {
+  AccessLevel,
+  ConversationMembership,
+  OwnershipTransfer,
+} from "@/client";
+
+// Response types for the API calls
+type MembershipsResponse = {
+  data?: ConversationMembership[];
+};
+
+type TransfersResponse = {
+  data?: OwnershipTransfer[];
+};
+
+/**
+ * Hook to fetch conversation memberships
+ */
+export function useMemberships(conversationId: string | null) {
+  return useQuery({
+    queryKey: ["memberships", conversationId],
+    enabled: Boolean(conversationId),
+    queryFn: async (): Promise<ConversationMembership[]> => {
+      if (!conversationId) return [];
+      const response = (await SharingService.listConversationMemberships({
+        conversationId,
+      })) as unknown as MembershipsResponse;
+      return response.data ?? [];
+    },
+  });
+}
+
+/**
+ * Hook to share a conversation with a new user
+ */
+export function useShareConversation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      conversationId,
+      userId,
+      accessLevel,
+    }: {
+      conversationId: string;
+      userId: string;
+      accessLevel: AccessLevel;
+    }) => {
+      return SharingService.shareConversation({
+        conversationId,
+        requestBody: { userId, accessLevel },
+      });
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: ["memberships", variables.conversationId],
+      });
+    },
+  });
+}
+
+/**
+ * Hook to update a member's access level
+ */
+export function useUpdateMembership() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      conversationId,
+      userId,
+      accessLevel,
+    }: {
+      conversationId: string;
+      userId: string;
+      accessLevel: AccessLevel;
+    }) => {
+      return SharingService.updateConversationMembership({
+        conversationId,
+        userId,
+        requestBody: { accessLevel },
+      });
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: ["memberships", variables.conversationId],
+      });
+    },
+  });
+}
+
+/**
+ * Hook to remove a member from a conversation
+ */
+export function useRemoveMembership() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      conversationId,
+      userId,
+    }: {
+      conversationId: string;
+      userId: string;
+    }) => {
+      return SharingService.deleteConversationMembership({
+        conversationId,
+        userId,
+      });
+    },
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: ["memberships", variables.conversationId],
+      });
+    },
+  });
+}
+
+/**
+ * Hook to list pending ownership transfers
+ */
+export function usePendingTransfers(role?: "sender" | "recipient" | "all") {
+  return useQuery({
+    queryKey: ["pending-transfers", role],
+    queryFn: async (): Promise<OwnershipTransfer[]> => {
+      const response = (await SharingService.listPendingTransfers({
+        role,
+      })) as unknown as TransfersResponse;
+      return response.data ?? [];
+    },
+  });
+}
+
+/**
+ * Hook to get a pending transfer for a specific conversation
+ */
+export function usePendingTransferForConversation(
+  conversationId: string | null,
+) {
+  const transfersQuery = usePendingTransfers();
+
+  const pendingTransfer = transfersQuery.data?.find(
+    (t) => t.conversationId === conversationId,
+  );
+
+  return {
+    ...transfersQuery,
+    data: pendingTransfer ?? null,
+  };
+}
+
+/**
+ * Hook to create an ownership transfer
+ */
+export function useCreateTransfer() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      conversationId,
+      newOwnerUserId,
+    }: {
+      conversationId: string;
+      newOwnerUserId: string;
+    }) => {
+      return SharingService.createOwnershipTransfer({
+        requestBody: { conversationId, newOwnerUserId },
+      });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["pending-transfers"],
+      });
+    },
+  });
+}
+
+/**
+ * Hook to accept an ownership transfer
+ */
+export function useAcceptTransfer() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ transferId }: { transferId: string }) => {
+      return SharingService.acceptTransfer({ transferId });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["pending-transfers"],
+      });
+      // Also invalidate memberships since ownership changed
+      void queryClient.invalidateQueries({
+        queryKey: ["memberships"],
+      });
+      // Invalidate conversations list as ownership may have changed
+      void queryClient.invalidateQueries({
+        queryKey: ["conversations"],
+      });
+    },
+  });
+}
+
+/**
+ * Hook to delete (cancel or decline) an ownership transfer
+ */
+export function useDeleteTransfer() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ transferId }: { transferId: string }) => {
+      return SharingService.deleteTransfer({ transferId });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["pending-transfers"],
+      });
+    },
+  });
+}
+
+/**
+ * Utility to determine if a user can manage members
+ */
+export function canManageMembers(accessLevel: AccessLevel | undefined): boolean {
+  return accessLevel === "owner" || accessLevel === "manager";
+}
+
+/**
+ * Utility to determine if a user can transfer ownership
+ */
+export function canTransferOwnership(
+  accessLevel: AccessLevel | undefined,
+): boolean {
+  return accessLevel === "owner";
+}
+
+/**
+ * Utility to determine what access levels a user can assign to others
+ * Managers can only assign writer/reader
+ * Owners can assign any level except owner
+ */
+export function getAssignableAccessLevels(
+  currentUserAccessLevel: AccessLevel | undefined,
+): AccessLevel[] {
+  if (currentUserAccessLevel === "owner") {
+    return ["manager", "writer", "reader"];
+  }
+  if (currentUserAccessLevel === "manager") {
+    return ["writer", "reader"];
+  }
+  return [];
+}
+
+/**
+ * Utility to determine if a user can modify another member's access
+ */
+export function canModifyMember(
+  currentUserAccessLevel: AccessLevel | undefined,
+  targetMemberAccessLevel: AccessLevel | undefined,
+): boolean {
+  if (!currentUserAccessLevel || !targetMemberAccessLevel) return false;
+
+  // Can't modify yourself through this mechanism
+  // Owner can modify anyone except other owners (there's only one owner)
+  if (currentUserAccessLevel === "owner") {
+    return targetMemberAccessLevel !== "owner";
+  }
+
+  // Manager can only modify writers and readers
+  if (currentUserAccessLevel === "manager") {
+    return (
+      targetMemberAccessLevel === "writer" ||
+      targetMemberAccessLevel === "reader"
+    );
+  }
+
+  return false;
+}

--- a/docs/enhancements/025-sharing-ui.md
+++ b/docs/enhancements/025-sharing-ui.md
@@ -137,19 +137,17 @@ Owners and managers see the full sharing controls:
 │  └───────────────────────────────────────────────────────────┘  │
 │                                                                 │
 │  ┌───────────────────────────────────────────────────────────┐  │
-│  │ 👤 user_bob_wilson                      [Reader ▾]   🗑   │  │
+│  │ 👤 user_bob_wilson                      [Reader ▾]   ⋮   │  │
 │  │    Added Jan 22, 2025                                     │  │
 │  └───────────────────────────────────────────────────────────┘  │
-│                                                                 │
-│  ─────────────────────────────────────────────────────────────  │
-│                                                                 │
-│  ⚙️ Advanced                          (Owner only)              │
-│     Transfer ownership →                                        │
 │                                                                 │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-**Note**: Managers see dropdowns and remove buttons for writers/readers only. They cannot modify other managers or the owner. The "Advanced" section with ownership transfer is only visible to owners.
+**Notes**:
+- Managers see dropdowns and overflow menus (⋮) for writers/readers only. They cannot modify other managers or the owner.
+- The overflow menu contains "Remove" and (for owners only) "Transfer ownership".
+- Owners see the overflow menu on all members.
 
 #### Writer/Reader View (Read-Only)
 
@@ -249,20 +247,33 @@ Writers and readers see a simplified view without editing controls:
 
 #### Initiating a Transfer (Owner)
 
-Triggered from the "Advanced" section. Opens a confirmation modal.
+Since transfers can only be made to existing members, the "Transfer ownership" action appears as a menu option on each member row (visible only to the owner). This is more intuitive than a separate section with a member dropdown.
+
+**Member Row with Transfer Option** (Owner view):
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ 👤 user_jane_smith                     [Manager ▾]   ⋮       │
+│    Added Jan 20, 2025                              ┌───────┐ │
+│                                                    │ Remove│ │
+│                                                    │ ───── │ │
+│                                                    │ 👑 Transfer │
+│                                                    │ ownership   │
+│                                                    └───────┘ │
+└───────────────────────────────────────────────────────────────┘
+```
+
+When the owner clicks "Transfer ownership" on a member, a confirmation modal opens:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                                                              ✕  │
 │  Transfer ownership                                             │
 │                                                                 │
-│  The new owner will need to accept the transfer.                │
-│  You will become a Manager after they accept.                   │
+│  Transfer ownership to user_jane_smith?                         │
 │                                                                 │
-│  Transfer to:                                                   │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │ Select a member...                                     ▾  │  │
-│  └───────────────────────────────────────────────────────────┘  │
+│  They will need to accept the transfer.                         │
+│  You will become a Manager after they accept.                   │
 │                                                                 │
 │                            [ Cancel ]  [ Request Transfer ]     │
 │                                                                 │
@@ -270,26 +281,32 @@ Triggered from the "Advanced" section. Opens a confirmation modal.
 ```
 
 **Interaction Flow (Owner)**:
-1. User clicks "Transfer ownership" in advanced section
-2. Confirmation modal opens
-3. User selects new owner from dropdown (existing members only)
-4. User confirms with "Request Transfer" button
-5. On success: Transfer created as "pending", UI shows pending state
+1. Owner clicks the overflow menu (⋮) on a member row
+2. Owner selects "Transfer ownership" from the menu
+3. Confirmation modal opens showing the selected member
+4. Owner confirms with "Request Transfer" button
+5. On success: Transfer created as "pending", UI shows pending state on that member row
 
 #### Pending Transfer State (Owner View)
 
-When a pending transfer exists, the Advanced section shows:
+When a pending transfer exists, the member row shows the pending state:
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│  ⚙️ Advanced                                                    │
-│                                                                 │
-│  ⏳ Transfer pending                                            │
-│     Waiting for user_jane_smith to accept                       │
-│                                    [ Cancel Transfer ]          │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
+┌───────────────────────────────────────────────────────────────┐
+│ 👤 user_jane_smith                          Manager  🔧       │
+│    Added Jan 20, 2025                                         │
+│    ┌─────────────────────────────────────────────────────┐    │
+│    │ ⏳ Transfer pending · Waiting for acceptance        │    │
+│    │                              [ Cancel Transfer ]    │    │
+│    └─────────────────────────────────────────────────────┘    │
+└───────────────────────────────────────────────────────────────┘
 ```
+
+**Notes:**
+- The pending transfer banner is shown inline on the recipient's member row
+- Access level dropdown and remove button are hidden while transfer is pending
+- Only one pending transfer can exist per conversation
+- Owner can cancel the transfer from this inline banner
 
 #### Incoming Transfer (Recipient View)
 
@@ -370,8 +387,9 @@ When conversation has no shared members:
 | `MemberListItem` | `member-list-item.tsx` | Individual member row |
 | `AddMemberForm` | `add-member-form.tsx` | Input for adding new members |
 | `AccessLevelSelect` | `access-level-select.tsx` | Dropdown for access levels |
-| `TransferRequestModal` | `transfer-request-modal.tsx` | Request ownership transfer (owner) |
-| `TransferPendingBanner` | `transfer-pending-banner.tsx` | Shows pending transfer status |
+| `MemberOverflowMenu` | `member-overflow-menu.tsx` | Overflow menu with Remove/Transfer actions |
+| `TransferConfirmModal` | `transfer-confirm-modal.tsx` | Confirm ownership transfer (owner) |
+| `TransferPendingBanner` | `transfer-pending-banner.tsx` | Inline pending transfer status on member row |
 | `IncomingTransferBanner` | `incoming-transfer-banner.tsx` | Accept/decline transfer (recipient) |
 
 ### Component Hierarchy
@@ -384,12 +402,12 @@ ChatPanel
 │           ├── IncomingTransferBanner (if recipient of pending transfer)
 │           ├── AddMemberForm (owner/manager only)
 │           │   └── AccessLevelSelect
-│           ├── MemberList
-│           │   └── MemberListItem
-│           │       └── AccessLevelSelect
-│           └── Advanced Section (owner only)
-│               ├── TransferPendingBanner (if pending transfer exists)
-│               └── TransferRequestModal (if no pending transfer)
+│           └── MemberList
+│               └── MemberListItem
+│                   ├── AccessLevelSelect
+│                   ├── MemberOverflowMenu (owner/manager only)
+│                   │   └── TransferConfirmModal (owner only, on "Transfer" click)
+│                   └── TransferPendingBanner (if this member has pending transfer)
 ```
 
 ### State Management
@@ -419,7 +437,7 @@ isTransferSender: boolean           // Is current user the sender?
 
 // Local state
 isShareModalOpen: boolean
-isTransferModalOpen: boolean
+transferTargetUserId: string | null // User ID when transfer confirm modal is open
 pendingMemberId: string | null      // For optimistic updates
 ```
 
@@ -542,11 +560,12 @@ For smaller screens:
 
 ### Phase 5: Ownership Transfer
 1. Fetch pending transfer when opening share modal
-2. TransferRequestModal (owner only, if no pending transfer)
-3. Pending transfer state UI (owner view with cancel option)
-4. Incoming transfer banner (recipient view with accept/decline)
-5. Handle accept/reject/cancel actions
-6. Post-acceptance: UI updates to reflect new owner
+2. Add overflow menu to member rows with "Remove" and "Transfer ownership" options
+3. TransferConfirmModal when owner clicks "Transfer ownership" on a member
+4. Inline pending transfer banner on recipient's member row (with cancel option)
+5. Incoming transfer banner at top of modal (recipient view with accept/decline)
+6. Handle accept/decline/cancel actions
+7. Post-acceptance: UI updates to reflect new owner
 
 ### Phase 6: Polish
 1. Animations and transitions
@@ -572,15 +591,18 @@ For smaller screens:
 - [ ] Writer/reader can view all members
 
 ### Transfer Flow
-- [ ] Owner can request transfer (transfer option hidden for non-owners)
-- [ ] Cannot request transfer if one is already pending
-- [ ] Owner sees pending transfer state with cancel option
-- [ ] Owner can cancel (delete) pending transfer
-- [ ] Recipient sees incoming transfer banner
-- [ ] Recipient can accept transfer
+- [ ] Owner sees "Transfer ownership" in member overflow menu
+- [ ] Non-owners do not see "Transfer ownership" option
+- [ ] Clicking "Transfer ownership" opens confirmation modal with member name
+- [ ] Cannot request transfer if one is already pending (option disabled or hidden)
+- [ ] Pending transfer shows inline banner on recipient's member row
+- [ ] Owner can cancel pending transfer from inline banner
+- [ ] Recipient sees incoming transfer banner at top of share modal
+- [ ] Recipient can accept transfer (becomes owner)
 - [ ] Recipient can decline (delete) transfer
 - [ ] After acceptance: recipient is owner, former owner is manager
 - [ ] Deleted transfers are hard deleted (not visible after delete)
+- [ ] UI correctly refetches memberships after transfer acceptance
 
 ### Edge Cases
 - [ ] Empty state displays correctly
@@ -601,13 +623,21 @@ For smaller screens:
 The generated TypeScript client needs these services:
 
 ```typescript
-// From OpenAPI spec
+// Membership operations
 SharingService.listConversationMemberships({ conversationId })
 SharingService.shareConversation({ conversationId, requestBody })
 SharingService.updateConversationMembership({ conversationId, userId, requestBody })
 SharingService.deleteConversationMembership({ conversationId, userId })
-SharingService.transferConversationOwnership({ conversationId, requestBody })
+
+// Ownership transfer operations
+SharingService.listPendingTransfers({ role? })        // GET /v1/ownership-transfers
+SharingService.createOwnershipTransfer({ requestBody }) // POST /v1/ownership-transfers
+SharingService.getTransfer({ transferId })            // GET /v1/ownership-transfers/{id}
+SharingService.acceptTransfer({ transferId })         // POST /v1/ownership-transfers/{id}/accept (returns 204)
+SharingService.deleteTransfer({ transferId })         // DELETE /v1/ownership-transfers/{id} (returns 204)
 ```
+
+**Note**: `acceptTransfer` returns `204 No Content` on success (the transfer is deleted after ownership changes). The UI should refetch memberships after acceptance to reflect the new owner.
 
 Verify the client is regenerated with sharing endpoints included.
 

--- a/memory-service-contracts/src/main/resources/openapi.yml
+++ b/memory-service-contracts/src/main/resources/openapi.yml
@@ -629,6 +629,7 @@ paths:
       summary: List conversation memberships
       description: |-
         Lists all users that have access to the conversation and their access levels.
+        Any conversation member (owner, manager, writer, or reader) can list memberships.
       operationId: listConversationMemberships
       parameters:
         - name: conversationId

--- a/memory-service/src/main/java/io/github/chirino/memory/store/impl/MongoMemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/impl/MongoMemoryStore.java
@@ -313,7 +313,8 @@ public class MongoMemoryStore implements MemoryStore {
     @Override
     public List<ConversationMembershipDto> listMemberships(String userId, String conversationId) {
         String groupId = resolveGroupId(conversationId);
-        ensureHasAccess(groupId, userId, AccessLevel.MANAGER);
+        // Any member can view the membership list
+        ensureHasAccess(groupId, userId, AccessLevel.READER);
         return membershipRepository.listForConversationGroup(groupId).stream()
                 .map(this::toMembershipDto)
                 .collect(Collectors.toList());

--- a/memory-service/src/main/java/io/github/chirino/memory/store/impl/PostgresMemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/impl/PostgresMemoryStore.java
@@ -304,7 +304,8 @@ public class PostgresMemoryStore implements MemoryStore {
     public List<ConversationMembershipDto> listMemberships(String userId, String conversationId) {
         UUID cid = UUID.fromString(conversationId);
         UUID groupId = resolveGroupId(cid);
-        ensureHasAccess(groupId, userId, AccessLevel.MANAGER);
+        // Any member can view the membership list
+        ensureHasAccess(groupId, userId, AccessLevel.READER);
         return membershipRepository.listForConversationGroup(groupId).stream()
                 .map(this::toMembershipDto)
                 .collect(Collectors.toList());

--- a/memory-service/src/test/resources/features/sharing-grpc.feature
+++ b/memory-service/src/test/resources/features/sharing-grpc.feature
@@ -126,7 +126,7 @@ Feature: Conversation Sharing gRPC API
     """
     Then the gRPC response should have status "PERMISSION_DENIED"
 
-  Scenario: List memberships without manager access via gRPC
+  Scenario: List memberships as a reader via gRPC
     Given there is a conversation owned by "bob"
     And I am authenticated as user "charlie"
     And the conversation is shared with user "charlie" with access level "reader"
@@ -134,7 +134,7 @@ Feature: Conversation Sharing gRPC API
     """
     conversation_id: "${conversationId}"
     """
-    Then the gRPC response should have status "PERMISSION_DENIED"
+    Then the gRPC response should not have an error
 
   Scenario: Update membership without manager access via gRPC
     Given there is a conversation owned by "bob"

--- a/memory-service/src/test/resources/features/sharing-rest.feature
+++ b/memory-service/src/test/resources/features/sharing-rest.feature
@@ -159,13 +159,13 @@ Feature: Conversation Sharing REST API
     Then the response status should be 403
     And the response should contain error code "forbidden"
 
-  Scenario: List memberships without manager access
+  Scenario: List memberships as a reader
     Given there is a conversation owned by "bob"
     And I am authenticated as user "charlie"
     And the conversation is shared with user "charlie" with access level "reader"
     When I list memberships for that conversation
-    Then the response status should be 403
-    And the response should contain error code "forbidden"
+    Then the response status should be 200
+    And the response should contain at least 2 memberships
 
   Scenario: Update membership without manager access
     Given there is a conversation owned by "bob"

--- a/quarkus/examples/agent-quarkus/src/main/java/example/CurrentUserResource.java
+++ b/quarkus/examples/agent-quarkus/src/main/java/example/CurrentUserResource.java
@@ -1,0 +1,42 @@
+package example;
+
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import java.util.Map;
+import org.eclipse.microprofile.jwt.JsonWebToken;
+
+/**
+ * Returns information about the current authenticated user.
+ */
+@Path("/v1/me")
+@ApplicationScoped
+public class CurrentUserResource {
+
+    @Inject SecurityIdentity securityIdentity;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Map<String, String> getCurrentUser() {
+        String userId = null;
+
+        // Try to get preferred_username from JWT claims
+        if (securityIdentity.getPrincipal() instanceof JsonWebToken jwt) {
+            userId = jwt.getClaim("preferred_username");
+            if (userId == null) {
+                userId = jwt.getName();
+            }
+        }
+
+        // Fall back to principal name
+        if (userId == null) {
+            userId = securityIdentity.getPrincipal().getName();
+        }
+
+        return Map.of("userId", userId != null ? userId : "anonymous");
+    }
+}

--- a/quarkus/examples/agent-quarkus/src/main/java/example/MemoryServiceProxyResource.java
+++ b/quarkus/examples/agent-quarkus/src/main/java/example/MemoryServiceProxyResource.java
@@ -8,6 +8,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
@@ -78,6 +79,14 @@ public class MemoryServiceProxyResource {
         return proxy.listConversationForks(conversationId);
     }
 
+    @GET
+    @Path("/{conversationId}/memberships")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listConversationMemberships(
+            @PathParam("conversationId") String conversationId) {
+        return proxy.listConversationMemberships(conversationId);
+    }
+
     @POST
     @Path("/{conversationId}/memberships")
     @Consumes(MediaType.APPLICATION_JSON)
@@ -87,60 +96,28 @@ public class MemoryServiceProxyResource {
         return proxy.shareConversation(conversationId, body);
     }
 
+    @PATCH
+    @Path("/{conversationId}/memberships/{userId}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateConversationMembership(
+            @PathParam("conversationId") String conversationId,
+            @PathParam("userId") String userId,
+            String body) {
+        return proxy.updateConversationMembership(conversationId, userId, body);
+    }
+
+    @DELETE
+    @Path("/{conversationId}/memberships/{userId}")
+    public Response deleteConversationMembership(
+            @PathParam("conversationId") String conversationId,
+            @PathParam("userId") String userId) {
+        return proxy.deleteConversationMembership(conversationId, userId);
+    }
+
     @DELETE
     @Path("/{conversationId}/response")
     public Response cancelResponse(@PathParam("conversationId") String conversationId) {
         return proxy.cancelResponse(conversationId);
     }
-
-    //
-    // These are addtional APIs we could expose, but our frontend does not need them yet.
-    //
-    // @POST
-    // @Consumes(MediaType.APPLICATION_JSON)
-    // @Produces(MediaType.APPLICATION_JSON)
-    // public Response createConversation(String body) {
-    //     return proxy.createConversation(body);
-    // }
-    // @POST
-    // @Path("/{conversationId}/entries")
-    // @Consumes(MediaType.APPLICATION_JSON)
-    // @Produces(MediaType.APPLICATION_JSON)
-    // public Response appendConversationEntry(
-    //         @PathParam("conversationId") String conversationId, String body) {
-    //     return proxy.appendConversationEntry(conversationId, body);
-    // }
-    // @GET
-    // @Path("/{conversationId}/memberships")
-    // @Produces(MediaType.APPLICATION_JSON)
-    // public Response listConversationMemberships(
-    //         @PathParam("conversationId") String conversationId) {
-    //     return proxy.listConversationMemberships(conversationId);
-    // }
-    // @PATCH
-    // @Path("/{conversationId}/memberships/{userId}")
-    // @Consumes(MediaType.APPLICATION_JSON)
-    // @Produces(MediaType.APPLICATION_JSON)
-    // public Response updateConversationMembership(
-    //         @PathParam("conversationId") String conversationId,
-    //         @PathParam("userId") String userId,
-    //         String body) {
-    //     return proxy.updateConversationMembership(conversationId, userId, body);
-    // }
-    // @POST
-    // @Path("/{conversationId}/transfer-ownership")
-    // @Consumes(MediaType.APPLICATION_JSON)
-    // public Response transferConversationOwnership(
-    //         @PathParam("conversationId") String conversationId, String body) {
-    //     return proxy.transferConversationOwnership(conversationId, body);
-    // }
-    // @POST
-    // @Path("/{conversationId}/summaries")
-    // @Consumes(MediaType.APPLICATION_JSON)
-    // @Produces(MediaType.APPLICATION_JSON)
-    // public Response createConversationSummary(
-    //         @PathParam("conversationId") String conversationId, String body) {
-    //     return proxy.createConversationSummary(conversationId, body);
-    // }
-
 }

--- a/quarkus/examples/agent-quarkus/src/main/java/example/OwnershipTransfersProxyResource.java
+++ b/quarkus/examples/agent-quarkus/src/main/java/example/OwnershipTransfersProxyResource.java
@@ -1,0 +1,61 @@
+package example;
+
+import io.github.chirino.memory.runtime.MemoryServiceProxy;
+import io.smallrye.common.annotation.Blocking;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * JAX-RS resource that proxies requests to the /v1/ownership-transfers endpoint so that the
+ * frontend can manage ownership transfers.
+ */
+@Path("/v1/ownership-transfers")
+@ApplicationScoped
+@Blocking
+public class OwnershipTransfersProxyResource {
+
+    @Inject MemoryServiceProxy proxy;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listPendingTransfers(@QueryParam("role") String role) {
+        return proxy.listPendingTransfers(role);
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response createOwnershipTransfer(String body) {
+        return proxy.createOwnershipTransfer(body);
+    }
+
+    @GET
+    @Path("/{transferId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getTransfer(@PathParam("transferId") String transferId) {
+        return proxy.getTransfer(transferId);
+    }
+
+    @DELETE
+    @Path("/{transferId}")
+    public Response deleteTransfer(@PathParam("transferId") String transferId) {
+        return proxy.deleteTransfer(transferId);
+    }
+
+    @POST
+    @Path("/{transferId}/accept")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response acceptTransfer(@PathParam("transferId") String transferId) {
+        return proxy.acceptTransfer(transferId);
+    }
+}

--- a/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/runtime/MemoryServiceProxy.java
+++ b/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/runtime/MemoryServiceProxy.java
@@ -12,6 +12,7 @@ import io.github.chirino.memory.client.api.SharingApi;
 import io.github.chirino.memory.client.model.Channel;
 import io.github.chirino.memory.client.model.CreateConversationRequest;
 import io.github.chirino.memory.client.model.CreateEntryRequest;
+import io.github.chirino.memory.client.model.CreateOwnershipTransferRequest;
 import io.github.chirino.memory.client.model.ForkFromEntryRequest;
 import io.github.chirino.memory.client.model.IndexTranscriptRequest;
 import io.github.chirino.memory.client.model.ShareConversationRequest;
@@ -187,6 +188,60 @@ public class MemoryServiceProxy {
             LOG.errorf(e, "Error parsing update membership request body");
             return handleException(e);
         }
+    }
+
+    public Response deleteConversationMembership(String conversationId, String userId) {
+        return executeVoid(
+                () -> sharingApi().deleteConversationMembership(toUuid(conversationId), userId),
+                NO_CONTENT,
+                "Error deleting membership for history %s, user %s",
+                conversationId,
+                userId);
+    }
+
+    public Response listPendingTransfers(String role) {
+        return execute(
+                () -> sharingApi().listPendingTransfers(role),
+                OK,
+                "Error listing pending transfers");
+    }
+
+    public Response createOwnershipTransfer(String body) {
+        try {
+            CreateOwnershipTransferRequest request =
+                    OBJECT_MAPPER.readValue(body, CreateOwnershipTransferRequest.class);
+            return execute(
+                    () -> sharingApi().createOwnershipTransfer(request),
+                    CREATED,
+                    "Error creating ownership transfer");
+        } catch (Exception e) {
+            LOG.errorf(e, "Error parsing create transfer request body");
+            return handleException(e);
+        }
+    }
+
+    public Response getTransfer(String transferId) {
+        return execute(
+                () -> sharingApi().getTransfer(toUuid(transferId)),
+                OK,
+                "Error getting transfer %s",
+                transferId);
+    }
+
+    public Response acceptTransfer(String transferId) {
+        return execute(
+                () -> sharingApi().acceptTransfer(toUuid(transferId)),
+                OK,
+                "Error accepting transfer %s",
+                transferId);
+    }
+
+    public Response deleteTransfer(String transferId) {
+        return executeVoid(
+                () -> sharingApi().deleteTransfer(toUuid(transferId)),
+                NO_CONTENT,
+                "Error deleting transfer %s",
+                transferId);
     }
 
     public Response indexConversationTranscript(String body) {

--- a/spring/examples/agent-spring/src/main/java/example/agent/CurrentUserController.java
+++ b/spring/examples/agent-spring/src/main/java/example/agent/CurrentUserController.java
@@ -1,0 +1,32 @@
+package example.agent;
+
+import java.util.Map;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Returns information about the current authenticated user.
+ */
+@RestController
+@RequestMapping("/v1/me")
+class CurrentUserController {
+
+    @GetMapping
+    public Map<String, String> getCurrentUser(@AuthenticationPrincipal OAuth2User oauth2User) {
+        if (oauth2User == null) {
+            return Map.of("userId", "anonymous");
+        }
+        // Try preferred_username first (standard OIDC claim), then fall back to name, then sub
+        String userId = oauth2User.getAttribute("preferred_username");
+        if (userId == null) {
+            userId = oauth2User.getAttribute("name");
+        }
+        if (userId == null) {
+            userId = oauth2User.getName();
+        }
+        return Map.of("userId", userId != null ? userId : "anonymous");
+    }
+}

--- a/spring/examples/agent-spring/src/main/java/example/agent/MemoryServiceProxyController.java
+++ b/spring/examples/agent-spring/src/main/java/example/agent/MemoryServiceProxyController.java
@@ -4,6 +4,7 @@ import io.github.chirino.memoryservice.client.MemoryServiceProxy;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -61,10 +62,29 @@ class MemoryServiceProxyController {
         return proxy.listConversationForks(conversationId);
     }
 
+    @GetMapping("/{conversationId}/memberships")
+    public ResponseEntity<?> listConversationMemberships(@PathVariable String conversationId) {
+        return proxy.listConversationMemberships(conversationId);
+    }
+
     @PostMapping("/{conversationId}/memberships")
     public ResponseEntity<?> shareConversation(
             @PathVariable String conversationId, @RequestBody String body) {
         return proxy.shareConversation(conversationId, body);
+    }
+
+    @PatchMapping("/{conversationId}/memberships/{userId}")
+    public ResponseEntity<?> updateConversationMembership(
+            @PathVariable String conversationId,
+            @PathVariable String userId,
+            @RequestBody String body) {
+        return proxy.updateConversationMembership(conversationId, userId, body);
+    }
+
+    @DeleteMapping("/{conversationId}/memberships/{userId}")
+    public ResponseEntity<?> deleteConversationMembership(
+            @PathVariable String conversationId, @PathVariable String userId) {
+        return proxy.deleteConversationMembership(conversationId, userId);
     }
 
     @DeleteMapping("/{conversationId}/response")

--- a/spring/examples/agent-spring/src/main/java/example/agent/OwnershipTransfersProxyController.java
+++ b/spring/examples/agent-spring/src/main/java/example/agent/OwnershipTransfersProxyController.java
@@ -1,0 +1,49 @@
+package example.agent;
+
+import io.github.chirino.memoryservice.client.MemoryServiceProxy;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/ownership-transfers")
+class OwnershipTransfersProxyController {
+
+    private final MemoryServiceProxy proxy;
+
+    OwnershipTransfersProxyController(MemoryServiceProxy proxy) {
+        this.proxy = proxy;
+    }
+
+    @GetMapping
+    public ResponseEntity<?> listPendingTransfers(
+            @RequestParam(value = "role", required = false) String role) {
+        return proxy.listPendingTransfers(role);
+    }
+
+    @PostMapping
+    public ResponseEntity<?> createOwnershipTransfer(@RequestBody String body) {
+        return proxy.createOwnershipTransfer(body);
+    }
+
+    @GetMapping("/{transferId}")
+    public ResponseEntity<?> getTransfer(@PathVariable String transferId) {
+        return proxy.getTransfer(transferId);
+    }
+
+    @DeleteMapping("/{transferId}")
+    public ResponseEntity<?> deleteTransfer(@PathVariable String transferId) {
+        return proxy.deleteTransfer(transferId);
+    }
+
+    @PostMapping("/{transferId}/accept")
+    public ResponseEntity<?> acceptTransfer(@PathVariable String transferId) {
+        return proxy.acceptTransfer(transferId);
+    }
+}


### PR DESCRIPTION
Add conversation sharing UI components and hooks:
- ShareModal with member list, add member form, and transfer ownership
- AccessLevelSelect dropdown with configurable open direction
- MemberListItem with overflow menu and pending transfer display
- useSharing and useCurrentUser React Query hooks

Add sharing API proxy endpoints to example applications:
- Quarkus: OwnershipTransfersProxyResource and sharing methods in proxy
- Spring: OwnershipTransfersProxyController and sharing methods in proxy

Change membership list access from manager-only to any member:
- Update PostgresMemoryStore and MongoMemoryStore to use READER access
- Update OpenAPI spec to document that any member can list memberships
- Update Cucumber tests (REST and gRPC) to expect success for readers