### PR TITLE
feat: add memory_epochs eviction to purge old agent memory epochs

### DIFF
--- a/memory-service-contracts/src/main/resources/openapi-admin.yml
+++ b/memory-service-contracts/src/main/resources/openapi-admin.yml
@@ -736,7 +736,13 @@ components:
             enum:
               - conversation_groups
               - conversation_memberships
-          description: Which resource types to evict.
+              - memory_epochs
+          description: |-
+            Which resource types to evict.
+            - conversation_groups: Soft-deleted conversation groups past retention.
+            - conversation_memberships: Soft-deleted memberships past retention.
+            - memory_epochs: Entries from non-latest memory epochs past retention.
+              The latest epoch per (conversation, client) is always preserved.
           example: ["conversation_groups"]
         justification:
           type: string

--- a/memory-service/src/main/java/io/github/chirino/memory/api/AdminResource.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/AdminResource.java
@@ -412,7 +412,8 @@ public class AdminResource {
             // Validate resource types
             for (String type : resourceTypes) {
                 if (!"conversation_groups".equals(type)
-                        && !"conversation_memberships".equals(type)) {
+                        && !"conversation_memberships".equals(type)
+                        && !"memory_epochs".equals(type)) {
                     return badRequest("Unknown resource type: " + type);
                 }
             }

--- a/memory-service/src/main/java/io/github/chirino/memory/store/EpochKey.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/EpochKey.java
@@ -1,0 +1,12 @@
+package io.github.chirino.memory.store;
+
+import java.util.UUID;
+
+/**
+ * Identifies a unique epoch for a specific agent in a conversation.
+ *
+ * <p>Epochs are scoped per-client: each agent (clientId) has its own epoch sequence per
+ * conversation. This record represents the tuple (conversationId, clientId, epoch) that uniquely
+ * identifies a memory epoch.
+ */
+public record EpochKey(UUID conversationId, String clientId, long epoch) {}

--- a/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
@@ -119,4 +119,26 @@ public interface MemoryStore {
     long countEvictableMemberships(OffsetDateTime cutoff);
 
     int hardDeleteMembershipsBatch(OffsetDateTime cutoff, int limit);
+
+    // Memory epoch eviction support
+
+    /**
+     * Find epochs eligible for eviction (not latest, past retention).
+     *
+     * @param cutoff epochs with max(created_at) before this are eligible
+     * @param limit maximum epochs to return
+     * @return list of (conversationId, clientId, epoch) tuples
+     */
+    List<EpochKey> findEvictableEpochs(OffsetDateTime cutoff, int limit);
+
+    /** Count entries in evictable epochs for progress estimation. */
+    long countEvictableEpochEntries(OffsetDateTime cutoff);
+
+    /**
+     * Delete entries for the specified epochs. Also queues vector store cleanup tasks for affected
+     * entries.
+     *
+     * @return number of entries deleted
+     */
+    int deleteEntriesForEpochs(List<EpochKey> epochs);
 }

--- a/memory-service/src/main/java/io/github/chirino/memory/store/impl/MongoMemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/impl/MongoMemoryStore.java
@@ -40,6 +40,7 @@ import io.github.chirino.memory.mongo.repo.MongoConversationRepository;
 import io.github.chirino.memory.mongo.repo.MongoEntryRepository;
 import io.github.chirino.memory.mongo.repo.MongoTaskRepository;
 import io.github.chirino.memory.store.AccessDeniedException;
+import io.github.chirino.memory.store.EpochKey;
 import io.github.chirino.memory.store.MemoryEpochFilter;
 import io.github.chirino.memory.store.MemoryStore;
 import io.github.chirino.memory.store.ResourceConflictException;
@@ -1650,5 +1651,224 @@ public class MongoMemoryStore implements MemoryStore {
         // Delete by exact _id match to avoid cross-product issues
         Bson deleteFilter = Filters.in("_id", ids);
         return (int) getMembershipCollection().deleteMany(deleteFilter).getDeletedCount();
+    }
+
+    @Override
+    @Transactional
+    public List<EpochKey> findEvictableEpochs(OffsetDateTime cutoff, int limit) {
+        Instant cutoffInstant = cutoff.toInstant();
+
+        // MongoDB aggregation pipeline to find evictable epochs
+        List<Document> pipeline =
+                List.of(
+                        // Match memory channel entries with epoch
+                        new Document(
+                                "$match",
+                                new Document()
+                                        .append("channel", "MEMORY")
+                                        .append("epoch", new Document("$ne", null))),
+
+                        // Group by (conversationId, clientId, epoch) to get last updated time
+                        new Document(
+                                "$group",
+                                new Document()
+                                        .append(
+                                                "_id",
+                                                new Document()
+                                                        .append("conversationId", "$conversationId")
+                                                        .append("clientId", "$clientId")
+                                                        .append("epoch", "$epoch"))
+                                        .append("lastUpdated", new Document("$max", "$createdAt"))),
+
+                        // Group by (conversationId, clientId) to find latest epoch
+                        new Document(
+                                "$group",
+                                new Document()
+                                        .append(
+                                                "_id",
+                                                new Document()
+                                                        .append(
+                                                                "conversationId",
+                                                                "$_id.conversationId")
+                                                        .append("clientId", "$_id.clientId"))
+                                        .append(
+                                                "epochs",
+                                                new Document(
+                                                        "$push",
+                                                        new Document()
+                                                                .append("epoch", "$_id.epoch")
+                                                                .append(
+                                                                        "lastUpdated",
+                                                                        "$lastUpdated")))
+                                        .append("latestEpoch", new Document("$max", "$_id.epoch"))),
+
+                        // Unwind epochs array
+                        new Document("$unwind", "$epochs"),
+
+                        // Filter non-latest epochs past cutoff
+                        new Document(
+                                "$match",
+                                new Document(
+                                        "$expr",
+                                        new Document(
+                                                "$and",
+                                                List.of(
+                                                        new Document(
+                                                                "$lt",
+                                                                List.of(
+                                                                        "$epochs.epoch",
+                                                                        "$latestEpoch")),
+                                                        new Document(
+                                                                "$lt",
+                                                                List.of(
+                                                                        "$epochs.lastUpdated",
+                                                                        cutoffInstant)))))),
+
+                        // Project to output format
+                        new Document(
+                                "$project",
+                                new Document()
+                                        .append("conversationId", "$_id.conversationId")
+                                        .append("clientId", "$_id.clientId")
+                                        .append("epoch", "$epochs.epoch")),
+
+                        // Limit results
+                        new Document("$limit", limit));
+
+        List<EpochKey> result = new ArrayList<>();
+        for (Document doc : getEntryCollection().aggregate(pipeline)) {
+            result.add(
+                    new EpochKey(
+                            UUID.fromString(doc.getString("conversationId")),
+                            doc.getString("clientId"),
+                            doc.getLong("epoch")));
+        }
+        return result;
+    }
+
+    @Override
+    public long countEvictableEpochEntries(OffsetDateTime cutoff) {
+        Instant cutoffInstant = cutoff.toInstant();
+
+        // First find evictable epochs, then count entries
+        List<Document> pipeline =
+                List.of(
+                        // Match memory channel entries with epoch
+                        new Document(
+                                "$match",
+                                new Document()
+                                        .append("channel", "MEMORY")
+                                        .append("epoch", new Document("$ne", null))),
+
+                        // Group by (conversationId, clientId, epoch)
+                        new Document(
+                                "$group",
+                                new Document()
+                                        .append(
+                                                "_id",
+                                                new Document()
+                                                        .append("conversationId", "$conversationId")
+                                                        .append("clientId", "$clientId")
+                                                        .append("epoch", "$epoch"))
+                                        .append("lastUpdated", new Document("$max", "$createdAt"))
+                                        .append("count", new Document("$sum", 1))),
+
+                        // Group by (conversationId, clientId) to find latest epoch
+                        new Document(
+                                "$group",
+                                new Document()
+                                        .append(
+                                                "_id",
+                                                new Document()
+                                                        .append(
+                                                                "conversationId",
+                                                                "$_id.conversationId")
+                                                        .append("clientId", "$_id.clientId"))
+                                        .append(
+                                                "epochs",
+                                                new Document(
+                                                        "$push",
+                                                        new Document()
+                                                                .append("epoch", "$_id.epoch")
+                                                                .append(
+                                                                        "lastUpdated",
+                                                                        "$lastUpdated")
+                                                                .append("count", "$count")))
+                                        .append("latestEpoch", new Document("$max", "$_id.epoch"))),
+
+                        // Unwind epochs array
+                        new Document("$unwind", "$epochs"),
+
+                        // Filter non-latest epochs past cutoff
+                        new Document(
+                                "$match",
+                                new Document(
+                                        "$expr",
+                                        new Document(
+                                                "$and",
+                                                List.of(
+                                                        new Document(
+                                                                "$lt",
+                                                                List.of(
+                                                                        "$epochs.epoch",
+                                                                        "$latestEpoch")),
+                                                        new Document(
+                                                                "$lt",
+                                                                List.of(
+                                                                        "$epochs.lastUpdated",
+                                                                        cutoffInstant)))))),
+
+                        // Sum all counts
+                        new Document(
+                                "$group",
+                                new Document()
+                                        .append("_id", null)
+                                        .append("total", new Document("$sum", "$epochs.count"))));
+
+        Document result = getEntryCollection().aggregate(pipeline).first();
+        if (result == null) {
+            return 0;
+        }
+        Number total = result.get("total", Number.class);
+        return total != null ? total.longValue() : 0;
+    }
+
+    @Override
+    @Transactional
+    public int deleteEntriesForEpochs(List<EpochKey> epochs) {
+        if (epochs.isEmpty()) {
+            return 0;
+        }
+
+        // Build OR filter for all epoch keys
+        List<Bson> epochFilters =
+                epochs.stream()
+                        .map(
+                                key ->
+                                        Filters.and(
+                                                Filters.eq(
+                                                        "conversationId",
+                                                        key.conversationId().toString()),
+                                                Filters.eq("clientId", key.clientId()),
+                                                Filters.eq("epoch", key.epoch()),
+                                                Filters.eq("channel", "MEMORY")))
+                        .toList();
+
+        Bson filter = Filters.or(epochFilters);
+
+        // 1. Find entry IDs for vector store cleanup
+        List<String> entryIds =
+                getEntryCollection()
+                        .find(filter)
+                        .map(doc -> doc.getString("_id"))
+                        .into(new ArrayList<>());
+
+        // 2. Queue vector store cleanup tasks
+        for (String entryId : entryIds) {
+            taskRepository.createTask("vector_store_delete_entry", Map.of("entryId", entryId));
+        }
+
+        // 3. Delete entries
+        return (int) getEntryCollection().deleteMany(filter).getDeletedCount();
     }
 }

