### PR TITLE
refactor: move security identity resolution from interceptor to store

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,33 +1,30 @@
 # TODO List
 
-* Getting latest memory of a conversation is likely to be a very frequently accessed operation: cache it.
-
-* Improve the langchain4j memory interface: Switch to the langchain4j MemoryChatStore once https://github.com/langchain4j/langchain4j/pull/4416 is released.
+* Make sure we record partial response in history if connection to LLM fails
 * Figure out how muli-modal content should be handled.
-* Implement conversation sharing / multi-user conversations (some backend is there, need front end using to demo)
-* require API_KEY for all api calls.
-* renaming summerization endpoints to search indexing..
+* Expose Metrics
+* Support OpenTracing
+* Improve the langchain4j memory interface: Switch to the langchain4j MemoryChatStore once https://github.com/langchain4j/langchain4j/pull/4416 is released.
+* Brand the project and move it to an org/foundation.
 
-* Review cache control headers
+# Hardening Work
+
+* require API_KEY for all api calls.
 * validate CreateMessageRequest.userId matches the bearer token principle.
 * test grpc resume redirects
 * test/find the message size limits of the app.
 * validate all api fields
 * protect against huge api requests.
-* Brand the project and move it to an org/foundation.
+
+# Performance Related
+
+* Getting latest memory of a conversation is likely to be a very frequently accessed operation: cache it.
+* are there any http cache/headers that could reduce load against the server?
 * Look into partitioning the messages table to improve pref.
-* Expose Metrics
-* Support OpenTracing
 
 # Need Dev Feedback for:
 
-* Conversations id are UUIDs.. should support any string?
-* Can the @RecordConversation bits be moved into Quarkus Langchain4j?
+* Can the @RecordConversation bits be moved into Quarkus Langchain4j? https://github.com/quarkiverse/quarkus-langchain4j/issues/2068#issuecomment-3816044002
 * Do we need multi-tenancy support?  What would it look like?
-* Ponder how best to kick off/manage async search indexing
 * How useful is the current summarize/index feature?
-* Should the Message type in the api contracts be renamed to something like Entry/Event/Posting (since it actually holds messages?)
-
-# Bug List
-
-* bug: make sure we record partial response in history if connection to LLM fails
+* Ponder how best to kick off/manage async search indexing maybe move this into the admin api?


### PR DESCRIPTION
Simplify ConversationInterceptor by moving security identity resolution and streaming adapter logic into ConversationStore. This makes the store more self-contained and reduces the interceptor's responsibilities.

- Add resolveIdentity() method to ConversationStore
- Add appendAgentMessage(String, Multi<String>) overload for streaming
- Add appendAgentMessage(String, String) overload that resolves token internally
- Remove unused imports and fields from ConversationInterceptor
- Reorganize TODO.md into logical sections