### PR TITLE
fix: persist partial LLM responses on upstream stream failure

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # TODO List
 
-* Make sure we record partial response in history if connection to LLM fails
 * Figure out how muli-modal content should be handled.
 * Expose Metrics
 * Support OpenTracing


### PR DESCRIPTION
Previously, when the LLM service terminated unexpectedly mid-stream, any tokens already received were lost. User cancellation and successful completion both persisted partial responses, but upstream failures did not.

Update both Quarkus ConversationStreamAdapter and Spring ConversationHistoryStreamAdvisor to persist buffered content in their failure handlers before propagating the error. This ensures conversation history captures partial responses regardless of how the stream ends.