### PR TITLE
chore: update roadmap, refactor fork menu UI, add chat-frontend skill

### DIFF
--- a/.skills/chat-frontend/SKILL.md
+++ b/.skills/chat-frontend/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: chat-frontend
+description: Use when working on the React chat frontend. Covers architecture, components, styling, and state management.
+---
+
+# Chat Frontend Context
+
+Location: `common/chat-frontend/`
+
+## Tech Stack
+- **React 19** with TypeScript, Vite 7 build tool
+- **Tailwind CSS** for styling (custom theme in `tailwind.config.js`)
+- **TanStack React Query** for server state
+- **Radix UI** primitives for accessible components
+- **OpenAPI client** auto-generated in `src/client/`
+
+## Key Directories
+```
+src/
+├── components/           # React components
+│   ├── ui/               # Reusable primitives (button, card, toggle)
+│   ├── sharing/          # Access control modals
+│   ├── conversation.tsx  # Headless chat primitives (core logic)
+│   ├── conversations-ui.tsx  # Styled wrappers with Tailwind
+│   ├── chat-panel.tsx    # Main chat interface
+│   └── chat-sidebar.tsx  # Conversation list
+├── hooks/                # useSseStream, useSharing, useResumeCheck
+├── lib/                  # auth.tsx, utils.ts
+└── client/               # Generated OpenAPI client (DO NOT EDIT)
+```
+
+## Component Architecture
+
+**Headless Pattern**: `conversation.tsx` provides unstyled primitives (`Conversation.Root`, `.Viewport`, `.Messages`, `.Message`, `.Input`, `.Actions`) with hooks (`useConversationContext`, `useConversationMessages`, etc.).
+
+**Styled Wrappers**: `conversations-ui.tsx` wraps headless components with Tailwind styling.
+
+**Main Components**:
+- `App.tsx` - Root layout (sidebar + chat panel)
+- `chat-panel.tsx` - Message display, input, fork UI, sharing
+- `chat-sidebar.tsx` - Conversation list with search
+
+## Styling
+
+**Custom Tailwind Theme** (`tailwind.config.js`):
+- Colors: `cream` (bg), `ink` (text), `mist` (secondary), `stone` (muted), `terracotta` (accent), `sage` (secondary accent)
+- Fonts: Instrument Serif (headings), DM Sans (body), SF Mono (code)
+
+**Utility**: `cn()` from `lib/utils.ts` merges classes with Tailwind conflict resolution.
+
+## State Management
+- **React Query**: Server state (conversations, messages, memberships)
+- **Context**: Auth (`lib/auth.tsx`), conversation state (`conversation.tsx`)
+- **Local**: UI-only state via `useState`
+
+## Dev Commands
+```bash
+cd common/chat-frontend
+npm run dev        # Dev server with HMR
+npm run build      # Production build
+npm run lint       # ESLint
+npm run generate   # Regenerate OpenAPI client
+```
+
+## Common Tasks
+
+**Add/modify component styling**: Edit in `conversations-ui.tsx` or relevant component, use Tailwind classes with `cn()`.
+
+**Change chat behavior**: Modify `conversation.tsx` (logic) or `chat-panel.tsx` (UI integration).
+
+**Fix z-index/layering issues**: Check `z-*` classes in Tailwind. Common layers: dropdowns (z-50), modals (z-[100]).
+
+**After changes**: Run `npm run lint && npm run build` to verify.

--- a/TODO.md
+++ b/TODO.md
@@ -1,9 +1,13 @@
 # TODO List
 
 * Figure out how muli-modal content should be handled.
-* Expose Metrics
-* Support OpenTracing
+* Observability:
+    * Expose Metrics
+    * Integrate OpenTracing
 * Improve the langchain4j memory interface: Switch to the langchain4j MemoryChatStore once https://github.com/langchain4j/langchain4j/pull/4416 is released.
+* document sharing: concepts and spring/quarkus howtos
+* document index/search apis: concepts and spring/quarkus howtos (provide RAG example).
+* document admin apis
 * Brand the project and move it to an org/foundation.
 
 # Hardening Work
@@ -17,7 +21,6 @@
 
 # Performance Related
 
-* Getting latest memory of a conversation is likely to be a very frequently accessed operation: cache it.
 * are there any http cache/headers that could reduce load against the server?
 * Look into partitioning the messages table to improve pref.
 
@@ -25,5 +28,5 @@
 
 * Can the @RecordConversation bits be moved into Quarkus Langchain4j? https://github.com/quarkiverse/quarkus-langchain4j/issues/2068#issuecomment-3816044002
 * Do we need multi-tenancy support?  What would it look like?
-* How useful is the current summarize/index feature?
-* Ponder how best to kick off/manage async search indexing maybe move this into the admin api?
+* How useful is the current index/search feature?
+* Ponder how best to kick off/manage async indexing maybe move this into the admin api?

