### PR TITLE
refactor: consolidate Keycloak clients and enhance dev services config

### DIFF
--- a/common/chat-frontend/src/lib/auth.tsx
+++ b/common/chat-frontend/src/lib/auth.tsx
@@ -10,7 +10,7 @@ import { OpenAPI } from "@/client";
 // OIDC Configuration with sensible defaults for local development
 const keycloakUrl = import.meta.env.VITE_KEYCLOAK_URL || "http://localhost:8081";
 const keycloakRealm = import.meta.env.VITE_KEYCLOAK_REALM || "memory-service";
-const keycloakClientId = import.meta.env.VITE_KEYCLOAK_CLIENT_ID || "agent-frontend";
+const keycloakClientId = import.meta.env.VITE_KEYCLOAK_CLIENT_ID || "frontend";
 
 const oidcConfig = {
   authority: `${keycloakUrl}/realms/${keycloakRealm}`,

--- a/common/keycloak/memory-service-realm.json
+++ b/common/keycloak/memory-service-realm.json
@@ -71,19 +71,31 @@
       ]
     },
     {
-      "clientId": "admin-frontend",
-      "name": "Admin Frontend",
-      "description": "Public client for admin SPA",
+      "clientId": "frontend",
+      "name": "Agent Frontend",
+      "description": "Public client for agent chat SPA",
       "enabled": true,
       "protocol": "openid-connect",
       "publicClient": true,
       "redirectUris": [
-        "http://localhost:3000/*",
-        "http://127.0.0.1:3000/*"
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "http://localhost:8080/*",
+        "http://127.0.0.1:8080/*",
+        "http://localhost:9090/*",
+        "http://127.0.0.1:9090/*",
+        "http://localhost:5173/*",
+        "http://127.0.0.1:5173/*"
       ],
       "webOrigins": [
         "http://localhost:3000",
-        "http://127.0.0.1:3000"
+        "http://127.0.0.1:3000",
+        "http://localhost:8080",
+        "http://127.0.0.1:8080",
+        "http://localhost:9090",
+        "http://127.0.0.1:9090",
+        "http://localhost:5173",
+        "http://127.0.0.1:5173"
       ],
       "standardFlowEnabled": true,
       "implicitFlowEnabled": false,
@@ -112,42 +124,6 @@
             "jsonType.label": "String"
           }
         }
-      ]
-    },
-    {
-      "clientId": "agent-frontend",
-      "name": "Agent Frontend",
-      "description": "Public client for agent chat SPA",
-      "enabled": true,
-      "protocol": "openid-connect",
-      "publicClient": true,
-      "redirectUris": [
-        "http://localhost:8080/*",
-        "http://127.0.0.1:8080/*",
-        "http://localhost:9090/*",
-        "http://127.0.0.1:9090/*",
-        "http://localhost:5173/*",
-        "http://127.0.0.1:5173/*"
-      ],
-      "webOrigins": [
-        "http://localhost:8080",
-        "http://127.0.0.1:8080",
-        "http://localhost:9090",
-        "http://127.0.0.1:9090",
-        "http://localhost:5173",
-        "http://127.0.0.1:5173"
-      ],
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": false,
-      "authorizationServicesEnabled": false,
-      "fullScopeAllowed": true,
-      "defaultClientScopes": [
-        "web-origins",
-        "profile",
-        "roles",
-        "email"
       ]
     }
   ]

--- a/memory-service/src/main/resources/application.properties
+++ b/memory-service/src/main/resources/application.properties
@@ -62,21 +62,19 @@ data.encryption.provider.plain.type=plain
 # Enable HTTP access logging
 quarkus.http.access-log.enabled=true
 quarkus.log.level=INFO
+
 quarkus.log.category."io.quarkus.http.access-log".level=INFO
 quarkus.log.category."io.github.chirino.memory".level=INFO
-quarkus.log.category."io.github.chirino.memory.response".level=INFO
-quarkus.log.category."io.github.chirino.memory.membership.audit".level=INFO
+#quarkus.log.category."io.github.chirino.memory.membership.audit".level=INFO
+#quarkus.log.category."io.github.chirino.memory.response".level=INFO
+quarkus.log.category."io.github.chirino.memory.grpc".level=WARN
 
-# Quarkus OIDC adapter + runtime validation
-quarkus.log.category."io.quarkus.oidc".level=DEBUG
-quarkus.log.category."io.quarkus.oidc.runtime".level=DEBUG
-
-# Underlying JWT validation libraries
-quarkus.log.category."io.smallrye.jwt".level=DEBUG
-quarkus.log.category."io.smallrye.jwt.auth".level=DEBUG
-
-# Vert.x auth layer observations
-quarkus.log.category."io.vertx.ext.auth".level=DEBUG
+# Uncomment the following to enable more detailed logging for OIDC and JWT.
+# quarkus.log.category."io.quarkus.oidc".level=DEBUG
+# quarkus.log.category."io.quarkus.oidc.runtime".level=DEBUG
+# quarkus.log.category."io.smallrye.jwt".level=DEBUG
+# quarkus.log.category."io.smallrye.jwt.auth".level=DEBUG
+# quarkus.log.category."io.vertx.ext.auth".level=DEBUG
 
 quarkus.grpc.server.use-separate-server=false
 quarkus.grpc.server.grpc-health.enabled=true

--- a/quarkus/examples/chat-quarkus/src/main/resources/application.properties
+++ b/quarkus/examples/chat-quarkus/src/main/resources/application.properties
@@ -40,6 +40,9 @@ quarkus.datasource.devservices.image-name=pgvector/pgvector:pg17
 # Enable Redis dev service for the memory-service container to use
 quarkus.redis.devservices.enabled=true
 memory-service.cache.type=redis
+memory-service.devservices.port=8082
+memory-service.devservices.env."QUARKUS_HTTP_CORS"=true
+memory-service.devservices.env."QUARKUS_HTTP_CORS_ORIGINS"=http://localhost:3000
 
 # Enable HTTP access logging
 quarkus.http.access-log.enabled=true


### PR DESCRIPTION
Merge admin-frontend and agent-frontend Keycloak clients into a single "frontend" client with combined redirect URIs and web origins. Update auth.tsx to use the new client ID. Reduce verbose OIDC/JWT debug logging in application.properties. Add support for fixed port and additional environment variables in memory-service dev services container.