--- a/memory-service/src/main/java/io/github/chirino/memory/store/impl/PostgresMemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/impl/PostgresMemoryStore.java
@@ -37,6 +37,7 @@ import io.github.chirino.memory.persistence.repo.ConversationRepository;
 import io.github.chirino.memory.persistence.repo.EntryRepository;
 import io.github.chirino.memory.persistence.repo.TaskRepository;
 import io.github.chirino.memory.store.AccessDeniedException;
+import io.github.chirino.memory.store.EpochKey;
 import io.github.chirino.memory.store.MemoryEpochFilter;
 import io.github.chirino.memory.store.MemoryStore;
 import io.github.chirino.memory.store.ResourceConflictException;
@@ -1636,5 +1637,175 @@ public class PostgresMemoryStore implements MemoryStore {
                 .setParameter("cutoff", cutoff)
                 .setParameter("limit", limit)
                 .executeUpdate();
+    }
+
+    @Override
+    @Transactional
+    public List<EpochKey> findEvictableEpochs(OffsetDateTime cutoff, int limit) {
+        @SuppressWarnings("unchecked")
+        List<Object[]> results =
+                entityManager
+                        .createNativeQuery(
+                                """
+                                WITH epoch_stats AS (
+                                    SELECT
+                                        conversation_id,
+                                        client_id,
+                                        epoch,
+                                        MAX(created_at) as last_updated,
+                                        MAX(epoch) OVER (PARTITION BY conversation_id, client_id) as latest_epoch
+                                    FROM entries
+                                    WHERE channel = 'MEMORY'
+                                      AND epoch IS NOT NULL
+                                    GROUP BY conversation_id, client_id, epoch
+                                )
+                                SELECT conversation_id, client_id, epoch
+                                FROM epoch_stats
+                                WHERE epoch < latest_epoch
+                                  AND last_updated < :cutoff
+                                LIMIT :limit
+                                FOR UPDATE SKIP LOCKED
+                                """)
+                        .setParameter("cutoff", cutoff)
+                        .setParameter("limit", limit)
+                        .getResultList();
+
+        return results.stream()
+                .map(
+                        row ->
+                                new EpochKey(
+                                        (UUID) row[0],
+                                        (String) row[1],
+                                        ((Number) row[2]).longValue()))
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public long countEvictableEpochEntries(OffsetDateTime cutoff) {
+        return ((Number)
+                        entityManager
+                                .createNativeQuery(
+                                        """
+                                        WITH evictable_epochs AS (
+                                            SELECT
+                                                conversation_id,
+                                                client_id,
+                                                epoch,
+                                                MAX(created_at) as last_updated,
+                                                MAX(epoch) OVER (PARTITION BY conversation_id, client_id) as latest_epoch
+                                            FROM entries
+                                            WHERE channel = 'MEMORY'
+                                              AND epoch IS NOT NULL
+                                            GROUP BY conversation_id, client_id, epoch
+                                        )
+                                        SELECT COUNT(*) FROM entries e
+                                        JOIN evictable_epochs ev
+                                          ON e.conversation_id = ev.conversation_id
+                                         AND e.client_id = ev.client_id
+                                         AND e.epoch = ev.epoch
+                                        WHERE ev.epoch < ev.latest_epoch
+                                          AND ev.last_updated < :cutoff
+                                          AND e.channel = 'MEMORY'
+                                        """)
+                                .setParameter("cutoff", cutoff)
+                                .getSingleResult())
+                .longValue();
+    }
+
+    @Override
+    @Transactional
+    public int deleteEntriesForEpochs(List<EpochKey> epochs) {
+        if (epochs.isEmpty()) {
+            return 0;
+        }
+
+        // 1. Get entry IDs for vector store cleanup
+        List<UUID> entryIds = findEntryIdsForEpochs(epochs);
+
+        // 2. Queue vector store cleanup tasks
+        for (UUID entryId : entryIds) {
+            taskRepository.createTask(
+                    "vector_store_delete_entry", Map.of("entryId", entryId.toString()));
+        }
+
+        // 3. Delete entries - build VALUES clause dynamically
+        // Use CAST(:param AS uuid) instead of :param::uuid to avoid JPA parsing issues
+        StringBuilder values = new StringBuilder();
+        for (int i = 0; i < epochs.size(); i++) {
+            if (i > 0) {
+                values.append(", ");
+            }
+            values.append("(CAST(:conv")
+                    .append(i)
+                    .append(" AS uuid), :client")
+                    .append(i)
+                    .append(", :epoch")
+                    .append(i)
+                    .append(")");
+        }
+
+        var query =
+                entityManager.createNativeQuery(
+                        String.format(
+                                """
+                                DELETE FROM entries
+                                WHERE (conversation_id, client_id, epoch) IN (VALUES %s)
+                                  AND channel = 'MEMORY'
+                                """,
+                                values.toString()));
+
+        for (int i = 0; i < epochs.size(); i++) {
+            EpochKey key = epochs.get(i);
+            query.setParameter("conv" + i, key.conversationId().toString());
+            query.setParameter("client" + i, key.clientId());
+            query.setParameter("epoch" + i, key.epoch());
+        }
+
+        return query.executeUpdate();
+    }
+
+    private List<UUID> findEntryIdsForEpochs(List<EpochKey> epochs) {
+        if (epochs.isEmpty()) {
+            return List.of();
+        }
+
+        // Build VALUES clause dynamically
+        // Use CAST(:param AS uuid) instead of :param::uuid to avoid JPA parsing issues
+        StringBuilder values = new StringBuilder();
+        for (int i = 0; i < epochs.size(); i++) {
+            if (i > 0) {
+                values.append(", ");
+            }
+            values.append("(CAST(:conv")
+                    .append(i)
+                    .append(" AS uuid), :client")
+                    .append(i)
+                    .append(", :epoch")
+                    .append(i)
+                    .append(")");
+        }
+
+        var query =
+                entityManager.createNativeQuery(
+                        String.format(
+                                """
+                                SELECT id FROM entries
+                                WHERE (conversation_id, client_id, epoch) IN (VALUES %s)
+                                  AND channel = 'MEMORY'
+                                """,
+                                values.toString()),
+                        UUID.class);
+
+        for (int i = 0; i < epochs.size(); i++) {
+            EpochKey key = epochs.get(i);
+            query.setParameter("conv" + i, key.conversationId().toString());
+            query.setParameter("client" + i, key.clientId());
+            query.setParameter("epoch" + i, key.epoch());
+        }
+
+        @SuppressWarnings("unchecked")
+        List<UUID> result = query.getResultList();
+        return result;
     }
 }

