### PR TITLE
refactor(chat-frontend): simplify fork visualization with ForkView ab…

### DIFF
--- a/common/chat-frontend/src/App.tsx
+++ b/common/chat-frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { ChatSidebar } from "@/components/chat-sidebar";
 import { SearchModal } from "@/components/search-modal";
 import { PendingTransfersPanel } from "@/components/sharing";
 import { useResumeCheck } from "@/hooks/useResumeCheck";
-import { useAuth, getAccessToken } from "@/lib/auth";
+import { useAuth } from "@/lib/auth";
 
 type ListUserConversationsResponse = {
   data?: ConversationSummary[];
@@ -252,31 +252,6 @@ function App() {
     },
   });
 
-  const indexConversationMutation = useMutation({
-    mutationFn: async (conversationId: string) => {
-      const headers: Record<string, string> = {};
-      const token = getAccessToken();
-      if (token) {
-        headers["Authorization"] = `Bearer ${token}`;
-      }
-      const response = await fetch(`/v1/conversations/${conversationId}/index`, {
-        method: "POST",
-        headers,
-      });
-      if (!response.ok) {
-        throw new Error("Indexing failed");
-      }
-    },
-    onSuccess: (_, conversationId) => {
-      void queryClient.invalidateQueries({ queryKey: ["conversations"] });
-      void queryClient.invalidateQueries({ queryKey: ["messages", conversationId] });
-      setStatusMessage(null);
-    },
-    onError: () => {
-      setStatusMessage("Failed to index conversation. Please try again.");
-    },
-  });
-
   const handleNewChat = () => {
     setStatusMessage(null);
     const newId = generateConversationId();
@@ -311,14 +286,6 @@ function App() {
       deleteConversationMutation.mutate(conversationId);
     },
     [deleteConversationMutation],
-  );
-
-  const handleIndexConversationById = useCallback(
-    (conversationId: string) => {
-      setStatusMessage(null);
-      indexConversationMutation.mutate(conversationId);
-    },
-    [indexConversationMutation],
   );
 
   useEffect(() => {
@@ -370,7 +337,6 @@ function App() {
           onSelectConversationId={handleSelectConversationId}
           knownConversationIds={resolvedConversationIds}
           resumableConversationIds={resumableConversationIds}
-          onIndexConversation={handleIndexConversationById}
           onDeleteConversation={handleDeleteConversationById}
           currentUserId={currentUserId}
           currentUser={currentUser}

--- a/common/chat-frontend/src/components/conversation-hover-menu.tsx
+++ b/common/chat-frontend/src/components/conversation-hover-menu.tsx
@@ -1,24 +1,12 @@
-import { Sparkles, Trash2 } from "lucide-react";
+import { Trash2 } from "lucide-react";
 
 type ConversationHoverMenuProps = {
-  onIndex?: () => void;
   onDelete?: () => void;
 };
 
-export function ConversationHoverMenu({ onIndex, onDelete }: ConversationHoverMenuProps) {
+export function ConversationHoverMenu({ onDelete }: ConversationHoverMenuProps) {
   return (
     <div className="pointer-events-none absolute right-2 top-2 flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
-      <button
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation();
-          onIndex?.();
-        }}
-        className="pointer-events-auto rounded-lg border border-stone/10 bg-cream/90 p-1.5 text-stone transition-colors hover:border-sage/30 hover:text-sage"
-        title="Index conversation"
-      >
-        <Sparkles className="h-3.5 w-3.5" />
-      </button>
       <button
         type="button"
         onClick={(event) => {

--- a/common/chat-frontend/src/lib/conversation.ts
+++ b/common/chat-frontend/src/lib/conversation.ts
@@ -1,3 +1,5 @@
+import type { Entry, ConversationForkSummary } from "../client/types.gen";
+
 export const NEW_CONVERSATION_ID = "new";
 
 export function isNewConversationId(conversationId: string | null | undefined): boolean {
@@ -6,4 +8,167 @@ export function isNewConversationId(conversationId: string | null | undefined): 
 
 export function generateConversationId(): string {
   return typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : `session-${Date.now()}`;
+}
+
+/**
+ * Information about a fork option that branches at a specific entry.
+ */
+export interface ForkOption {
+  /** The conversation ID of the forked conversation */
+  conversationId: string;
+  /** The conversation ID from which this fork originated */
+  forkedAtConversationId?: string | null;
+  /** The entry ID where the fork branches (the last entry included before the fork) */
+  forkedAtEntryId?: string | null;
+  /** When the fork was created */
+  createdAt?: string | null;
+  /** Preview text/label for the fork */
+  label?: string;
+}
+
+/**
+ * An entry with optional fork information showing where conversations branch.
+ */
+export interface EntryAndForkInfo {
+  /** The entry data */
+  entry: Entry;
+  /** Forks that branch at this entry (i.e., this entry is the first one excluded in those forks) */
+  forks?: ForkOption[];
+}
+
+/**
+ * Helper interface for visualizing conversation forks.
+ * Created by `createForkView` from entries and forks API responses.
+ */
+export interface ForkView {
+  /** Returns all unique conversation IDs present in the entries */
+  conversationIds(): string[];
+  /**
+   * Returns entries for a specific conversation with fork information attached.
+   * Includes entries from ancestor conversations up to each fork point,
+   * providing the full conversation history as seen from this conversation.
+   */
+  entries(conversationId: string): EntryAndForkInfo[];
+}
+
+/**
+ * Creates a ForkView to help visualize conversation forks.
+ *
+ * This function processes the results from the `/entries` and `/forks` API calls
+ * and provides methods to easily access entries grouped by conversation with
+ * fork branch points annotated.
+ *
+ * Fork semantics: When a fork has `forkedAtEntryId = X`, it means the fork
+ * includes all entries up to and including X, but excludes entries after X.
+ * Therefore, the entry immediately after X in the original conversation is
+ * where the fork "branches" - this is the entry that gets the fork annotation.
+ *
+ * @param entries - Array of entries (typically from `/entries?forks=all`)
+ * @param forks - Array of fork summaries (from `/forks`)
+ * @returns A ForkView object with methods to access entries and fork info
+ *
+ * @example
+ * ```typescript
+ * const entries = await listConversationEntries({ conversationId, forks: 'all' });
+ * const forks = await listConversationForks({ conversationId });
+ * const view = createForkView(entries.data, forks.data);
+ *
+ * // Get all conversation IDs
+ * const convIds = view.conversationIds();
+ *
+ * // Get entries for a specific conversation with fork info
+ * for (const item of view.entries(convIds[0])) {
+ *   console.log(item.entry.id);
+ *   if (item.forks) {
+ *     console.log(`  Has ${item.forks.length} fork(s)`);
+ *   }
+ * }
+ * ```
+ */
+export function createForkView(entries: Entry[], forks: ConversationForkSummary[]): ForkView {
+  const forksByEntryId = new Map<string, ForkOption[]>();
+  const forksByConversationId = new Map<string, ConversationForkSummary>();
+  for (const fork of forks) {
+    const key = fork.forkedAtEntryId || "";
+    if (!forksByEntryId.has(key)) {
+      forksByEntryId.set(key, []);
+    }
+    if (fork.conversationId) {
+      forksByConversationId.set(fork.conversationId, fork);
+    }
+  }
+
+  const entriesByConversation = new Map<string, Entry[]>();
+  for (const entry of entries) {
+    const convId = entry.conversationId;
+    if (!entriesByConversation.has(convId)) {
+      entriesByConversation.set(convId, []);
+    }
+    const entries = entriesByConversation.get(convId)!;
+
+    const forkSummary = forksByConversationId.get(entry.conversationId);
+    const forkPointId = entries.length === 0 ? forkSummary?.forkedAtEntryId || "" : entries[entries.length - 1].id;
+
+    const fork = forksByEntryId.get(forkPointId);
+
+    if (fork) {
+      const content = entry.content[0] as { text?: string } | undefined;
+      fork.push({
+        forkedAtConversationId: forkSummary?.forkedAtConversationId,
+        forkedAtEntryId: forkSummary?.forkedAtEntryId,
+        conversationId: entry.conversationId,
+        createdAt: entry.createdAt,
+        label: content?.text,
+      });
+    }
+
+    entries.push(entry);
+  }
+
+  /**
+   * Recursively get entries for a conversation, including ancestor entries.
+   * @param conversationId - The conversation to get entries for
+   * @param untilEntryId - If provided, only include entries up to and including this entry ID.
+   *                       If null/undefined, include all entries from this conversation.
+   */
+  function getEntries(conversationId: string, untilEntryId?: string | null): Entry[] {
+    const result: Entry[] = [];
+
+    // First, recursively get parent entries if this conversation is a fork
+    const meta = forksByConversationId.get(conversationId);
+    if (meta?.forkedAtConversationId && meta.forkedAtEntryId) {
+      result.push(...getEntries(meta.forkedAtConversationId, meta.forkedAtEntryId));
+    }
+
+    // Then add entries from this conversation
+    const convEntries = entriesByConversation.get(conversationId) ?? [];
+    for (const entry of convEntries) {
+      result.push(entry);
+      if (entry.id === untilEntryId) {
+        break;
+      }
+    }
+
+    return result;
+  }
+
+  return {
+    conversationIds(): string[] {
+      return Array.from(entriesByConversation.keys()).sort();
+    },
+
+    entries(conversationId: string): EntryAndForkInfo[] {
+      const combinedEntries = getEntries(conversationId);
+
+      let prevId = "";
+      return combinedEntries.map((entry) => {
+        const result: EntryAndForkInfo = {
+          entry,
+          forks: forksByEntryId.get(prevId),
+        };
+        prevId = entry.id;
+        return result;
+      });
+    },
+  };
 }

--- a/memory-service/src/main/resources/application.properties
+++ b/memory-service/src/main/resources/application.properties
@@ -1,18 +1,13 @@
+# Enable PostgreSQL dev service for the memory-service container to use
+quarkus.datasource.db-kind=postgresql
+quarkus.datasource.devservices.enabled=true
+quarkus.datasource.devservices.db-name=memory_service
 # To be able to use the pgvector dev service, we need to set the image name
 quarkus.datasource.devservices.image-name=pgvector/pgvector:pg17
 
-# Dev profile: local PostgreSQL (used for quarkus:dev and manual runs)
-%dev.quarkus.http.port=8081
-
 # Liquibase for PostgreSQL
-%dev.quarkus.liquibase.migrate-at-start=true
-%prod.quarkus.liquibase.migrate-at-start=true
+quarkus.liquibase.migrate-at-start=true
 quarkus.liquibase.change-log=db/changelog/db.changelog-master.yaml
-
-# Test profile: use Dev Services to start a PostgreSQL container automatically.
-%test.quarkus.datasource.devservices.enabled=true
-%test.quarkus.liquibase.migrate-at-start=true
-%test.quarkus.liquibase.change-log=db/changelog/db.changelog-master.yaml
 
 # Prefer JSONB for JSON mappings on PostgreSQL
 hibernate.type.preferred_json_format=jsonb
@@ -134,10 +129,6 @@ memory-service.tasks.stale-claim-timeout=PT5M
 memory-service.eviction.batch-size=1000
 memory-service.eviction.batch-delay-ms=100
 
-%dev.quarkus.datasource.db-kind=postgresql
-%dev.quarkus.redis.devservices.enabled=true
-%dev.memory-service.cache.type=redis
-
 %test.quarkus.datasource.db-kind=postgresql
 %test.quarkus.redis.devservices.enabled=true
 %test.memory-service.cache.type=redis
@@ -148,3 +139,21 @@ quarkus.http.cors.methods=GET,POST,PUT,PATCH,DELETE,OPTIONS
 quarkus.http.cors.headers=accept,authorization,content-type,x-requested-with
 quarkus.http.cors.exposed-headers=content-type,authorization
 quarkus.http.cors.access-control-allow-credentials=true
+
+# Keycloak dev services - expose on port 8081 and import realm (dev profile only)
+%dev.quarkus.keycloak.devservices.enabled=true
+%dev.quarkus.keycloak.devservices.port=8081
+%dev.quarkus.keycloak.devservices.realm-path=../common/keycloak/memory-service-realm.json
+
+%dev.quarkus.http.port=8082
+%dev.memory-service.api-keys.port=8082   
+%dev.memory-service.api-keys.agent=agent-api-key-1
+%dev.memory-service.roles.admin.oidc.role=admin
+%dev.memory-service.roles.auditor.oidc.role=auditor
+%dev.memory-service.roles.indexer.clients=agent
+%dev.quarkus.http.cors=true
+%dev.quarkus.http.cors.origins=http://localhost:3000
+
+%dev.quarkus.datasource.db-kind=postgresql
+%dev.quarkus.redis.devservices.enabled=true
+%dev.memory-service.cache.type=redis

--- a/quarkus/examples/chat-quarkus/src/main/java/example/MemoryServiceProxyResource.java
+++ b/quarkus/examples/chat-quarkus/src/main/java/example/MemoryServiceProxyResource.java
@@ -59,7 +59,7 @@ public class MemoryServiceProxyResource {
             @QueryParam("after") String after,
             @QueryParam("limit") Integer limit) {
         return proxy.listConversationEntries(
-                conversationId, after, limit, Channel.HISTORY, null, null);
+                conversationId, after, limit, Channel.HISTORY, null, "all");
     }
 
     @POST

--- a/quarkus/examples/chat-quarkus/src/main/resources/application.properties
+++ b/quarkus/examples/chat-quarkus/src/main/resources/application.properties
@@ -54,3 +54,14 @@ memory-service.devservices.env.QUARKUS_HTTP_CORS_ORIGINS=http://localhost:3000
 # Enable HTTP access logging
 quarkus.http.access-log.enabled=true
 quarkus.log.category."io.quarkus.http.access-log".level=INFO
+
+# Use the alt profile to run both the memory-service and chat-quarkus in dev mode.
+#   ./mvnw -T 1C -pl :memory-service quarkus:dev
+#   ./mvnw -T 1C -pl :chat-quarkus quarkus:dev -Dquarkus.profile=alt
+%alt.quarkus.devservices.enabled=false
+%alt.memory-service.client.url=http://localhost:8082
+%alt.memory-service.client.api-key=agent-api-key-1
+%alt.quarkus.oidc.auth-server-url=http://localhost:8081/realms/memory-service
+%alt.quarkus.oidc.token-issuer=http://localhost:8081/realms/memory-service
+%alt.quarkus.oidc.client-id=memory-service-client
+%alt.quarkus.oidc.credentials.secret=change-me

--- a/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryServiceChatMemory.java
+++ b/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryServiceChatMemory.java
@@ -107,6 +107,13 @@ public class MemoryServiceChatMemory implements ChatMemory {
             if (entry.getContent() == null) {
                 continue;
             }
+            // Only decode entries with LC4J content type
+            if (!"LC4J".equals(entry.getContentType())) {
+                LOG.debugf(
+                        "Skipping entry %s with contentType=%s (not LC4J)",
+                        entry.getId(), entry.getContentType());
+                continue;
+            }
 
             for (Object block : entry.getContent()) {
                 if (block == null) {
@@ -146,6 +153,6 @@ public class MemoryServiceChatMemory implements ChatMemory {
                     conversationId,
                     entryId);
         }
-        return null;
+        return List.of();
     }
 }


### PR DESCRIPTION
…straction

Extract fork handling logic into a new createForkView helper that provides a cleaner API for accessing conversation entries with fork branch points. This removes the complex lazy-loading fork label logic from ChatPanelContent and centralizes fork computation in conversation.ts.

Also removes the manual "Index conversation" UI (now automatic), reorganizes dev services config to add Keycloak on port 8081, and adds an %alt profile for running memory-service and chat-quarkus simultaneously in dev mode.