### PR TITLE
feat: add pluggable cache for memory entries with Micrometer metrics

### DIFF
--- a/memory-service/pom.xml
+++ b/memory-service/pom.xml
@@ -84,6 +84,12 @@
       <artifactId>quarkus-liquibase-mongodb</artifactId>
     </dependency>
 
+    <!-- Metrics -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+    </dependency>
+
     <!-- MongoDB -->
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/memory-service/src/main/java/io/github/chirino/memory/cache/CachedMemoryEntries.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/cache/CachedMemoryEntries.java
@@ -1,0 +1,38 @@
+package io.github.chirino.memory.cache;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Cached memory entries for a conversation/client pair. Contains the current epoch and all entries
+ * in their encrypted form.
+ */
+public record CachedMemoryEntries(long epoch, List<CachedEntry> entries) {
+
+    @JsonCreator
+    public CachedMemoryEntries(
+            @JsonProperty("epoch") long epoch, @JsonProperty("entries") List<CachedEntry> entries) {
+        this.epoch = epoch;
+        this.entries = entries;
+    }
+
+    /** Individual cached entry. Stores encrypted content as-is from database. */
+    public record CachedEntry(
+            UUID id, String contentType, byte[] encryptedContent, Instant createdAt) {
+
+        @JsonCreator
+        public CachedEntry(
+                @JsonProperty("id") UUID id,
+                @JsonProperty("contentType") String contentType,
+                @JsonProperty("encryptedContent") byte[] encryptedContent,
+                @JsonProperty("createdAt") Instant createdAt) {
+            this.id = id;
+            this.contentType = contentType;
+            this.encryptedContent = encryptedContent;
+            this.createdAt = createdAt;
+        }
+    }
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/cache/InfinispanMemoryEntriesCache.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/cache/InfinispanMemoryEntriesCache.java
@@ -1,0 +1,228 @@
+package io.github.chirino.memory.cache;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.infinispan.client.hotrod.RemoteCache;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.infinispan.client.hotrod.exceptions.HotRodClientException;
+import org.infinispan.client.hotrod.exceptions.TransportException;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class InfinispanMemoryEntriesCache implements MemoryEntriesCache {
+    private static final Logger LOG = Logger.getLogger(InfinispanMemoryEntriesCache.class);
+    private static final String CACHE_NAME = "memory-entries";
+    private static final Duration RETRY_DELAY = Duration.ofMillis(200);
+
+    private final boolean infinispanEnabled;
+    private final Instance<RemoteCacheManager> cacheManagers;
+    private final Duration startupTimeout;
+    private final Duration ttl;
+    private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
+    private volatile RemoteCache<String, String> cache;
+    private Counter cacheHits;
+    private Counter cacheMisses;
+    private Counter cacheErrors;
+
+    @Inject
+    public InfinispanMemoryEntriesCache(
+            @ConfigProperty(name = "memory-service.cache.type") Optional<String> cacheType,
+            @ConfigProperty(
+                            name = "memory-service.cache.infinispan.startup-timeout",
+                            defaultValue = "PT30S")
+                    Duration startupTimeout,
+            @ConfigProperty(name = "memory-service.cache.epoch.ttl", defaultValue = "PT10M")
+                    Duration ttl,
+            @Any Instance<RemoteCacheManager> cacheManagers,
+            ObjectMapper objectMapper,
+            MeterRegistry meterRegistry) {
+        this.infinispanEnabled = cacheType.map("infinispan"::equalsIgnoreCase).orElse(false);
+        this.startupTimeout = startupTimeout;
+        this.ttl = ttl;
+        this.cacheManagers = cacheManagers;
+        this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    void init() {
+        // Initialize metrics
+        cacheHits = meterRegistry.counter("memory.entries.cache.hits", "backend", "infinispan");
+        cacheMisses = meterRegistry.counter("memory.entries.cache.misses", "backend", "infinispan");
+        cacheErrors = meterRegistry.counter("memory.entries.cache.errors", "backend", "infinispan");
+
+        if (!infinispanEnabled) {
+            return;
+        }
+
+        if (cacheManagers.isUnsatisfied()) {
+            LOG.warn(
+                    "Memory entries cache is enabled (memory-service.cache.type=infinispan) but"
+                            + " no Infinispan client is available.");
+            return;
+        }
+
+        try {
+            RemoteCacheManager cacheManager = cacheManagers.get();
+            cache = cacheManager.getCache(CACHE_NAME);
+            if (cache == null) {
+                LOG.warnf(
+                        "Memory entries cache is enabled (memory-service.cache.type=infinispan) but"
+                                + " cache '%s' is not available.",
+                        CACHE_NAME);
+            }
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to initialize Infinispan memory entries cache");
+        }
+    }
+
+    @Override
+    public boolean available() {
+        if (cache == null) {
+            return false;
+        }
+        try {
+            withRetry(
+                    "available",
+                    () -> {
+                        cache.size();
+                        return Boolean.TRUE;
+                    });
+            return true;
+        } catch (RuntimeException e) {
+            LOG.debugf(e, "Infinispan memory entries cache is not available yet");
+            return false;
+        }
+    }
+
+    @Override
+    public Optional<CachedMemoryEntries> get(UUID conversationId, String clientId) {
+        if (!available()) {
+            cacheMisses.increment();
+            return Optional.empty();
+        }
+        try {
+            String key = buildKey(conversationId, clientId);
+            // maxIdle automatically refreshes TTL on access - no manual re-put needed
+            String json = withRetry("get", () -> cache.get(key));
+            if (json == null) {
+                cacheMisses.increment();
+                return Optional.empty();
+            }
+            cacheHits.increment();
+            return Optional.of(objectMapper.readValue(json, CachedMemoryEntries.class));
+        } catch (JsonProcessingException e) {
+            LOG.warnf(e, "Failed to deserialize memory entries from Infinispan cache");
+            cacheErrors.increment();
+            return Optional.empty();
+        } catch (RuntimeException e) {
+            LOG.warnf(
+                    e,
+                    "Failed to get memory entries from Infinispan cache for %s/%s",
+                    conversationId,
+                    clientId);
+            cacheErrors.increment();
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void set(UUID conversationId, String clientId, CachedMemoryEntries entries) {
+        if (!available()) {
+            return;
+        }
+        try {
+            String key = buildKey(conversationId, clientId);
+            String json = objectMapper.writeValueAsString(entries);
+            // Use maxIdle for sliding TTL that refreshes on access
+            // lifespan=-1 means no hard expiration, only idle-based expiration
+            withRetry(
+                    "set",
+                    () ->
+                            cache.put(
+                                    key,
+                                    json,
+                                    -1,
+                                    TimeUnit.MILLISECONDS,
+                                    ttl.toMillis(),
+                                    TimeUnit.MILLISECONDS));
+        } catch (JsonProcessingException e) {
+            LOG.warnf(e, "Failed to serialize memory entries for Infinispan cache");
+        } catch (RuntimeException e) {
+            LOG.warnf(
+                    e,
+                    "Failed to set memory entries in Infinispan cache for %s/%s",
+                    conversationId,
+                    clientId);
+        }
+    }
+
+    @Override
+    public void remove(UUID conversationId, String clientId) {
+        if (!available()) {
+            return;
+        }
+        try {
+            String key = buildKey(conversationId, clientId);
+            withRetry("remove", () -> cache.remove(key));
+        } catch (RuntimeException e) {
+            LOG.warnf(
+                    e,
+                    "Failed to remove memory entries from Infinispan cache for %s/%s",
+                    conversationId,
+                    clientId);
+        }
+    }
+
+    private String buildKey(UUID conversationId, String clientId) {
+        return conversationId + ":" + clientId;
+    }
+
+    private <T> T withRetry(String operation, Supplier<T> action) {
+        long deadline = System.nanoTime() + startupTimeout.toNanos();
+        RuntimeException lastFailure = null;
+        while (true) {
+            try {
+                return action.get();
+            } catch (RuntimeException e) {
+                if (!isRetryable(e)) {
+                    throw e;
+                }
+                lastFailure = e;
+                if (System.nanoTime() >= deadline) {
+                    throw e;
+                }
+                sleep();
+                LOG.debugf(
+                        "Retrying Infinispan memory entries cache %s after connection failure",
+                        operation);
+            }
+        }
+    }
+
+    private boolean isRetryable(RuntimeException e) {
+        return e instanceof TransportException || e instanceof HotRodClientException;
+    }
+
+    private void sleep() {
+        try {
+            Thread.sleep(RETRY_DELAY.toMillis());
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/cache/MemoryEntriesCache.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/cache/MemoryEntriesCache.java
@@ -1,0 +1,31 @@
+package io.github.chirino.memory.cache;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Cache for storing memory entries per conversation/client pair. Entries are stored in their
+ * encrypted form for security. Implementations must handle unavailability gracefully.
+ */
+public interface MemoryEntriesCache {
+
+    /** Returns true if the cache backend is available and configured. */
+    boolean available();
+
+    /**
+     * Get cached memory entries for a conversation/client pair. Refreshes the TTL on cache hit.
+     *
+     * @return Optional.empty() if not cached or cache unavailable
+     */
+    Optional<CachedMemoryEntries> get(UUID conversationId, String clientId);
+
+    /**
+     * Store memory entries for a conversation/client pair. The entries should contain encrypted
+     * content (not decrypted). Sets/refreshes the TTL based on memory-service.cache.epoch.ttl
+     * config.
+     */
+    void set(UUID conversationId, String clientId, CachedMemoryEntries entries);
+
+    /** Remove cached entries (e.g., on conversation delete or eviction). */
+    void remove(UUID conversationId, String clientId);
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/cache/MemoryEntriesCacheSelector.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/cache/MemoryEntriesCacheSelector.java
@@ -1,0 +1,28 @@
+package io.github.chirino.memory.cache;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/** Selects the appropriate MemoryEntriesCache implementation based on configuration. */
+@ApplicationScoped
+public class MemoryEntriesCacheSelector {
+
+    @ConfigProperty(name = "memory-service.cache.type", defaultValue = "none")
+    String cacheType;
+
+    @Inject RedisMemoryEntriesCache redisCache;
+
+    @Inject InfinispanMemoryEntriesCache infinispanCache;
+
+    @Inject NoopMemoryEntriesCache noopCache;
+
+    public MemoryEntriesCache select() {
+        String type = cacheType == null ? "none" : cacheType.trim().toLowerCase();
+        return switch (type) {
+            case "redis" -> redisCache.available() ? redisCache : noopCache;
+            case "infinispan" -> infinispanCache.available() ? infinispanCache : noopCache;
+            default -> noopCache;
+        };
+    }
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/cache/NoopMemoryEntriesCache.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/cache/NoopMemoryEntriesCache.java
@@ -1,0 +1,30 @@
+package io.github.chirino.memory.cache;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.Optional;
+import java.util.UUID;
+
+/** No-op implementation of MemoryEntriesCache used when caching is disabled. */
+@ApplicationScoped
+public class NoopMemoryEntriesCache implements MemoryEntriesCache {
+
+    @Override
+    public boolean available() {
+        return false;
+    }
+
+    @Override
+    public Optional<CachedMemoryEntries> get(UUID conversationId, String clientId) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void set(UUID conversationId, String clientId, CachedMemoryEntries entries) {
+        // No-op
+    }
+
+    @Override
+    public void remove(UUID conversationId, String clientId) {
+        // No-op
+    }
+}

--- a/memory-service/src/main/java/io/github/chirino/memory/cache/RedisMemoryEntriesCache.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/cache/RedisMemoryEntriesCache.java
@@ -1,0 +1,165 @@
+package io.github.chirino.memory.cache;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.quarkus.redis.datasource.keys.ReactiveKeyCommands;
+import io.quarkus.redis.datasource.value.GetExArgs;
+import io.quarkus.redis.datasource.value.ReactiveValueCommands;
+import io.quarkus.redis.datasource.value.SetArgs;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+public class RedisMemoryEntriesCache implements MemoryEntriesCache {
+    private static final Logger LOG = Logger.getLogger(RedisMemoryEntriesCache.class);
+    private static final String KEY_PREFIX = "memory:entries:";
+    private static final Duration REDIS_TIMEOUT = Duration.ofSeconds(5);
+
+    private final boolean redisEnabled;
+    private final String clientName;
+    private final Duration ttl;
+    private final Instance<ReactiveRedisDataSource> redisSources;
+    private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
+    private volatile ReactiveKeyCommands<String> keys;
+    private volatile ReactiveValueCommands<String, String> values;
+    private Counter cacheHits;
+    private Counter cacheMisses;
+    private Counter cacheErrors;
+
+    @Inject
+    public RedisMemoryEntriesCache(
+            @ConfigProperty(name = "memory-service.cache.type") Optional<String> cacheType,
+            @ConfigProperty(name = "memory-service.cache.redis.client") Optional<String> clientName,
+            @ConfigProperty(name = "memory-service.cache.epoch.ttl", defaultValue = "PT10M")
+                    Duration ttl,
+            @Any Instance<ReactiveRedisDataSource> redisSources,
+            ObjectMapper objectMapper,
+            MeterRegistry meterRegistry) {
+        this.redisEnabled = cacheType.map("redis"::equalsIgnoreCase).orElse(false);
+        this.clientName = clientName.filter(it -> !it.isBlank()).orElse(null);
+        this.ttl = ttl;
+        this.redisSources = redisSources;
+        this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @PostConstruct
+    void init() {
+        // Initialize metrics
+        cacheHits = meterRegistry.counter("memory.entries.cache.hits", "backend", "redis");
+        cacheMisses = meterRegistry.counter("memory.entries.cache.misses", "backend", "redis");
+        cacheErrors = meterRegistry.counter("memory.entries.cache.errors", "backend", "redis");
+
+        if (!redisEnabled) {
+            return;
+        }
+
+        Instance<ReactiveRedisDataSource> selected =
+                clientName != null
+                        ? redisSources.select(RedisClientName.Literal.of(clientName))
+                        : redisSources;
+        if (selected.isUnsatisfied()) {
+            LOG.warnf(
+                    "Memory entries cache is enabled (memory-service.cache.type=redis) but Redis"
+                            + " client '%s' is not available.",
+                    clientName == null ? "<default>" : clientName);
+            return;
+        }
+
+        ReactiveRedisDataSource dataSource = selected.get();
+        keys = dataSource.key();
+        values = dataSource.value(String.class);
+    }
+
+    @Override
+    public boolean available() {
+        return keys != null && values != null;
+    }
+
+    @Override
+    public Optional<CachedMemoryEntries> get(UUID conversationId, String clientId) {
+        if (!available()) {
+            cacheMisses.increment();
+            return Optional.empty();
+        }
+        try {
+            String key = buildKey(conversationId, clientId);
+            // GETEX with EX option atomically gets and refreshes TTL
+            String json = values.getex(key, new GetExArgs().ex(ttl)).await().atMost(REDIS_TIMEOUT);
+            if (json == null) {
+                cacheMisses.increment();
+                return Optional.empty();
+            }
+            cacheHits.increment();
+            return Optional.of(objectMapper.readValue(json, CachedMemoryEntries.class));
+        } catch (Exception e) {
+            LOG.warnf(
+                    e,
+                    "Failed to get memory entries from Redis cache for %s/%s",
+                    conversationId,
+                    clientId);
+            cacheErrors.increment();
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void set(UUID conversationId, String clientId, CachedMemoryEntries entries) {
+        if (!available()) {
+            return;
+        }
+        try {
+            String key = buildKey(conversationId, clientId);
+            String json = objectMapper.writeValueAsString(entries);
+            // Set with TTL
+            values.set(key, json, new SetArgs().ex(ttl))
+                    .subscribe()
+                    .with(
+                            ignored -> {},
+                            failure ->
+                                    LOG.warnf(
+                                            failure,
+                                            "Failed to set memory entries in Redis cache for %s/%s",
+                                            conversationId,
+                                            clientId));
+        } catch (JsonProcessingException e) {
+            LOG.warnf(e, "Failed to serialize memory entries for Redis cache");
+        }
+    }
+
+    @Override
+    public void remove(UUID conversationId, String clientId) {
+        if (!available()) {
+            return;
+        }
+        String key = buildKey(conversationId, clientId);
+        keys.del(key)
+                .subscribe()
+                .with(
+                        ignored -> {},
+                        failure ->
+                                LOG.warnf(
+                                        failure,
+                                        "Failed to remove memory entries from Redis cache for"
+                                                + " %s/%s",
+                                        conversationId,
+                                        clientId));
+    }
+
+    private String buildKey(UUID conversationId, String clientId) {
+        return KEY_PREFIX + conversationId + ":" + clientId;
+    }
+}

--- a/memory-service/src/main/resources/application.properties
+++ b/memory-service/src/main/resources/application.properties
@@ -23,6 +23,7 @@ quarkus.hibernate-orm.mapping.format.global=ignore
 # Memory service provider selection
 memory-service.datastore.type=postgres
 memory-service.cache.type=none
+memory-service.cache.epoch.ttl=PT10M
 memory-service.vector.type=none
 
 # OIDC / Keycloak configuration (following Quarkus Keycloak authorization guide)

--- a/memory-service/src/test/java/io/github/chirino/memory/PostgresqlInfinispanTestProfile.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/PostgresqlInfinispanTestProfile.java
@@ -7,16 +7,21 @@ public class PostgresqlInfinispanTestProfile implements QuarkusTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
-        return Map.of(
-                "memory-service.datastore.type", "postgres",
-                "memory-service.vector.type", "pgvector",
-                "memory-service.cache.type", "infinispan",
-                "quarkus.infinispan-client.cache.response-resumer.configuration",
+        return Map.ofEntries(
+                Map.entry("memory-service.datastore.type", "postgres"),
+                Map.entry("memory-service.vector.type", "pgvector"),
+                Map.entry("memory-service.cache.type", "infinispan"),
+                Map.entry(
+                        "quarkus.infinispan-client.cache.response-resumer.configuration",
                         "<distributed-cache><encoding"
-                                + " media-type=\"application/x-protostream\"/></distributed-cache>",
-                "quarkus.datasource.devservices.enabled", "true",
-                "quarkus.infinispan-client.devservices.enabled", "true",
-                "quarkus.liquibase.migrate-at-start", "true",
-                "quarkus.datasource.devservices.image-name", "pgvector/pgvector:pg17");
+                            + " media-type=\"application/x-protostream\"/></distributed-cache>"),
+                Map.entry(
+                        "quarkus.infinispan-client.cache.memory-entries.configuration",
+                        "<distributed-cache><encoding"
+                                + " media-type=\"text/plain\"/></distributed-cache>"),
+                Map.entry("quarkus.datasource.devservices.enabled", "true"),
+                Map.entry("quarkus.infinispan-client.devservices.enabled", "true"),
+                Map.entry("quarkus.liquibase.migrate-at-start", "true"),
+                Map.entry("quarkus.datasource.devservices.image-name", "pgvector/pgvector:pg17"));
     }
 }

--- a/memory-service/src/test/resources/features/memory-cache-rest.feature
+++ b/memory-service/src/test/resources/features/memory-cache-rest.feature
@@ -1,0 +1,50 @@
+Feature: Memory entries cache via REST
+  As an agent
+  I want memory entries to be cached
+  So that repeated reads are fast
+
+  Background:
+    Given I am authenticated as user "alice"
+    And I have a conversation with title "Cache test"
+
+  Scenario: Cache is populated on first read and used on subsequent reads
+    Given I am authenticated as agent with API key "test-agent-key"
+    And the conversation has a memory entry "Hello from cache test" with epoch 1 and contentType "test.v1"
+    And I record the current cache metrics
+    # First read - should be cache miss, then populate cache
+    When I list memory entries for the conversation with epoch "LATEST"
+    Then the response status should be 200
+    And the response should contain 1 entry
+    And the cache miss count should have increased by at least 1
+    # Record metrics again before second read
+    Given I record the current cache metrics
+    # Second read - should be cache hit
+    When I list memory entries for the conversation with epoch "LATEST"
+    Then the response status should be 200
+    And the response should contain 1 entry
+    And the cache hit count should have increased by at least 1
+
+  Scenario: Cache is updated after sync
+    Given I am authenticated as agent with API key "test-agent-key-b"
+    And the conversation has a memory entry "Initial content" with epoch 1 and contentType "test.v1"
+    And I record the current cache metrics
+    # Read to populate cache
+    When I list memory entries for the conversation with epoch "LATEST"
+    Then the response status should be 200
+    And the response should contain 1 entry
+    # Sync new content (should update cache, not invalidate it)
+    When I sync memory entries with request:
+      """
+      {
+        "channel": "MEMORY",
+        "contentType": "test.v1",
+        "content": [{"type": "text", "text": "Initial content"}, {"type": "text", "text": "Additional content"}]
+      }
+      """
+    Then the response status should be 200
+    # Record metrics before next read
+    Given I record the current cache metrics
+    # Read after sync - should be cache hit (cache was updated by sync)
+    When I list memory entries for the conversation with epoch "LATEST"
+    Then the response status should be 200
+    And the cache hit count should have increased by at least 1


### PR DESCRIPTION
Implement Phase 3 of enhancement 026-memory-perf: pluggable cache for memory entries that reduces database queries for repeated reads.

Cache implementations:
- RedisMemoryEntriesCache: uses GETEX for atomic get+TTL refresh
- InfinispanMemoryEntriesCache: uses maxIdle for native sliding TTL
- NoopMemoryEntriesCache: fallback when caching is disabled
- MemoryEntriesCacheSelector: selects implementation based on config

Key features:
- Configurable TTL via memory-service.cache.epoch.ttl (default PT10M)
- TTL refreshes on both get and set operations (sliding window)
- Cache invalidation on sync modifications
- Micrometer metrics for cache hits, misses, and errors

Test infrastructure:
- Cucumber step definitions for cache metrics verification
- Feature file testing cache population and invalidation
- Infinispan memory-entries cache configuration for tests

Configuration: memory-service.cache.type=[none|redis|infinispan]