### PR TITLE
improve apis for sync and admin 

### DIFF
--- a/memory-service-contracts/src/main/resources/openapi-admin.yml
+++ b/memory-service-contracts/src/main/resources/openapi-admin.yml
@@ -346,6 +346,51 @@ paths:
       security:
         - BearerAuth: []
 
+  /v1/admin/conversations/{id}/forks:
+    get:
+      tags: [Admin]
+      summary: List forks for any conversation (admin/auditor)
+      description: |-
+        Returns all forked conversations that share the same root conversation as the
+        given conversation. Each fork entry includes the message id at which it forked
+        and the timestamp when the forked conversation was created.
+
+        This endpoint provides admin access to fork information for any conversation,
+        regardless of ownership. Requires auditor or admin role.
+      operationId: adminListForks
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Conversation identifier (UUID format).
+          schema:
+            type: string
+            format: uuid
+        - name: justification
+          in: query
+          required: false
+          description: Reason for this admin action (for audit log).
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Forked conversations related to this conversation's root.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ConversationForkSummary'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        default:
+          $ref: '#/components/responses/Error'
+      security:
+        - BearerAuth: []
+
   /v1/admin/conversations/search:
     post:
       tags: [Admin]
@@ -644,6 +689,30 @@ components:
           type: string
         accessLevel:
           $ref: '#/components/schemas/AccessLevel'
+        createdAt:
+          type: string
+          format: date-time
+
+    ConversationForkSummary:
+      type: object
+      description: Summary of a forked conversation originating at a given entry.
+      properties:
+        conversationId:
+          type: string
+          format: uuid
+          description: Unique identifier for the forked conversation.
+        forkedAtEntryId:
+          type: string
+          format: uuid
+          description: Entry ID at which this forked conversation diverged.
+        forkedAtConversationId:
+          type: string
+          format: uuid
+          nullable: true
+          description: Conversation ID where the fork occurred.
+        title:
+          type: string
+          nullable: true
         createdAt:
           type: string
           format: date-time

--- a/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
@@ -105,6 +105,8 @@ public interface MemoryStore {
 
     List<ConversationMembershipDto> adminListMemberships(String conversationId);
 
+    List<ConversationForkSummaryDto> adminListForks(String conversationId);
+
     List<SearchResultDto> adminSearchEntries(AdminSearchQuery query);
 
     // Eviction support


### PR DESCRIPTION
[feat: consolidate sync API to single entry with multi-message content](https://github.com/chirino/memory-service/commit/12d27c1a18af3af0f5b68068a2d81e170cccbb4b) 

Change the memory sync endpoint to accept a single CreateEntryRequest
where the content array contains all messages, instead of a list of
separate entries. This reduces database inserts from N (one per message)
to 1 (single entry containing all messages).

Key changes:
- API: POST /entries/sync now accepts CreateEntryRequest directly
- gRPC: SyncEntriesRequest.entry (singular) replaces entries (repeated)
- Response: SyncEntryResponse.entry replaces entries array
- Sync logic: Compare flattened content arrays using JSON comparison
- Clients: LangChain4j and Spring AI updated to batch all messages

Benefits:
- Reduced write amplification on sync (N inserts → 1 insert)
- Simpler API contract for agent developers
- Content-level delta detection for append optimization


[feat: add admin endpoint for listing conversation forks](https://github.com/chirino/memory-service/commit/2c01e062166c0afb267c07cee45c0048361d93c2) 

Add /v1/admin/conversations/{id}/forks endpoint that allows admins and
auditors to view fork information for any conversation regardless of
ownership.

Changes:
- Add endpoint definition to openapi-admin.yml with ConversationForkSummary schema
- Add adminListForks() to MemoryStore interface
- Implement in PostgresMemoryStore and MongoMemoryStore
- Add endpoint to AdminResource with auditor role requirement and audit logging
- Add Cucumber tests for admin/auditor access, 403 for regular users, and
  justification logging