--- a/memory-service/src/test/resources/features/eviction-rest.feature
+++ b/memory-service/src/test/resources/features/eviction-rest.feature
@@ -308,3 +308,200 @@ Feature: Data Eviction
     Then the SQL result should match:
       | group_id     |
       | ${groupId}   |
+
+  # Memory Epoch Eviction Tests
+
+  Scenario: Evict old epochs while preserving latest
+    Given I have a conversation with title "Multi-Epoch Test"
+    And set "convId" to "${conversationId}"
+    And the conversation has memory entries for client "agent-A":
+      | epoch | created_days_ago | content        |
+      | 0     | 100              | old-entry-1    |
+      | 0     | 100              | old-entry-2    |
+      | 1     | 50               | mid-entry-1    |
+      | 2     | 10               | current-entry  |
+    When I call POST "/v1/admin/evict" with body:
+      """
+      {
+        "retentionPeriod": "P60D",
+        "resourceTypes": ["memory_epochs"]
+      }
+      """
+    Then the response status should be 204
+    # Epoch 0 entries should be deleted (not latest, > 60 days old)
+    When I execute SQL query:
+      """
+      SELECT COUNT(*) as count FROM entries WHERE conversation_id = '${convId}' AND epoch = 0
+      """
+    Then the SQL result should match:
+      | count |
+      | 0     |
+    # Epoch 1 entries should still exist (not latest, but < 60 days old)
+    When I execute SQL query:
+      """
+      SELECT COUNT(*) as count FROM entries WHERE conversation_id = '${convId}' AND epoch = 1
+      """
+    Then the SQL result should match:
+      | count |
+      | 1     |
+    # Epoch 2 entries should still exist (is latest)
+    When I execute SQL query:
+      """
+      SELECT COUNT(*) as count FROM entries WHERE conversation_id = '${convId}' AND epoch = 2
+      """
+    Then the SQL result should match:
+      | count |
+      | 1     |
+
+  Scenario: Preserve latest epoch even if old
+    Given I have a conversation with title "Single Epoch Test"
+    And set "convId" to "${conversationId}"
+    And the conversation has memory entries for client "agent-B":
+      | epoch | created_days_ago | content        |
+      | 0     | 365              | ancient-entry  |
+    When I call POST "/v1/admin/evict" with body:
+      """
+      {
+        "retentionPeriod": "P30D",
+        "resourceTypes": ["memory_epochs"]
+      }
+      """
+    Then the response status should be 204
+    # Epoch 0 should still exist (is latest, even though very old)
+    When I execute SQL query:
+      """
+      SELECT COUNT(*) as count FROM entries WHERE conversation_id = '${convId}' AND epoch = 0
+      """
+    Then the SQL result should match:
+      | count |
+      | 1     |
+
+  Scenario: Independent eviction per client
+    Given I have a conversation with title "Multi-Client Test"
+    And set "convId" to "${conversationId}"
+    And the conversation has memory entries for client "agent-A":
+      | epoch | created_days_ago | content         |
+      | 0     | 100              | agent-A-epoch-0 |
+      | 1     | 10               | agent-A-epoch-1 |
+    And the conversation has memory entries for client "agent-B":
+      | epoch | created_days_ago | content         |
+      | 0     | 100              | agent-B-epoch-0 |
+    When I call POST "/v1/admin/evict" with body:
+      """
+      {
+        "retentionPeriod": "P30D",
+        "resourceTypes": ["memory_epochs"]
+      }
+      """
+    Then the response status should be 204
+    # agent-A epoch 0 should be deleted (not latest, > 30 days old)
+    When I execute SQL query:
+      """
+      SELECT COUNT(*) as count FROM entries WHERE conversation_id = '${convId}' AND client_id = 'agent-A' AND epoch = 0
+      """
+    Then the SQL result should match:
+      | count |
+      | 0     |
+    # agent-A epoch 1 should still exist (is latest)
+    When I execute SQL query:
+      """
+      SELECT COUNT(*) as count FROM entries WHERE conversation_id = '${convId}' AND client_id = 'agent-A' AND epoch = 1
+      """
+    Then the SQL result should match:
+      | count |
+      | 1     |
+    # agent-B epoch 0 should still exist (is latest for agent-B)
+    When I execute SQL query:
+      """
+      SELECT COUNT(*) as count FROM entries WHERE conversation_id = '${convId}' AND client_id = 'agent-B' AND epoch = 0
+      """
+    Then the SQL result should match:
+      | count |
+      | 1     |
+
+  Scenario: Epoch eviction with SSE progress
+    Given I have a conversation with title "SSE Epoch Test"
+    And the conversation has memory entries for client "agent-A":
+      | epoch | created_days_ago | content   |
+      | 0     | 100              | old-1     |
+      | 0     | 100              | old-2     |
+      | 1     | 10               | current   |
+    When I call POST "/v1/admin/evict" with Accept "text/event-stream" and body:
+      """
+      {
+        "retentionPeriod": "P30D",
+        "resourceTypes": ["memory_epochs"]
+      }
+      """
+    Then the response status should be 200
+    And the response content type should be "text/event-stream"
+    And the SSE stream should contain progress events
+    And the final progress should be 100
+
+  Scenario: Vector store cleanup tasks created for epoch eviction
+    Given I have a conversation with title "Vector Epoch Test"
+    And set "convId" to "${conversationId}"
+    And the conversation has memory entries for client "agent-A":
+      | epoch | created_days_ago | content   |
+      | 0     | 100              | old-entry |
+      | 1     | 10               | current   |
+    When I call POST "/v1/admin/evict" with body:
+      """
+      {
+        "retentionPeriod": "P30D",
+        "resourceTypes": ["memory_epochs"]
+      }
+      """
+    Then the response status should be 204
+    # vector_store_delete_entry task should be created
+    When I execute SQL query:
+      """
+      SELECT COUNT(*) as count FROM tasks WHERE task_type = 'vector_store_delete_entry'
+      """
+    Then the SQL result should match:
+      | count |
+      | 1     |
+
+  Scenario: Evict epochs combined with other resource types
+    Given I have a conversation with title "Combined Eviction"
+    And set "groupId" to "${conversationGroupId}"
+    And set "convId" to "${conversationId}"
+    And the conversation has memory entries for client "agent-A":
+      | epoch | created_days_ago | content   |
+      | 0     | 100              | old-entry |
+      | 1     | 10               | current   |
+    And I have a conversation with title "To Delete"
+    And set "deleteGroupId" to "${conversationGroupId}"
+    And the conversation was soft-deleted 100 days ago
+    When I call POST "/v1/admin/evict" with body:
+      """
+      {
+        "retentionPeriod": "P30D",
+        "resourceTypes": ["conversation_groups", "memory_epochs"]
+      }
+      """
+    Then the response status should be 204
+    # Soft-deleted group should be removed
+    When I execute SQL query:
+      """
+      SELECT COUNT(*) as count FROM conversation_groups WHERE id = '${deleteGroupId}'
+      """
+    Then the SQL result should match:
+      | count |
+      | 0     |
+    # Old epoch should be removed
+    When I execute SQL query:
+      """
+      SELECT COUNT(*) as count FROM entries WHERE conversation_id = '${convId}' AND epoch = 0
+      """
+    Then the SQL result should match:
+      | count |
+      | 0     |
+    # Latest epoch preserved
+    When I execute SQL query:
+      """
+      SELECT COUNT(*) as count FROM entries WHERE conversation_id = '${convId}' AND epoch = 1
+      """
+    Then the SQL result should match:
+      | count |
+      | 1     |


### PR DESCRIPTION
Extends the admin eviction endpoint to support evicting entries from old memory epochs that are no longer the "current" epoch for their conversation and have not been updated for longer than the retention period.

Key changes:
- Add memory_epochs to resourceTypes enum in OpenAPI spec
- Add EpochKey record to identify (conversationId, clientId, epoch) tuples
- Add findEvictableEpochs, countEvictableEpochEntries, deleteEntriesForEpochs to MemoryStore interface
- Implement epoch eviction in PostgresMemoryStore using CTEs and window functions to identify non-latest epochs past retention
- Implement epoch eviction in MongoMemoryStore using aggregation pipelines
- Queue vector_store_delete_entry tasks for affected entries
- Add 7 Cucumber test scenarios covering epoch eviction behavior

The latest epoch per (conversation, client) is always preserved, even if old.