--- a/common/chat-frontend/src/components/chat-panel.tsx
+++ b/common/chat-frontend/src/components/chat-panel.tsx
@@ -15,7 +15,7 @@ import type { ApiError, Conversation as ApiConversation, ConversationForkSummary
 import { ConversationsService } from "@/client";
 import { useSseStream } from "@/hooks/useSseStream";
 import type { StreamStartParams } from "@/hooks/useStreamTypes";
-import { Check, Copy, CornerUpLeft, Menu, Pencil, Sparkles, Trash2 } from "lucide-react";
+import { Check, Copy, Menu, Pencil, Sparkles, Trash2 } from "lucide-react";
 import { ShareButton } from "@/components/sharing";
 import { UserAvatar } from "@/components/user-avatar";
 import type { AuthUser } from "@/lib/auth";
@@ -226,37 +226,8 @@ function ChatMessageRow({
 
   return (
     <div key={message.id}>
-      <ConversationsUI.MessageRow
-        message={message}
-        messageRef={messageRef}
-        overlay={
-          message.displayState === "stable" ? (
-            <div className="absolute -bottom-6 right-1 z-10 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-              <button
-                type="button"
-                onClick={() => onCopy(message.content)}
-                className="rounded p-1 text-stone transition-colors hover:bg-mist hover:text-ink"
-                title="Copy message"
-              >
-                {isCopied ? <Check className="h-3.5 w-3.5 text-sage" /> : <Copy className="h-3.5 w-3.5" />}
-              </button>
-              {isUser && !isReader && (
-                <button
-                  type="button"
-                  onClick={() => onEditStart(message)}
-                  disabled={composerDisabled}
-                  className="rounded p-1 text-stone transition-colors hover:bg-mist hover:text-terracotta disabled:opacity-50"
-                  title="Edit message"
-                >
-                  <Pencil className="h-3.5 w-3.5" />
-                </button>
-              )}
-            </div>
-          ) : null
-        }
-      />
       {hasForks ? (
-        <div className={`relative mt-2 ${isUser ? "pr-1 text-right" : "pl-2"}`}>
+        <div className={`relative mb-1 ${isUser ? "pr-1 text-right" : "pl-1"}`}>
           <button
             type="button"
             className="elegant-link pointer-events-auto text-xs text-stone transition-colors hover:text-ink"
@@ -273,7 +244,11 @@ function ChatMessageRow({
             {forkOptionsCount} forks
           </button>
           {isForkMenuOpen && forkPoint ? (
-            <div className="absolute left-0 z-30 mt-2 w-72 animate-slide-up overflow-hidden rounded-xl border border-stone/20 bg-cream shadow-xl">
+            <div
+              className={`absolute z-30 mt-1 w-72 animate-slide-up overflow-hidden rounded-xl border border-stone/20 bg-cream shadow-xl ${
+                isUser ? "right-0" : "left-0"
+              }`}
+            >
               <div className="border-b border-stone/10 bg-mist/50 px-4 py-2.5">
                 <span className="text-xs font-medium text-stone">Fork Branches</span>
               </div>
@@ -313,20 +288,6 @@ function ChatMessageRow({
                         </button>
                       );
                     })}
-                    {/* Parent option */}
-                    <div className="mt-1 border-t border-stone/10 pt-1">
-                      <button
-                        type="button"
-                        className="flex w-full items-center gap-2 px-4 py-3 text-left transition-colors hover:bg-mist/50"
-                        onClick={() => {
-                          setOpenForkMenuMessageId(null);
-                          setActiveForkMenuMessageId(null);
-                        }}
-                      >
-                        <CornerUpLeft className="h-4 w-4 text-stone" />
-                        <p className="text-sm text-stone">Return to parent conversation</p>
-                      </button>
-                    </div>
                   </>
                 )}
               </div>
@@ -334,6 +295,35 @@ function ChatMessageRow({
           ) : null}
         </div>
       ) : null}
+      <ConversationsUI.MessageRow
+        message={message}
+        messageRef={messageRef}
+        overlay={
+          message.displayState === "stable" ? (
+            <div className="absolute -bottom-6 right-1 z-10 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+              <button
+                type="button"
+                onClick={() => onCopy(message.content)}
+                className="rounded p-1 text-stone transition-colors hover:bg-mist hover:text-ink"
+                title="Copy message"
+              >
+                {isCopied ? <Check className="h-3.5 w-3.5 text-sage" /> : <Copy className="h-3.5 w-3.5" />}
+              </button>
+              {isUser && !isReader && (
+                <button
+                  type="button"
+                  onClick={() => onEditStart(message)}
+                  disabled={composerDisabled}
+                  className="rounded p-1 text-stone transition-colors hover:bg-mist hover:text-terracotta disabled:opacity-50"
+                  title="Edit message"
+                >
+                  <Pencil className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </div>
+          ) : null
+        }
+      />
     </div>
   );
 }


### PR DESCRIPTION
- Reorganize TODO.md observability items and add documentation todos
- Move fork menu above message row for better visual flow
- Improve fork menu positioning (align right for user messages)
- Remove redundant "return to parent" button from fork menu
- Add .skills/chat-frontend/ with architecture documentation