### PR TITLE
feat: unify search APIs and add prefix matching for full-text search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ A memory service for AI agents that stores messages exchanged with LLMs and user
 # Then search for errors using Grep tool on test.log
 ```
 
-**Pre-release**: Changes do not need backward compatibility.
+**Pre-release**: Changes do not need backward compatibility.  Don't deprecate, just delete.  The datastores are reset frequently.
 
 ## Skills
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -69,6 +69,7 @@ services:
     environment:
       # Trusted agent API keys (first value is surfaced to the Spring app via the service connection)
       MEMORY_SERVICE_API_KEYS_AGENT: agent-api-key-1,agent-api-key-2
+
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/memory_service
       QUARKUS_DATASOURCE_USERNAME: postgres
       QUARKUS_DATASOURCE_PASSWORD: postgres
@@ -79,7 +80,11 @@ services:
       KEYCLOAK_CLIENT_SECRET: change-me
       MEMORY_SERVICE_CACHE_TYPE: redis
       QUARKUS_REDIS_HOSTS: redis://redis:6379
-      # CORS configuration for SPA access
+
+      # To allow admin access to the memory service
+      MEMORY_SERVICE_ROLES_ADMIN_OIDC_ROLE: admin
+      MEMORY_SERVICE_ROLES_AUDITOR_OIDC_ROLE: auditor
+      MEMORY_SERVICE_ROLES_INDEXER_CLIENTS: agent
       QUARKUS_HTTP_CORS: "true"
       QUARKUS_HTTP_CORS_ORIGINS: http://localhost:3000
     depends_on:

--- a/memory-service/src/main/java/io/github/chirino/memory/model/AdminSearchQuery.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/model/AdminSearchQuery.java
@@ -3,11 +3,13 @@ package io.github.chirino.memory.model;
 public class AdminSearchQuery {
 
     private String query;
+    private String searchType;
     private Integer limit;
     private String after;
     private String userId;
     private boolean includeDeleted;
     private Boolean includeEntry;
+    private Boolean groupByConversation;
 
     public String getQuery() {
         return query;
@@ -55,5 +57,21 @@ public class AdminSearchQuery {
 
     public void setIncludeEntry(Boolean includeEntry) {
         this.includeEntry = includeEntry;
+    }
+
+    public String getSearchType() {
+        return searchType;
+    }
+
+    public void setSearchType(String searchType) {
+        this.searchType = searchType;
+    }
+
+    public Boolean getGroupByConversation() {
+        return groupByConversation;
+    }
+
+    public void setGroupByConversation(Boolean groupByConversation) {
+        this.groupByConversation = groupByConversation;
     }
 }

--- a/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/MemoryStore.java
@@ -14,7 +14,6 @@ import io.github.chirino.memory.api.dto.IndexConversationsResponse;
 import io.github.chirino.memory.api.dto.IndexEntryRequest;
 import io.github.chirino.memory.api.dto.OwnershipTransferDto;
 import io.github.chirino.memory.api.dto.PagedEntries;
-import io.github.chirino.memory.api.dto.SearchEntriesRequest;
 import io.github.chirino.memory.api.dto.SearchResultsDto;
 import io.github.chirino.memory.api.dto.ShareConversationRequest;
 import io.github.chirino.memory.api.dto.SyncResult;
@@ -125,8 +124,6 @@ public interface MemoryStore {
      * @param indexedAt the timestamp when the entry was indexed
      */
     void setIndexedAt(String entryId, OffsetDateTime indexedAt);
-
-    SearchResultsDto searchEntries(String userId, SearchEntriesRequest request);
 
     // Admin methods — no userId scoping, configurable deleted-resource visibility
     List<ConversationSummaryDto> adminListConversations(AdminConversationQuery query);

--- a/memory-service/src/main/java/io/github/chirino/memory/vector/FullTextSearchRepository.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/vector/FullTextSearchRepository.java
@@ -4,16 +4,22 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.jboss.logging.Logger;
 
 /**
  * Repository for PostgreSQL full-text search using tsvector and GIN indexes.
  *
  * <p>Provides fast keyword search with stemming, ranking, and highlighting as a fallback when
- * vector search is unavailable or returns no results.
+ * vector search is unavailable or returns no results. Uses prefix matching with the :* operator
+ * to match partial words (e.g., "Jav" matches "JavaScript").
  */
 @ApplicationScoped
 public class FullTextSearchRepository {
+
+    private static final Logger LOG = Logger.getLogger(FullTextSearchRepository.class);
 
     @Inject EntityManager entityManager;
 
@@ -30,6 +36,15 @@ public class FullTextSearchRepository {
     public List<FullTextSearchResult> search(
             String userId, String query, int limit, boolean groupByConversation) {
 
+        // Convert query to prefix tsquery format (e.g., "Jav script" -> "Jav:* & script:*")
+        String prefixQuery = toPrefixTsQuery(query);
+        if (prefixQuery.isEmpty()) {
+            LOG.infof("fullTextSearch: empty query after conversion, original='%s'", query);
+            return List.of();
+        }
+        LOG.infof(
+                "fullTextSearch: converted query '%s' to prefix tsquery '%s'", query, prefixQuery);
+
         String sql;
         if (groupByConversation) {
             sql =
@@ -38,18 +53,18 @@ public class FullTextSearchRepository {
                         SELECT
                             e.id AS entry_id,
                             e.conversation_id,
-                            ts_rank(e.indexed_content_tsv, plainto_tsquery('english', ?1)) AS score,
-                            ts_headline('english', e.indexed_content, plainto_tsquery('english', ?1),
+                            ts_rank(e.indexed_content_tsv, to_tsquery('english', ?1)) AS score,
+                            ts_headline('english', e.indexed_content, to_tsquery('english', ?1),
                                 'StartSel=<mark>, StopSel=</mark>, MaxWords=50, MinWords=20') AS highlight,
                             ROW_NUMBER() OVER (
                                 PARTITION BY e.conversation_id
-                                ORDER BY ts_rank(e.indexed_content_tsv, plainto_tsquery('english', ?1)) DESC
+                                ORDER BY ts_rank(e.indexed_content_tsv, to_tsquery('english', ?1)) DESC
                             ) AS rank_in_conversation
                         FROM entries e
                         JOIN conversations c ON c.id = e.conversation_id AND c.deleted_at IS NULL
                         JOIN conversation_groups cg ON cg.id = c.conversation_group_id AND cg.deleted_at IS NULL
                         JOIN conversation_memberships cm ON cm.conversation_group_id = cg.id AND cm.user_id = ?2
-                        WHERE e.indexed_content_tsv @@ plainto_tsquery('english', ?1)
+                        WHERE e.indexed_content_tsv @@ to_tsquery('english', ?1)
                     )
                     SELECT entry_id, conversation_id, score, highlight
                     FROM accessible_ranked
@@ -63,14 +78,14 @@ public class FullTextSearchRepository {
                     SELECT
                         e.id AS entry_id,
                         e.conversation_id,
-                        ts_rank(e.indexed_content_tsv, plainto_tsquery('english', ?1)) AS score,
-                        ts_headline('english', e.indexed_content, plainto_tsquery('english', ?1),
+                        ts_rank(e.indexed_content_tsv, to_tsquery('english', ?1)) AS score,
+                        ts_headline('english', e.indexed_content, to_tsquery('english', ?1),
                             'StartSel=<mark>, StopSel=</mark>, MaxWords=50, MinWords=20') AS highlight
                     FROM entries e
                     JOIN conversations c ON c.id = e.conversation_id AND c.deleted_at IS NULL
                     JOIN conversation_groups cg ON cg.id = c.conversation_group_id AND cg.deleted_at IS NULL
                     JOIN conversation_memberships cm ON cm.conversation_group_id = cg.id AND cm.user_id = ?2
-                    WHERE e.indexed_content_tsv @@ plainto_tsquery('english', ?1)
+                    WHERE e.indexed_content_tsv @@ to_tsquery('english', ?1)
                     ORDER BY score DESC
                     LIMIT ?3
                     """;
@@ -80,10 +95,158 @@ public class FullTextSearchRepository {
         List<Object[]> rows =
                 entityManager
                         .createNativeQuery(sql)
-                        .setParameter(1, query)
+                        .setParameter(1, prefixQuery)
                         .setParameter(2, userId)
                         .setParameter(3, limit)
                         .getResultList();
+
+        return rows.stream()
+                .map(
+                        row ->
+                                new FullTextSearchResult(
+                                        row[0].toString(), // entry_id
+                                        row[1].toString(), // conversation_id
+                                        ((Number) row[2]).doubleValue(), // score
+                                        (String) row[3] // highlight
+                                        ))
+                .toList();
+    }
+
+    /**
+     * Converts a plain text query to a PostgreSQL tsquery with prefix matching.
+     *
+     * <p>Example: "Jav script" becomes "Jav:* & script:*"
+     *
+     * @param query the plain text search query
+     * @return the tsquery string with prefix operators
+     */
+    private String toPrefixTsQuery(String query) {
+        if (query == null || query.isBlank()) {
+            return "";
+        }
+
+        return Arrays.stream(query.trim().split("\\s+"))
+                .filter(word -> !word.isEmpty())
+                .map(this::escapeTsQueryWord)
+                .filter(word -> !word.isEmpty())
+                .map(word -> word + ":*")
+                .collect(Collectors.joining(" & "));
+    }
+
+    /**
+     * Escapes special characters in a word for use in to_tsquery.
+     *
+     * <p>Removes characters that have special meaning in tsquery syntax.
+     */
+    private String escapeTsQueryWord(String word) {
+        // Remove tsquery special characters: & | ! ( ) : * \ '
+        return word.replaceAll("[&|!():'\\\\*]", "");
+    }
+
+    /**
+     * Admin full-text search on indexed_content without membership filtering.
+     *
+     * @param query the search query
+     * @param limit maximum results
+     * @param groupByConversation when true, returns best match per conversation
+     * @param userId optional filter by conversation owner
+     * @param includeDeleted whether to include soft-deleted conversations
+     * @return search results with scores and highlights
+     */
+    @Transactional
+    public List<FullTextSearchResult> adminSearch(
+            String query,
+            int limit,
+            boolean groupByConversation,
+            String userId,
+            boolean includeDeleted) {
+
+        // Convert query to prefix tsquery format (e.g., "Jav script" -> "Jav:* & script:*")
+        String prefixQuery = toPrefixTsQuery(query);
+        if (prefixQuery.isEmpty()) {
+            LOG.infof("adminSearch: empty query after conversion, original='%s'", query);
+            return List.of();
+        }
+        LOG.infof(
+                "adminSearch: converted query '%s' to prefix tsquery '%s', userId=%s,"
+                        + " includeDeleted=%s",
+                query, prefixQuery, userId, includeDeleted);
+
+        // Build dynamic WHERE clauses
+        StringBuilder deletedFilter = new StringBuilder();
+        if (!includeDeleted) {
+            deletedFilter.append(" AND c.deleted_at IS NULL AND cg.deleted_at IS NULL");
+        }
+
+        StringBuilder userFilter = new StringBuilder();
+        if (userId != null && !userId.isBlank()) {
+            userFilter.append(" AND c.owner_user_id = ?4");
+        }
+
+        String sql;
+        if (groupByConversation) {
+            sql =
+                    """
+                    WITH ranked AS (
+                        SELECT
+                            e.id AS entry_id,
+                            e.conversation_id,
+                            ts_rank(e.indexed_content_tsv, to_tsquery('english', ?1)) AS score,
+                            ts_headline('english', e.indexed_content, to_tsquery('english', ?1),
+                                'StartSel=<mark>, StopSel=</mark>, MaxWords=50, MinWords=20') AS highlight,
+                            ROW_NUMBER() OVER (
+                                PARTITION BY e.conversation_id
+                                ORDER BY ts_rank(e.indexed_content_tsv, to_tsquery('english', ?1)) DESC
+                            ) AS rank_in_conversation
+                        FROM entries e
+                        JOIN conversations c ON c.id = e.conversation_id
+                        JOIN conversation_groups cg ON cg.id = c.conversation_group_id
+                        WHERE e.indexed_content_tsv @@ to_tsquery('english', ?1)
+                    """
+                            + deletedFilter
+                            + userFilter
+                            + """
+                            )
+                            SELECT entry_id, conversation_id, score, highlight
+                            FROM ranked
+                            WHERE rank_in_conversation = 1
+                            ORDER BY score DESC
+                            LIMIT ?2
+                            """;
+        } else {
+            sql =
+                    """
+                    SELECT
+                        e.id AS entry_id,
+                        e.conversation_id,
+                        ts_rank(e.indexed_content_tsv, to_tsquery('english', ?1)) AS score,
+                        ts_headline('english', e.indexed_content, to_tsquery('english', ?1),
+                            'StartSel=<mark>, StopSel=</mark>, MaxWords=50, MinWords=20') AS highlight
+                    FROM entries e
+                    JOIN conversations c ON c.id = e.conversation_id
+                    JOIN conversation_groups cg ON cg.id = c.conversation_group_id
+                    WHERE e.indexed_content_tsv @@ to_tsquery('english', ?1)
+                    """
+                            + deletedFilter
+                            + userFilter
+                            + """
+                            ORDER BY score DESC
+                            LIMIT ?2
+                            """;
+        }
+
+        var nativeQuery =
+                entityManager
+                        .createNativeQuery(sql)
+                        .setParameter(1, prefixQuery)
+                        .setParameter(2, limit);
+
+        if (userId != null && !userId.isBlank()) {
+            nativeQuery.setParameter(4, userId);
+        }
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = nativeQuery.getResultList();
 
         return rows.stream()
                 .map(

--- a/memory-service/src/main/java/io/github/chirino/memory/vector/NoopVectorStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/vector/NoopVectorStore.java
@@ -2,6 +2,7 @@ package io.github.chirino.memory.vector;
 
 import io.github.chirino.memory.api.dto.SearchEntriesRequest;
 import io.github.chirino.memory.api.dto.SearchResultsDto;
+import io.github.chirino.memory.model.AdminSearchQuery;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.Collections;
 
@@ -15,6 +16,14 @@ public class NoopVectorStore implements VectorStore {
 
     @Override
     public SearchResultsDto search(String userId, SearchEntriesRequest request) {
+        SearchResultsDto result = new SearchResultsDto();
+        result.setResults(Collections.emptyList());
+        result.setNextCursor(null);
+        return result;
+    }
+
+    @Override
+    public SearchResultsDto adminSearch(AdminSearchQuery query) {
         SearchResultsDto result = new SearchResultsDto();
         result.setResults(Collections.emptyList());
         result.setNextCursor(null);

--- a/memory-service/src/main/java/io/github/chirino/memory/vector/VectorStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/vector/VectorStore.java
@@ -2,6 +2,7 @@ package io.github.chirino.memory.vector;
 
 import io.github.chirino.memory.api.dto.SearchEntriesRequest;
 import io.github.chirino.memory.api.dto.SearchResultsDto;
+import io.github.chirino.memory.model.AdminSearchQuery;
 
 public interface VectorStore {
 
@@ -9,12 +10,21 @@ public interface VectorStore {
 
     SearchResultsDto search(String userId, SearchEntriesRequest request);
 
+    /**
+     * Admin search without membership restrictions. Supports the same search types (semantic,
+     * fulltext, auto) as the user-facing search but can search across all users.
+     *
+     * @param query the admin search query with optional userId filter and includeDeleted flag
+     * @return search results
+     */
+    SearchResultsDto adminSearch(AdminSearchQuery query);
+
     void upsertTranscriptEmbedding(
             String conversationGroupId, String conversationId, String entryId, float[] embedding);
 
     /**
-     * Delete all embeddings for a conversation group.
-     * Used by the background task queue for cleanup after eviction.
+     * Delete all embeddings for a conversation group. Used by the background task queue for cleanup
+     * after eviction.
      */
     void deleteByConversationGroupId(String conversationGroupId);
 }

--- a/quarkus/examples/chat-quarkus/src/main/resources/application.properties
+++ b/quarkus/examples/chat-quarkus/src/main/resources/application.properties
@@ -40,9 +40,14 @@ quarkus.datasource.devservices.image-name=pgvector/pgvector:pg17
 # Enable Redis dev service for the memory-service container to use
 quarkus.redis.devservices.enabled=true
 memory-service.cache.type=redis
+
+# To allow admin access to the memory service
 memory-service.devservices.port=8082
-memory-service.devservices.env."QUARKUS_HTTP_CORS"=true
-memory-service.devservices.env."QUARKUS_HTTP_CORS_ORIGINS"=http://localhost:3000
+memory-service.devservices.env.MEMORY_SERVICE_ROLES_ADMIN_OIDC_ROLE=admin
+memory-service.devservices.env.MEMORY_SERVICE_ROLES_AUDITOR_OIDC_ROLE=auditor
+memory-service.devservices.env.MEMORY_SERVICE_ROLES_INDEXER_CLIENTS=agent
+memory-service.devservices.env.QUARKUS_HTTP_CORS=true
+memory-service.devservices.env.QUARKUS_HTTP_CORS_ORIGINS=http://localhost:3000
 
 # Enable HTTP access logging
 quarkus.http.access-log.enabled=true

--- a/spring/examples/chat-spring/compose.yaml
+++ b/spring/examples/chat-spring/compose.yaml
@@ -66,6 +66,7 @@ services:
     environment:
       # Trusted agent API keys (first value is surfaced to the Spring app via the service connection)
       MEMORY_SERVICE_API_KEYS_AGENT: agent-api-key-1,agent-api-key-2
+
       QUARKUS_DATASOURCE_JDBC_URL: jdbc:postgresql://postgres:5432/memory_service
       QUARKUS_DATASOURCE_USERNAME: postgres
       QUARKUS_DATASOURCE_PASSWORD: postgres
@@ -76,6 +77,14 @@ services:
       KEYCLOAK_CLIENT_SECRET: change-me
       MEMORY_SERVICE_CACHE_TYPE: redis
       QUARKUS_REDIS_HOSTS: redis://redis:6379
+
+      # To allow admin access to the memory service
+      MEMORY_SERVICE_ROLES_ADMIN_OIDC_ROLE: admin
+      MEMORY_SERVICE_ROLES_AUDITOR_OIDC_ROLE: auditor
+      MEMORY_SERVICE_ROLES_INDEXER_CLIENTS: agent
+      QUARKUS_HTTP_CORS: "true"
+      QUARKUS_HTTP_CORS_ORIGINS: http://localhost:3000
+
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
- Remove deprecated in-memory searchEntries from PostgresMemoryStore and MongoMemoryStore
- Add prefix matching (:*) to full-text search so partial words match (e.g., "Jav" → "JavaScript")
- Unify admin search API with user-facing search interface (searchType, groupByConversation, etc.)
- Add adminSearch method to VectorStore for searching across all users
- Add comprehensive info-level logging throughout search flow
- Fix admin search response to include entryId (was missing)