### PR TITLE
feat: consolidate sync API to single entry with multi-message content

### DIFF
--- a/docs/enhancements/026-memory-perf.md
+++ b/docs/enhancements/026-memory-perf.md
@@ -1,0 +1,626 @@
+# Enhancement 026: Memory Channel SQL Access Pattern Analysis
+
+## Overview
+
+This document analyzes the primary SQL access patterns used when agents interact with the memory channel of conversations. The agent-facing API is designed for LLM context retrieval, particularly the `get` and `sync` operations that form the core agent workflow.
+
+## Agent Workflow
+
+Agents primarily perform two operations:
+
+1. **Get Messages** - Retrieve current memory entries for LLM context
+2. **Sync Messages** - Update memory entries when the agent's context changes
+
+These map to:
+- `GET /v1/conversations/{id}/entries?channel=memory&epoch=latest`
+- `POST /v1/conversations/{id}/entries/sync`
+
+## API Entry Points
+
+### Client Implementation
+
+The LangChain4j integration ([MemoryServiceChatMemoryStore.java](quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryServiceChatMemoryStore.java)) shows the typical agent pattern:
+
+```java
+// Get messages (line 64-70)
+conversationsApi().listConversationEntries(
+    UUID,           // conversationId
+    null,           // afterEntryId (cursor)
+    50,             // limit
+    Channel.MEMORY, // channel
+    null            // epoch (defaults to "latest")
+);
+
+// Sync messages (line 146-147)
+conversationsApi().syncConversationMemory(UUID, SyncEntriesRequest);
+```
+
+### Endpoint Implementations
+
+**ConversationsResource.java** handles these requests:
+- `listEntries()` (lines 169-234) - GET entries endpoint
+- `syncMemoryEntries()` (lines 291-331) - POST sync endpoint
+
+---
+
+## SQL Access Pattern: Get Messages (MEMORY Channel)
+
+### Call Flow
+
+```
+API Request
+    ↓
+ConversationsResource.listEntries()
+    ↓
+PostgresMemoryStore.getEntries() (line 631-664)
+    ↓
+PostgresMemoryStore.fetchMemoryEntries() (line 666-694)
+    ↓
+EntryRepository queries
+```
+
+### Query 1: Find Latest Epoch
+
+**Purpose**: Determine the most recent epoch for this agent's memory entries.
+
+**Repository Method**: [EntryRepository.findLatestMemoryEpoch()](memory-service/src/main/java/io/github/chirino/memory/persistence/repo/EntryRepository.java#L79-L95)
+
+```sql
+SELECT max(m.epoch)
+FROM entries m
+JOIN conversations c ON m.conversation_id = c.id
+JOIN conversation_groups g ON c.conversation_group_id = g.id
+WHERE m.conversation_id = :conversationId
+  AND m.channel = 'MEMORY'
+  AND m.client_id = :clientId
+  AND c.deleted_at IS NULL
+  AND g.deleted_at IS NULL
+```
+
+**Index Used**: `idx_entries_conversation_channel_client_epoch_created_at`
+```sql
+CREATE INDEX idx_entries_conversation_channel_client_epoch_created_at
+    ON entries (conversation_id, channel, client_id, epoch, created_at);
+```
+
+**Notes**:
+- Returns `NULL` if no memory entries exist for this conversation/client
+- Aggregate `max()` can use the index for efficient retrieval
+
+### Query 2: List Memory Entries by Epoch
+
+**Purpose**: Retrieve all entries from the latest epoch, ordered by creation time.
+
+**Repository Method**: [EntryRepository.listMemoryEntriesByEpoch()](memory-service/src/main/java/io/github/chirino/memory/persistence/repo/EntryRepository.java#L102-L136)
+
+```sql
+SELECT m.*
+FROM entries m
+JOIN conversations c ON m.conversation_id = c.id
+JOIN conversation_groups g ON c.conversation_group_id = g.id
+WHERE m.conversation_id = :conversationId
+  AND m.channel = 'MEMORY'
+  AND m.client_id = :clientId
+  AND m.epoch = :latestEpoch
+  AND c.deleted_at IS NULL
+  AND g.deleted_at IS NULL
+ORDER BY m.created_at, m.id
+LIMIT :limit
+```
+
+**Index Used**: `idx_entries_conversation_channel_client_epoch_created_at`
+
+**Pagination Variant** (when `afterEntryId` is provided):
+```sql
+-- First: lookup cursor entry to get its created_at
+SELECT * FROM entries WHERE id = :afterEntryId
+
+-- Then: add filter
+AND m.created_at > :cursorCreatedAt
+```
+
+### Total Queries for Get Messages
+
+| Scenario | Queries |
+|----------|---------|
+| First page, no entries exist | 1 (max epoch returns NULL, fallback to listByChannel) |
+| First page, entries exist | 2 (max epoch + list by epoch) |
+| Subsequent page | 3 (max epoch + cursor lookup + list by epoch) |
+
+---
+
+## SQL Access Pattern: Sync Messages
+
+### Call Flow
+
+```
+API Request
+    ↓
+ConversationsResource.syncMemoryEntries()
+    ↓
+PostgresMemoryStore.syncAgentEntries() (line 769-831)
+    ↓
+EntryRepository.findLatestMemoryEpoch()
+EntryRepository.listMemoryEntriesByEpoch()
+    ↓
+(comparison logic)
+    ↓
+PostgresMemoryStore.appendAgentEntries() (if changes detected)
+```
+
+### Query 1: Find Latest Epoch
+
+Same as Get Messages Query 1 above.
+
+### Query 2: Fetch All Entries from Latest Epoch
+
+**Purpose**: Load existing entries to compare against incoming sync request.
+
+**Repository Method**: [EntryRepository.listMemoryEntriesByEpoch()](memory-service/src/main/java/io/github/chirino/memory/persistence/repo/EntryRepository.java#L97-L100) (no-limit variant)
+
+```sql
+SELECT m.*
+FROM entries m
+JOIN conversations c ON m.conversation_id = c.id
+JOIN conversation_groups g ON c.conversation_group_id = g.id
+WHERE m.conversation_id = :conversationId
+  AND m.channel = 'MEMORY'
+  AND m.client_id = :clientId
+  AND m.epoch = :latestEpoch
+  AND c.deleted_at IS NULL
+  AND g.deleted_at IS NULL
+ORDER BY m.created_at, m.id
+```
+
+**Note**: Uses `Integer.MAX_VALUE` as limit to fetch ALL entries for comparison.
+
+### Sync Decision Logic
+
+After fetching existing entries, the sync compares content ([PostgresMemoryStore.java:786-830](memory-service/src/main/java/io/github/chirino/memory/store/impl/PostgresMemoryStore.java#L786-L830)):
+
+| Condition | Result | Queries |
+|-----------|--------|---------|
+| `existing == incoming` | No-op, return immediately | 2 (find epoch + list entries) |
+| `incoming` is prefix extension of `existing` | Append delta to current epoch | 2 + N inserts |
+| Otherwise | Create new epoch with all entries | 2 + M inserts |
+
+### Query 3: Insert Entry (Append)
+
+**Repository Method**: Direct entity persist via Panache
+
+```sql
+INSERT INTO entries (
+    id, conversation_id, conversation_group_id, user_id, client_id,
+    channel, epoch, content_type, content, created_at
+) VALUES (
+    :uuid, :conversationId, :groupId, :userId, :clientId,
+    'MEMORY', :epoch, :contentType, :encryptedContent, :now
+)
+```
+
+**Additional**: Update conversation timestamp
+```sql
+UPDATE conversations
+SET updated_at = :latestHistoryTimestamp
+WHERE id = :conversationId
+```
+
+### Total Queries for Sync
+
+| Scenario | Queries |
+|----------|---------|
+| No-op (exact match) | 2 |
+| Append to current epoch (N new entries) | 2 + N inserts + 1 update |
+| New epoch (M entries) | 2 + M inserts + 1 update |
+
+---
+
+## Database Schema
+
+### Entries Table
+
+```sql
+CREATE TABLE entries (
+    id                UUID PRIMARY KEY,
+    conversation_id   UUID NOT NULL REFERENCES conversations (id),
+    conversation_group_id UUID NOT NULL REFERENCES conversation_groups (id),
+    user_id           TEXT,
+    client_id         TEXT,          -- Agent identifier (from API key)
+    channel           TEXT NOT NULL, -- 'HISTORY', 'MEMORY', or 'TRANSCRIPT'
+    epoch             BIGINT,        -- Memory epoch (null for non-memory)
+    content_type      TEXT NOT NULL,
+    content           BYTEA NOT NULL,-- Encrypted JSON content
+    created_at        TIMESTAMPTZ NOT NULL
+);
+```
+
+### Relevant Indexes
+
+```sql
+-- Primary index for memory channel queries
+CREATE INDEX idx_entries_conversation_channel_client_epoch_created_at
+    ON entries (conversation_id, channel, client_id, epoch, created_at);
+
+-- Used for history channel and general queries
+CREATE INDEX idx_entries_conversation_created_at
+    ON entries (conversation_id, created_at);
+
+-- Used for group-level queries (forking)
+CREATE INDEX idx_entries_group_created_at
+    ON entries (conversation_group_id, created_at);
+```
+
+---
+
+## Access Pattern Summary
+
+### Memory Get Operation
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ GET /v1/conversations/{id}/entries?channel=memory&epoch=latest  │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Query 1: SELECT max(epoch) FROM entries                         │
+│          WHERE conversation_id=? AND channel='MEMORY'           │
+│          AND client_id=?                                        │
+│ Index: idx_entries_conversation_channel_client_epoch_created_at │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Query 2: SELECT * FROM entries                                  │
+│          WHERE conversation_id=? AND channel='MEMORY'           │
+│          AND client_id=? AND epoch=?                            │
+│          ORDER BY created_at, id LIMIT 50                       │
+│ Index: idx_entries_conversation_channel_client_epoch_created_at │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Memory Sync Operation
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ POST /v1/conversations/{id}/entries/sync                        │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Query 1: SELECT max(epoch) FROM entries                         │
+│          WHERE conversation_id=? AND channel='MEMORY'           │
+│          AND client_id=?                                        │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Query 2: SELECT * FROM entries                                  │
+│          WHERE conversation_id=? AND channel='MEMORY'           │
+│          AND client_id=? AND epoch=?                            │
+│          ORDER BY created_at, id (NO LIMIT - fetches all)       │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ Compare existing vs incoming messages                           │
+├─────────────────────────────────────────────────────────────────┤
+│ Case A: Exact match → No-op (0 writes)                          │
+│ Case B: Prefix extension → INSERT delta entries (N writes)      │
+│ Case C: Diverged → INSERT all entries with new epoch (M writes) │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Key Observations
+
+### Current Behavior
+
+1. **Two-query pattern**: Get and Sync both require finding max epoch before listing entries
+2. **Full fetch on sync**: Sync loads ALL existing entries to compare, not just count/hash
+3. **Content-level comparison**: Sync compares decrypted message content, not just entry IDs
+4. **Epoch isolation**: Each agent (clientId) has its own epoch sequence per conversation
+
+### Characteristics
+
+| Aspect | Observation |
+|--------|-------------|
+| Read amplification | Sync reads all entries even when only checking for no-op |
+| Index coverage | Primary index covers conversation+channel+client+epoch+created_at |
+| Join overhead | Every query joins conversations + conversation_groups for soft-delete check |
+| Content decryption | All entries are decrypted in memory for comparison |
+
+---
+
+---
+
+# Phase 1: Consolidate Sync to Single Entry
+
+## Motivation
+
+The current sync API accepts a `SyncEntriesRequest` containing a list of `CreateEntryRequest` objects, where each entry represents one message. This leads to:
+
+- **N inserts per sync**: When memory diverges, we insert M separate rows
+- **N inserts on append**: When extending, we insert N delta rows
+- **Row-per-message overhead**: Each message is a separate database row with its own UUID, timestamps, etc.
+
+## Proposed Change
+
+Change the sync API to accept a **single `CreateEntryRequest`** instead of `SyncEntriesRequest`. The entry's `content` array holds **all messages** in the agent's memory.
+
+### Current Model
+
+```
+SyncEntriesRequest {
+  entries: [
+    CreateEntryRequest { contentType: "LC4J", content: [msg1] },
+    CreateEntryRequest { contentType: "LC4J", content: [msg2] },
+    CreateEntryRequest { contentType: "LC4J", content: [msg3] },
+  ]
+}
+```
+
+Each entry becomes a separate database row:
+```
+entries table:
+| id    | epoch | content      |
+|-------|-------|--------------|
+| uuid1 | 1     | [msg1]       |
+| uuid2 | 1     | [msg2]       |
+| uuid3 | 1     | [msg3]       |
+```
+
+### Proposed Model
+
+```
+CreateEntryRequest {
+  contentType: "LC4J",
+  channel: "memory",
+  content: [msg1, msg2, msg3]  // All messages in one array
+}
+```
+
+Single database row per sync delta:
+```
+entries table:
+| id    | epoch | content              |
+|-------|-------|----------------------|
+| uuid1 | 1     | [msg1, msg2, msg3]   |
+```
+
+## API Changes
+
+### REST API
+
+**Current** (`POST /v1/conversations/{id}/entries/sync`):
+```yaml
+SyncEntriesRequest:
+  type: object
+  required:
+    - entries
+  properties:
+    entries:
+      type: array
+      items:
+        $ref: '#/components/schemas/CreateEntryRequest'
+```
+
+**Proposed**:
+```yaml
+# Reuse existing CreateEntryRequest directly
+# Request body is CreateEntryRequest, not SyncEntriesRequest
+```
+
+### gRPC API
+
+**Current**:
+```protobuf
+message SyncEntriesRequest {
+  bytes conversation_id = 1;
+  repeated CreateEntryRequest entries = 2;
+}
+
+rpc SyncEntries(SyncEntriesRequest) returns (SyncEntriesResponse);
+```
+
+**Proposed**:
+```protobuf
+message SyncEntryRequest {
+  bytes conversation_id = 1;
+  CreateEntryRequest entry = 2;  // Single entry, not repeated
+}
+
+rpc SyncEntry(SyncEntryRequest) returns (SyncEntryResponse);
+```
+
+## Sync Algorithm Changes
+
+### Comparison Logic
+
+The sync handler compares the incoming `content` array against the **flattened content** of all previous entries in the current epoch.
+
+```
+Existing entries (epoch=1):
+  Entry1.content = [msg1, msg2]
+  Entry2.content = [msg3]
+
+Flattened existing = [msg1, msg2, msg3]
+
+Incoming request:
+  content = [msg1, msg2, msg3, msg4, msg5]
+
+Result: Prefix extension detected
+  Delta to insert = [msg4, msg5] (as single new entry)
+```
+
+### Decision Matrix
+
+| Condition | Action | Inserts |
+|-----------|--------|---------|
+| `flattened_existing == incoming.content` | No-op | 0 |
+| `incoming.content` starts with `flattened_existing` | Append delta entry | 1 |
+| Any previous entry has different `contentType` | Diverged → new epoch | 1 |
+| Content mismatch | Diverged → new epoch | 1 |
+
+### Divergence Detection
+
+A sync is considered **diverged** if:
+
+1. **Content mismatch**: The incoming content doesn't start with the flattened existing content
+2. **ContentType mismatch**: Any previous entry in the epoch has a different `contentType` than the incoming request
+
+```java
+// Pseudo-code for divergence check
+boolean isDiverged(List<Entry> existingEntries, CreateEntryRequest incoming) {
+    // Check contentType consistency
+    for (Entry e : existingEntries) {
+        if (!e.getContentType().equals(incoming.getContentType())) {
+            return true;  // Diverged due to contentType change
+        }
+    }
+
+    // Flatten existing content
+    List<Object> flattenedExisting = existingEntries.stream()
+        .flatMap(e -> e.getContent().stream())
+        .toList();
+
+    // Check if incoming is prefix extension
+    return !isPrefix(flattenedExisting, incoming.getContent());
+}
+```
+
+## SQL Impact
+
+### Before (Current)
+
+```
+Sync with 10 new messages:
+  Query 1: SELECT max(epoch) ...
+  Query 2: SELECT * FROM entries WHERE epoch=? ...
+  Insert 1: INSERT INTO entries ... (msg1)
+  Insert 2: INSERT INTO entries ... (msg2)
+  ...
+  Insert 10: INSERT INTO entries ... (msg10)
+  Update: UPDATE conversations SET updated_at=...
+
+Total: 2 queries + 10 inserts + 1 update = 13 operations
+```
+
+### After (Proposed)
+
+```
+Sync with 10 new messages:
+  Query 1: SELECT max(epoch) ...
+  Query 2: SELECT * FROM entries WHERE epoch=? ...
+  Insert 1: INSERT INTO entries ... ([msg1..msg10] as delta)
+  Update: UPDATE conversations SET updated_at=...
+
+Total: 2 queries + 1 insert + 1 update = 4 operations
+```
+
+### Reduction Summary
+
+| Scenario | Current | Proposed | Reduction |
+|----------|---------|----------|-----------|
+| Append N messages | 2 + N + 1 | 2 + 1 + 1 | N-1 inserts saved |
+| New epoch (M messages) | 2 + M + 1 | 2 + 1 + 1 | M-1 inserts saved |
+| No-op | 2 | 2 | No change |
+
+## Get Messages Impact
+
+The `GET /entries?channel=memory` endpoint must reconstruct the message list from potentially multiple entries:
+
+```java
+// Current: Each entry = one message
+List<Message> messages = entries.stream()
+    .map(e -> decodeMessage(e.getContent().get(0)))
+    .toList();
+
+// Proposed: Flatten content arrays from all entries
+List<Message> messages = entries.stream()
+    .flatMap(e -> e.getContent().stream())
+    .map(this::decodeMessage)
+    .toList();
+```
+
+This is a minor change with no SQL impact.
+
+## Client Library Updates
+
+### LangChain4j Integration
+
+**Current** ([MemoryServiceChatMemoryStore.java](quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryServiceChatMemoryStore.java)):
+```java
+// Line 136-147: Creates one CreateEntryRequest per message
+List<CreateEntryRequest> entries = messages.stream()
+    .map(this::toCreateEntryRequest)
+    .toList();
+SyncEntriesRequest request = new SyncEntriesRequest();
+request.setEntries(entries);
+conversationsApi().syncConversationMemory(conversationId, request);
+```
+
+**Proposed**:
+```java
+// Single entry with all messages in content array
+CreateEntryRequest entry = new CreateEntryRequest();
+entry.setChannel(Channel.MEMORY);
+entry.setContentType("LC4J");
+entry.setContent(messages.stream()
+    .map(this::encodeMessage)
+    .toList());
+conversationsApi().syncConversationMemory(conversationId, entry);
+```
+
+## Migration Considerations
+
+### Backward Compatibility
+
+The new sync endpoint can coexist with the old one during migration:
+
+- `POST /v1/conversations/{id}/entries/sync` (old) - accepts `SyncEntriesRequest`
+- `POST /v1/conversations/{id}/memory/sync` (new) - accepts `CreateEntryRequest`
+
+Or deprecate the old endpoint and require client updates.
+
+### Existing Data
+
+Existing entries with single-message content arrays remain valid. The get/sync logic handles both:
+- Old entries: `content = [single_message]`
+- New entries: `content = [msg1, msg2, ..., msgN]`
+
+The flattening logic works uniformly across both formats.
+
+## Implementation Checklist
+
+- [x] Update OpenAPI spec (`openapi.yml`)
+  - [x] Modify existing sync endpoint to accept `CreateEntryRequest`
+  - [x] Update response schema (`SyncEntryResponse` with single `entry`)
+- [x] Update Proto definition (`memory_service.proto`)
+  - [x] Change `SyncEntriesRequest.entries` (repeated) to `entry` (singular)
+  - [x] Change `SyncEntriesResponse.entries` (repeated) to `entry` (optional)
+- [x] Regenerate API clients
+- [x] Update `PostgresMemoryStore.syncAgentEntry()`
+  - [x] Accept single `CreateEntryRequest`
+  - [x] Implement flattened content comparison
+  - [x] Handle contentType divergence check
+- [x] Update `MongoMemoryStore.syncAgentEntry()`
+- [x] Update `MemorySyncHelper`
+  - [x] Add `flattenContent()` utility
+  - [x] Add `contentEquals()` and `isContentPrefix()` methods
+  - [x] Add `extractDelta()` and `withEpochAndContent()` methods
+- [x] Update `ConversationsResource.syncMemoryEntries()`
+- [x] Update `EntriesGrpcService.syncEntries()`
+- [x] Update LangChain4j client (`MemoryServiceChatMemoryStore`)
+- [x] Update Spring AI client (`MemoryServiceChatMemoryRepository`)
+- [x] Add/update tests (cucumber feature files and step definitions)
+
+---
+
+## Future Optimization Opportunities
+
+*(To be analyzed in follow-up phases)*
+
+- Combine max(epoch) + list into single query
+- Add content hash for quick no-op detection without full fetch
+- Consider materialized view for latest epoch per conversation/client
+- Evaluate if soft-delete joins can be eliminated for memory-only queries

--- a/memory-service-contracts/src/main/resources/memory/v1/memory_service.proto
+++ b/memory-service-contracts/src/main/resources/memory/v1/memory_service.proto
@@ -24,10 +24,19 @@ message PageInfo {
   string next_page_token = 1;
 }
 
+// ConversationListMode controls which conversations are returned from each fork tree.
+// Conversations can be forked to create branches. All forks share the same
+// "conversation group" (fork tree). This mode determines which conversations
+// from each fork tree are included in list results.
 enum ConversationListMode {
+  // Unspecified defaults to LATEST_FORK.
   CONVERSATION_LIST_MODE_UNSPECIFIED = 0;
+  // Include all conversations the user can access (roots and forks).
   ALL = 1;
+  // Only include root conversations (conversations that are not forks).
   ROOTS = 2;
+  // Include only the most recently updated conversation per fork tree (default).
+  // This is useful for showing a single representative conversation from each tree.
   LATEST_FORK = 3;
 }
 
@@ -100,7 +109,10 @@ message CreateConversationRequest {
 }
 
 message ListConversationsRequest {
+  // Controls which conversations are returned from each fork tree.
+  // See ConversationListMode for details on each mode.
   ConversationListMode mode = 1;
+  // Optional text query for basic title/metadata search.
   string query = 2;
   PageRequest page = 3;
 }
@@ -148,14 +160,18 @@ message CreateEntryRequest {
 message SyncEntriesRequest {
   // Conversation identifier (UUID as 16-byte big-endian binary)
   bytes conversation_id = 1;
-  repeated CreateEntryRequest entries = 2;
+  // Single entry containing all messages in the agent's memory.
+  // The content array holds all messages; comparison is done against
+  // the flattened content of existing entries in the latest epoch.
+  CreateEntryRequest entry = 2;
 }
 
 message SyncEntriesResponse {
   optional int64 epoch = 1;
   bool no_op = 2;
   bool epoch_incremented = 3;
-  repeated Entry entries = 4;
+  // The entry that was appended during this sync, or empty if no-op.
+  optional Entry entry = 4;
 }
 
 message AppendEntryRequest {
@@ -303,6 +319,9 @@ service SystemService {
 }
 
 service ConversationsService {
+  // ListConversations returns conversations the user has access to.
+  // The mode parameter controls which conversations from each fork tree are returned.
+  // See ConversationListMode for available modes.
   rpc ListConversations(ListConversationsRequest) returns (ListConversationsResponse);
   rpc CreateConversation(CreateConversationRequest) returns (Conversation);
   rpc GetConversation(GetConversationRequest) returns (Conversation);

--- a/memory-service-contracts/src/main/resources/openapi-admin.yml
+++ b/memory-service-contracts/src/main/resources/openapi-admin.yml
@@ -43,8 +43,26 @@ paths:
       description: |-
         Lists conversations across all users. Supports filtering by userId,
         deleted status, and date ranges. Requires auditor or admin role.
+
+        **Fork Tree Behavior**: Conversations can be forked to create branches. All forks
+        share the same "conversation group" (fork tree). The `mode` parameter controls
+        which conversations from each fork tree are returned.
       operationId: adminListConversations
       parameters:
+        - name: mode
+          in: query
+          required: false
+          description: |-
+            Listing mode for conversations. Controls which conversations are returned
+            from each fork tree (conversation group).
+            - `all`: include all conversations (roots and forks).
+            - `roots`: only include root conversations (conversations that are not forks).
+            - `latest-fork`: include only the most recently updated conversation per fork tree.
+              This is useful for showing a single representative conversation from each tree.
+          schema:
+            type: string
+            enum: [all, roots, latest-fork]
+            default: latest-fork
         - name: userId
           in: query
           required: false

--- a/memory-service-contracts/src/main/resources/openapi.yml
+++ b/memory-service-contracts/src/main/resources/openapi.yml
@@ -28,20 +28,26 @@ paths:
       summary: List conversations visible to current user
       description: |-
         Lists all conversations the current user has access to (owner, manager, writer, or reader).
+
+        **Fork Tree Behavior**: Conversations can be forked to create branches. All forks
+        share the same "conversation group" (fork tree). The `mode` parameter controls
+        which conversations from each fork tree are returned.
       operationId: listConversations
       parameters:
         - name: mode
           in: query
           required: false
           description: |-
-            Listing mode for conversations.
+            Listing mode for conversations. Controls which conversations are returned
+            from each fork tree (conversation group).
             - `all`: include all conversations the user can access (roots and forks).
-            - `roots`: only include root conversations.
-            - `latest-fork`: include the most recently updated conversation per root tree.
+            - `roots`: only include root conversations (conversations that are not forks).
+            - `latest-fork`: include only the most recently updated conversation per fork tree.
+              This is useful for showing a single representative conversation from each tree.
           schema:
             type: string
             enum: [all, roots, latest-fork]
-            default: all
+            default: latest-fork
         - name: after
           in: query
           required: false
@@ -285,14 +291,18 @@ paths:
       tags: [Conversations]
       summary: Synchronize the agent memory epoch
       description: |-
-        Synchronizes the in-memory context for the conversation. The service fails
-        when any entry is not targeting the `memory` channel, then compares the
-        provided list to the entries already stored in the latest memory epoch.
-        If there is no difference it is a no-op, if the list merely appends more
-        entries they are added to the current epoch, otherwise a new epoch is
-        created and all provided entries are stored under the new epoch. Memory
-        sync is scoped to the calling client id (from the API key). Requires a
-        valid agent API key.
+        Synchronizes the in-memory context for the conversation. The request body
+        is a single entry whose `content` array contains all messages in the agent's
+        memory. The service compares this content against the flattened content of
+        all entries in the latest memory epoch.
+
+        If the content matches exactly, it's a no-op. If the incoming content is a
+        prefix extension (starts with existing content plus new items), only the
+        delta is appended to the current epoch. Otherwise, a new epoch is created
+        with the delta content.
+
+        The entry must target the `memory` channel. Memory sync is scoped to the
+        calling client id (from the API key). Requires a valid agent API key.
       operationId: syncConversationMemory
       parameters:
         - name: conversationId
@@ -307,14 +317,14 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SyncEntriesRequest'
+              $ref: '#/components/schemas/CreateEntryRequest'
       responses:
         '200':
           description: Result of the sync operation.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SyncEntriesResponse'
+                $ref: '#/components/schemas/SyncEntryResponse'
         '404':
           $ref: '#/components/responses/NotFound'
         default:
@@ -1113,35 +1123,7 @@ components:
           - type: "text"
             text: "Based on your past chats, here are three possible approaches…"
 
-    SyncEntriesRequest:
-      type: object
-      required:
-        - entries
-      properties:
-        entries:
-          type: array
-          description: |-
-            The desired memory epoch contents. Each entry must include the
-            `memory` channel and should match the ordering that the agent expects to
-            see replayed; only the agent may call this endpoint.
-          items:
-            $ref: '#/components/schemas/CreateEntryRequest'
-      example:
-        entries:
-          - userId: "user_1234"
-            channel: "memory"
-            contentType: "LC4J"
-            content:
-              - type: "text"
-                text: "The user asked about memory sync."
-          - userId: "user_1234"
-            channel: "memory"
-            contentType: "LC4J"
-            content:
-              - type: "text"
-                text: "I learned that child steps matter."
-
-    SyncEntriesResponse:
+    SyncEntryResponse:
       type: object
       properties:
         epoch:
@@ -1155,26 +1137,27 @@ components:
         epochIncremented:
           type: boolean
           description: True when the provided list diverged and a new epoch was started.
-        entries:
-          type: array
-          description: List of entries that were appended during this sync.
-          items:
-            $ref: '#/components/schemas/Entry'
+        entry:
+          $ref: '#/components/schemas/Entry'
+          nullable: true
+          description: The entry that was appended during this sync, or null if no-op.
       example:
         epoch: 5
         noOp: false
         epochIncremented: true
-        entries:
-          - id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
-            conversationId: "550e8400-e29b-41d4-a716-446655440000"
-            userId: "agent_memory"
-            channel: "memory"
-            epoch: 5
-            contentType: "LC4J"
-            content:
-              - type: "text"
-                text: "Updated memory after re-sync."
-            createdAt: "2025-01-10T14:40:12Z"
+        entry:
+          id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+          conversationId: "550e8400-e29b-41d4-a716-446655440000"
+          userId: "agent_memory"
+          channel: "memory"
+          epoch: 5
+          contentType: "LC4J"
+          content:
+            - type: "text"
+              text: "First message in memory."
+            - type: "text"
+              text: "Second message added during sync."
+          createdAt: "2025-01-10T14:40:12Z"
 
     IndexTranscriptRequest:
       type: object

--- a/memory-service/src/main/java/io/github/chirino/memory/api/AdminResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/AdminResource.java
@@ -85,6 +85,7 @@ public class AdminResource {
     @GET
     @Path("/conversations")
     public Response listConversations(
+            @QueryParam("mode") String mode,
             @QueryParam("userId") String userId,
             @QueryParam("includeDeleted") @jakarta.ws.rs.DefaultValue("false")
                     boolean includeDeleted,
@@ -97,6 +98,7 @@ public class AdminResource {
         try {
             roleResolver.requireAuditor(identity, apiKeyContext);
             Map<String, Object> params = new HashMap<>();
+            params.put("mode", mode);
             params.put("userId", userId);
             params.put("includeDeleted", includeDeleted);
             params.put("onlyDeleted", onlyDeleted);
@@ -104,6 +106,7 @@ public class AdminResource {
                     "listConversations", params, justification, identity, apiKeyContext);
 
             AdminConversationQuery query = new AdminConversationQuery();
+            query.setMode(ConversationListMode.fromQuery(mode));
             query.setUserId(userId);
             query.setIncludeDeleted(includeDeleted);
             query.setOnlyDeleted(onlyDeleted);

--- a/memory-service/src/main/java/io/github/chirino/memory/api/ConversationListMode.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/ConversationListMode.java
@@ -20,7 +20,7 @@ public enum ConversationListMode {
 
     public static ConversationListMode fromQuery(String value) {
         if (value == null || value.isBlank()) {
-            return ALL;
+            return LATEST_FORK;
         }
         for (ConversationListMode mode : values()) {
             if (mode.queryValue.equals(value)) {

--- a/memory-service/src/main/java/io/github/chirino/memory/api/dto/SyncResult.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/dto/SyncResult.java
@@ -1,14 +1,11 @@
 package io.github.chirino.memory.api.dto;
 
-import java.util.Collections;
-import java.util.List;
-
 public class SyncResult {
 
     private Long epoch;
     private boolean noOp;
     private boolean epochIncremented;
-    private List<EntryDto> entries = Collections.emptyList();
+    private EntryDto entry;
 
     public Long getEpoch() {
         return epoch;
@@ -34,11 +31,11 @@ public class SyncResult {
         this.epochIncremented = epochIncremented;
     }
 
-    public List<EntryDto> getEntries() {
-        return entries;
+    public EntryDto getEntry() {
+        return entry;
     }
 
-    public void setEntries(List<EntryDto> entries) {
-        this.entries = entries != null ? entries : Collections.emptyList();
+    public void setEntry(EntryDto entry) {
+        this.entry = entry;
     }
 }

--- a/memory-service/src/main/java/io/github/chirino/memory/grpc/ConversationsGrpcService.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/grpc/ConversationsGrpcService.java
@@ -160,12 +160,12 @@ public class ConversationsGrpcService extends AbstractGrpcService implements Con
     private static ConversationListMode toConversationListMode(
             io.github.chirino.memory.grpc.v1.ConversationListMode mode) {
         if (mode == null) {
-            return ConversationListMode.ALL;
+            return ConversationListMode.LATEST_FORK;
         }
         return switch (mode) {
             case ROOTS -> ConversationListMode.ROOTS;
-            case LATEST_FORK -> ConversationListMode.LATEST_FORK;
-            default -> ConversationListMode.ALL;
+            case ALL -> ConversationListMode.ALL;
+            default -> ConversationListMode.LATEST_FORK;
         };
     }
 }

--- a/memory-service/src/main/java/io/github/chirino/memory/model/AdminConversationQuery.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/model/AdminConversationQuery.java
@@ -1,9 +1,11 @@
 package io.github.chirino.memory.model;
 
+import io.github.chirino.memory.api.ConversationListMode;
 import java.time.OffsetDateTime;
 
 public class AdminConversationQuery {
 
+    private ConversationListMode mode = ConversationListMode.LATEST_FORK;
     private String userId;
     private boolean includeDeleted;
     private boolean onlyDeleted;
@@ -11,6 +13,14 @@ public class AdminConversationQuery {
     private OffsetDateTime deletedBefore;
     private String after;
     private int limit;
+
+    public ConversationListMode getMode() {
+        return mode;
+    }
+
+    public void setMode(ConversationListMode mode) {
+        this.mode = mode != null ? mode : ConversationListMode.LATEST_FORK;
+    }
 
     public String getUserId() {
         return userId;

--- a/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
@@ -85,11 +85,8 @@ public interface MemoryStore {
             List<CreateEntryRequest> entries,
             String clientId);
 
-    SyncResult syncAgentEntries(
-            String userId,
-            String conversationId,
-            List<CreateEntryRequest> entries,
-            String clientId);
+    SyncResult syncAgentEntry(
+            String userId, String conversationId, CreateEntryRequest entry, String clientId);
 
     EntryDto indexTranscript(IndexTranscriptRequest request, String clientId);
 

--- a/memory-service/src/main/java/io/github/chirino/memory/store/impl/MemorySyncHelper.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/impl/MemorySyncHelper.java
@@ -15,6 +15,128 @@ public final class MemorySyncHelper {
 
     private MemorySyncHelper() {}
 
+    /**
+     * Flattens the content arrays from multiple entries into a single list. This is used to compare
+     * the incoming sync request (single entry with all messages) against existing entries (which
+     * may have content spread across multiple entries).
+     */
+    public static List<Object> flattenContent(List<EntryDto> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<Object> result = new ArrayList<>();
+        for (EntryDto entry : entries) {
+            if (entry != null && entry.getContent() != null) {
+                result.addAll(entry.getContent());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Checks if all entries have the same contentType as the incoming request. Returns true if
+     * there's a contentType mismatch (diverged).
+     */
+    public static boolean hasContentTypeMismatch(
+            List<EntryDto> entries, String incomingContentType) {
+        if (entries == null || entries.isEmpty()) {
+            return false;
+        }
+        for (EntryDto entry : entries) {
+            if (entry != null && !Objects.equals(entry.getContentType(), incomingContentType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Compares two content lists for equality using JSON comparison to handle Map type differences.
+     */
+    public static boolean contentEquals(List<Object> existing, List<Object> incoming) {
+        if (existing == null && incoming == null) {
+            return true;
+        }
+        if (existing == null || incoming == null) {
+            return false;
+        }
+        if (existing.size() != incoming.size()) {
+            return false;
+        }
+        try {
+            JsonNode existingNode = OBJECT_MAPPER.valueToTree(existing);
+            JsonNode incomingNode = OBJECT_MAPPER.valueToTree(incoming);
+            return existingNode.equals(incomingNode);
+        } catch (Exception e) {
+            return Objects.equals(existing, incoming);
+        }
+    }
+
+    /**
+     * Checks if the existing content is a prefix of the incoming content. Returns true if incoming
+     * starts with all items from existing.
+     */
+    public static boolean isContentPrefix(List<Object> existing, List<Object> incoming) {
+        if (existing == null || existing.isEmpty()) {
+            return true;
+        }
+        if (incoming == null || incoming.size() < existing.size()) {
+            return false;
+        }
+        try {
+            for (int i = 0; i < existing.size(); i++) {
+                JsonNode existingNode = OBJECT_MAPPER.valueToTree(existing.get(i));
+                JsonNode incomingNode = OBJECT_MAPPER.valueToTree(incoming.get(i));
+                if (!existingNode.equals(incomingNode)) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            // Fallback to direct comparison
+            for (int i = 0; i < existing.size(); i++) {
+                if (!Objects.equals(existing.get(i), incoming.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    /**
+     * Extracts the delta (new content items) from incoming that aren't in existing. Assumes
+     * isContentPrefix has already returned true.
+     */
+    public static List<Object> extractDelta(List<Object> existing, List<Object> incoming) {
+        if (existing == null || existing.isEmpty()) {
+            return incoming != null ? new ArrayList<>(incoming) : Collections.emptyList();
+        }
+        if (incoming == null || incoming.size() <= existing.size()) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(incoming.subList(existing.size(), incoming.size()));
+    }
+
+    /**
+     * Creates a CreateEntryRequest with the specified epoch and delta content.
+     */
+    public static CreateEntryRequest withEpochAndContent(
+            CreateEntryRequest original, Long epoch, List<Object> deltaContent) {
+        CreateEntryRequest copy = new CreateEntryRequest();
+        copy.setUserId(original != null ? original.getUserId() : null);
+        copy.setChannel(CreateEntryRequest.ChannelEnum.MEMORY);
+        copy.setEpoch(epoch);
+        copy.setContentType(original != null ? original.getContentType() : null);
+        copy.setContent(deltaContent);
+        return copy;
+    }
+
+    public static Long nextEpoch(Long current) {
+        return current == null ? 1L : current + 1;
+    }
+
+    // ============ Legacy methods for backward compatibility ============
+
     public static List<MessageContent> fromRequests(List<CreateEntryRequest> requests) {
         if (requests == null || requests.isEmpty()) {
             return Collections.emptyList();
@@ -71,10 +193,6 @@ public final class MemorySyncHelper {
             normalized.add(copy);
         }
         return normalized;
-    }
-
-    public static Long nextEpoch(Long current) {
-        return current == null ? 1L : current + 1;
     }
 
     public static final class MessageContent {

--- a/memory-service/src/test/java/io/github/chirino/memory/cucumber/StepDefinitions.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/cucumber/StepDefinitions.java
@@ -1008,6 +1008,44 @@ public class StepDefinitions {
         assertThat("Sync response should contain " + count + " entries", entries.size(), is(count));
     }
 
+    @io.cucumber.java.en.Then("the sync response entry should be null")
+    public void theSyncResponseEntryShouldBeNull() {
+        trackUsage();
+        if (lastResponse == null) {
+            throw new AssertionError("No response has been received");
+        }
+        JsonPath jsonPath = lastResponse.jsonPath();
+        Object entry = jsonPath.get("entry");
+        assertThat("Sync response entry should be null", entry, is(nullValue()));
+    }
+
+    @io.cucumber.java.en.Then("the sync response entry should not be null")
+    public void theSyncResponseEntryShouldNotBeNull() {
+        trackUsage();
+        if (lastResponse == null) {
+            throw new AssertionError("No response has been received");
+        }
+        JsonPath jsonPath = lastResponse.jsonPath();
+        Object entry = jsonPath.get("entry");
+        assertThat("Sync response entry should not be null", entry, is(notNullValue()));
+    }
+
+    @io.cucumber.java.en.Then("the sync response entry content should be empty")
+    public void theSyncResponseEntryContentShouldBeEmpty() {
+        trackUsage();
+        if (lastResponse == null) {
+            throw new AssertionError("No response has been received");
+        }
+        JsonPath jsonPath = lastResponse.jsonPath();
+        Object entry = jsonPath.get("entry");
+        assertThat("Sync response entry should not be null", entry, is(notNullValue()));
+        List<?> content = jsonPath.getList("entry.content");
+        assertThat(
+                "Sync response entry content should be empty",
+                content == null || content.isEmpty(),
+                is(true));
+    }
+
     @io.cucumber.java.en.When("I create a summary with request:")
     public void iCreateASummaryWithRequest(String requestBody) {
         trackUsage();
@@ -1091,28 +1129,35 @@ public class StepDefinitions {
     @io.cucumber.java.en.When("I list conversations")
     public void iListConversations() {
         trackUsage();
-        iListConversationsWithParams(null, null, null);
+        iListConversationsWithParams(null, null, null, null);
     }
 
     @io.cucumber.java.en.When("I list conversations with limit {int}")
     public void iListConversationsWithLimit(int limit) {
         trackUsage();
-        iListConversationsWithParams(null, limit, null);
+        iListConversationsWithParams(null, limit, null, null);
     }
 
     @io.cucumber.java.en.When("I list conversations with limit {int} and after {string}")
     public void iListConversationsWithLimitAndAfter(int limit, String after) {
         trackUsage();
-        iListConversationsWithParams(after, limit, null);
+        iListConversationsWithParams(after, limit, null, null);
     }
 
     @io.cucumber.java.en.When("I list conversations with query {string}")
     public void iListConversationsWithQuery(String query) {
         trackUsage();
-        iListConversationsWithParams(null, null, query);
+        iListConversationsWithParams(null, null, query, null);
     }
 
-    private void iListConversationsWithParams(String after, Integer limit, String query) {
+    @io.cucumber.java.en.When("I list conversations with mode {string}")
+    public void iListConversationsWithMode(String mode) {
+        trackUsage();
+        iListConversationsWithParams(null, null, null, mode);
+    }
+
+    private void iListConversationsWithParams(
+            String after, Integer limit, String query, String mode) {
         var requestSpec = given();
         requestSpec = authenticateRequest(requestSpec);
         var request = requestSpec.when();
@@ -1124,6 +1169,9 @@ public class StepDefinitions {
         }
         if (query != null) {
             request = request.queryParam("query", query);
+        }
+        if (mode != null) {
+            request = request.queryParam("mode", mode);
         }
         this.lastResponse = request.get("/v1/conversations");
     }
@@ -1779,6 +1827,35 @@ public class StepDefinitions {
     public void theGrpcResponseShouldContainEntries(int count) {
         trackUsage();
         assertGrpcEntryCount(count);
+    }
+
+    @io.cucumber.java.en.Then("the gRPC response should have entry")
+    public void theGrpcResponseShouldHaveEntry() {
+        trackUsage();
+        JsonPath jsonPath = ensureGrpcJsonPath();
+        Object entry = jsonPath.get("entry");
+        assertThat("gRPC response should have entry", entry, is(notNullValue()));
+    }
+
+    @io.cucumber.java.en.Then("the gRPC response should not have entry")
+    public void theGrpcResponseShouldNotHaveEntry() {
+        trackUsage();
+        JsonPath jsonPath = ensureGrpcJsonPath();
+        Object entry = jsonPath.get("entry");
+        assertThat("gRPC response should not have entry", entry, is(nullValue()));
+    }
+
+    @io.cucumber.java.en.Then("the gRPC response entry content should be empty")
+    public void theGrpcResponseEntryContentShouldBeEmpty() {
+        trackUsage();
+        JsonPath jsonPath = ensureGrpcJsonPath();
+        Object entry = jsonPath.get("entry");
+        assertThat("gRPC response should have entry", entry, is(notNullValue()));
+        List<?> content = jsonPath.getList("entry.content");
+        assertThat(
+                "gRPC response entry content should be empty",
+                content == null || content.isEmpty(),
+                is(true));
     }
 
     @io.cucumber.java.en.Then("the gRPC response field {string} should be {string}")


### PR DESCRIPTION
Change the memory sync endpoint to accept a single CreateEntryRequest where the content array contains all messages, instead of a list of separate entries. This reduces database inserts from N (one per message) to 1 (single entry containing all messages).

Key changes:
- API: POST /entries/sync now accepts CreateEntryRequest directly
- gRPC: SyncEntriesRequest.entry (singular) replaces entries (repeated)
- Response: SyncEntryResponse.entry replaces entries array
- Sync logic: Compare flattened content arrays using JSON comparison
- Clients: LangChain4j and Spring AI updated to batch all messages

Benefits:
- Reduced write amplification on sync (N inserts → 1 insert)
- Simpler API contract for agent developers
- Content-level delta detection for append optimization