### PR TITLE
docs: update API terminology and client documentation

### DIFF
--- a/site/src/pages/docs/quarkus/advanced-features.mdx
+++ b/site/src/pages/docs/quarkus/advanced-features.mdx
@@ -17,19 +17,19 @@ Make sure you've completed the previous guides:
 
 ## Conversation Forking
 
-Conversation forking lets users branch off from any point in a conversation to explore alternative paths. 
+Conversation forking lets users branch off from any point in a conversation to explore alternative paths.
 Add these methods to the `ConversationsResource.java` to enable forking and listing forks:
 
 ```java
 @POST
-@Path("/{conversationId}/messages/{messageId}/fork")
+@Path("/{conversationId}/entries/{entryId}/fork")
 @Consumes(MediaType.APPLICATION_JSON)
 @Produces(MediaType.APPLICATION_JSON)
-public Response forkConversationAtMessage(
+public Response forkConversationAtEntry(
         @PathParam("conversationId") String conversationId,
-        @PathParam("messageId") String messageId,
+        @PathParam("entryId") String entryId,
         String body) {
-    return proxy.forkConversationAtMessage(conversationId, messageId, body);
+    return proxy.forkConversationAtEntry(conversationId, entryId, body);
 }
 
 @GET
@@ -41,28 +41,28 @@ public Response listConversationForks(@PathParam("conversationId") String conver
 ```
 
 The fork endpoint creates a new conversation that:
-- Copies all messages up to and exluding the specified message
+- Copies all entries up to and excluding the specified entry
 - Creates a new conversation ID for the fork
 - Links the fork back to the original conversation
 
 Test it with curl:
 
 ```bash
-# get the id of the first message in the conversation
-FIRST_MESSAGE_ID=$(curl -sSfX GET http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/messages \
+# get the id of the first entry in the conversation
+FIRST_ENTRY_ID=$(curl -sSfX GET http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/entries \
   -H "Authorization: Bearer $(get-token)" | jq -r '.data[0].id')
 
-curl -sSfX POST http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/messages/$FIRST_MESSAGE_ID/fork \
+curl -sSfX POST http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/entries/$FIRST_ENTRY_ID/fork \
   -H "Authorization: Bearer $(get-token)" \
   -H "Content-Type: application/json" \
   -d '{"title": "Alternative approach"}' | jq
 ```
 
-This will create a new conversation with the forkedAtConversationId `3579aac5-c86e-4b67-bbea-6ec1a3644942` and the title "Alternative approach", but you will will have a new conversation ID.
+This will create a new conversation with the forkedAtConversationId `3579aac5-c86e-4b67-bbea-6ec1a3644942` and the title "Alternative approach", but you will have a new conversation ID.
 
-If you browse to the to [http://localhost:8080/?conversationId=da597b28-5ccd-4900-92e9-0aec57394523](http://localhost:8080/?conversationId=da597b28-5ccd-4900-92e9-0aec57394523)
-you will see that the first message now has fork.  If you pick that fork you will see that the conversation history of the new fork is empty, because the selected message is
-not part of the fork, and we had selected the first message in the original conversation.
+If you browse to [http://localhost:8080/?conversationId=da597b28-5ccd-4900-92e9-0aec57394523](http://localhost:8080/?conversationId=da597b28-5ccd-4900-92e9-0aec57394523)
+you will see that the first entry now has a fork. If you pick that fork you will see that the conversation history of the new fork is empty, because the selected entry is
+not part of the fork, and we had selected the first entry in the original conversation.
 
 ## Streaming Responses
 

--- a/site/src/pages/docs/quarkus/conversation-history.mdx
+++ b/site/src/pages/docs/quarkus/conversation-history.mdx
@@ -100,9 +100,9 @@ This time when you browse to to the demo agent app at
 [http://localhost:8080/?conversationId=3579aac5-c86e-4b67-bbea-6ec1a3644942](http://localhost:8080/?conversationId=3579aac5-c86e-4b67-bbea-6ec1a3644942) 
 you should see the messages that were exchanged between you and the agent.
 
-## Expose Conversation Messages API
+## Expose Conversation Entries API
 
-To let the frontend load a conversation's message history,
+To let the frontend load a conversation's entry history,
 add a jackson dependency to enable JSON serialization/deserialization to the `pom.xml`:
 
 ```xml
@@ -117,7 +117,7 @@ Then create a REST resource that proxies requests to Memory Service:
 ```java
 package org.acme;
 
-import io.github.chirino.memory.client.model.MessageChannel;
+import io.github.chirino.memory.client.model.Channel;
 import io.github.chirino.memory.runtime.MemoryServiceProxy;
 import io.smallrye.common.annotation.Blocking;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -135,7 +135,7 @@ import jakarta.ws.rs.core.Response;
 @Blocking
 public class ConversationsResource {
 
-    @Inject 
+    @Inject
     MemoryServiceProxy proxy;
 
     @GET
@@ -146,14 +146,14 @@ public class ConversationsResource {
     }
 
     @GET
-    @Path("/{conversationId}/messages")
+    @Path("/{conversationId}/entries")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response listConversationMessages(
+    public Response listConversationEntries(
             @PathParam("conversationId") String conversationId,
             @QueryParam("after") String after,
             @QueryParam("limit") Integer limit) {
-        return proxy.listConversationMessages(
-                conversationId, after, limit, MessageChannel.HISTORY, null);
+        return proxy.listConversationEntries(
+                conversationId, after, limit, Channel.HISTORY, null, null);
     }
 }
 ```
@@ -162,7 +162,7 @@ The `MemoryServiceProxy` is helper class that makes it easier to implement a JAX
 - Authentication with the memory service
 - Passing through the user's bearer token for authorization
 
-The `MessageChannel.HISTORY` parameter ensures you get messages from the history channel (recorded by `@RecordConversation`) rather than the memory channel (used by agents internally).
+The `Channel.HISTORY` parameter ensures you get entries from the history channel (recorded by `@RecordConversation`) rather than the memory channel (used by agents internally).
 
 Test it with curl:
 
@@ -170,11 +170,11 @@ Test it with curl:
 curl -sSfX GET http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/ \
   -H "Authorization: Bearer $(get-token)" | jq
 
-curl -sSfX GET http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/messages \
+curl -sSfX GET http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/entries \
   -H "Authorization: Bearer $(get-token)" | jq
 ```
 
-You should see the conversation and messages that were exchanged between you and the agent.
+You should see the conversation and entries that were exchanged between you and the agent.
 
 ## Expose Conversation Listing API
 

--- a/site/src/pages/docs/quarkus/grpc-client.mdx
+++ b/site/src/pages/docs/quarkus/grpc-client.mdx
@@ -12,7 +12,7 @@ export const mavenDep = `<dependency>
   <version>${PROJECT_VERSION}</version>
 </dependency>`;
 
-The Quarkus extension provides a gRPC client for high-performance communication with Memory Service.
+The Quarkus extension provides gRPC clients for high-performance communication with Memory Service.
 
 ## Setup
 
@@ -23,34 +23,111 @@ Add the gRPC client dependency:
 ## Configuration
 
 ```properties
-quarkus.grpc.clients.memory-service.host=localhost
-quarkus.grpc.clients.memory-service.port=9000
+# Configure the gRPC client for each service you need
+quarkus.grpc.clients.conversations.host=localhost
+quarkus.grpc.clients.conversations.port=9000
+
+quarkus.grpc.clients.entries.host=localhost
+quarkus.grpc.clients.entries.port=9000
+
+quarkus.grpc.clients.search.host=localhost
+quarkus.grpc.clients.search.port=9000
 ```
 
-## Injecting the Client
+## Available Services
 
-### Blocking Client
+The Memory Service gRPC API is split into multiple services:
+
+| Service | Description |
+|---------|-------------|
+| `ConversationsService` | CRUD operations for conversations |
+| `EntriesService` | List, append, and sync entries |
+| `ConversationMembershipsService` | Sharing and membership management |
+| `OwnershipTransfersService` | Ownership transfer operations |
+| `SearchService` | Semantic search and indexing |
+| `ResponseResumerService` | Streaming response resumption |
+| `SystemService` | Health checks |
+
+## UUID Handling
+
+UUID fields in gRPC are represented as 16-byte big-endian binary values (not strings). Use this helper to convert:
 
 ```java
-@GrpcClient("memory-service")
-MemoryServiceGrpc.MemoryServiceBlockingStub client;
+import com.google.protobuf.ByteString;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+public class UuidHelper {
+    public static ByteString toBytes(UUID uuid) {
+        ByteBuffer buffer = ByteBuffer.allocate(16);
+        buffer.putLong(uuid.getMostSignificantBits());
+        buffer.putLong(uuid.getLeastSignificantBits());
+        return ByteString.copyFrom(buffer.array());
+    }
+
+    public static UUID fromBytes(ByteString bytes) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes.toByteArray());
+        return new UUID(buffer.getLong(), buffer.getLong());
+    }
+}
 ```
 
-### Async Client
+## Injecting Clients
+
+### ConversationsService
 
 ```java
-@GrpcClient("memory-service")
-MemoryServiceGrpc.MemoryServiceStub asyncClient;
+import io.github.chirino.memory.grpc.v1.*;
+import io.quarkus.grpc.GrpcClient;
+
+@GrpcClient("conversations")
+ConversationsServiceGrpc.ConversationsServiceBlockingStub conversationsClient;
 ```
 
-## Conversations
+### EntriesService
+
+```java
+@GrpcClient("entries")
+EntriesServiceGrpc.EntriesServiceBlockingStub entriesClient;
+```
+
+### SearchService
+
+```java
+@GrpcClient("search")
+SearchServiceGrpc.SearchServiceBlockingStub searchClient;
+```
+
+## Conversations API
+
+### List Conversations
+
+```java
+import io.github.chirino.memory.grpc.v1.*;
+
+ListConversationsResponse response = conversationsClient.listConversations(
+    ListConversationsRequest.newBuilder()
+        .setMode(ConversationListMode.LATEST_FORK)
+        .setPage(PageRequest.newBuilder()
+            .setPageSize(20)
+            .build())
+        .build()
+);
+
+for (ConversationSummary conv : response.getConversationsList()) {
+    UUID id = UuidHelper.fromBytes(conv.getId());
+    System.out.println(conv.getTitle() + " - " + id);
+}
+```
 
 ### Get Conversation
 
 ```java
-Conversation conv = client.getConversation(
+UUID conversationId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+
+Conversation conv = conversationsClient.getConversation(
     GetConversationRequest.newBuilder()
-        .setId("my-conversation")
+        .setConversationId(UuidHelper.toBytes(conversationId))
         .build()
 );
 ```
@@ -58,53 +135,174 @@ Conversation conv = client.getConversation(
 ### Create Conversation
 
 ```java
-Conversation conv = client.createConversation(
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+
+Conversation conv = conversationsClient.createConversation(
     CreateConversationRequest.newBuilder()
-        .setId("my-conversation")
-        .putMetadata("topic", "support")
+        .setTitle("My Conversation")
+        .setMetadata(Struct.newBuilder()
+            .putFields("topic", Value.newBuilder().setStringValue("support").build())
+            .build())
         .build()
 );
 ```
 
-### List Conversations
+### Delete Conversation
 
 ```java
-ListConversationsResponse response = client.listConversations(
-    ListConversationsRequest.newBuilder()
-        .setLimit(20)
+conversationsClient.deleteConversation(
+    DeleteConversationRequest.newBuilder()
+        .setConversationId(UuidHelper.toBytes(conversationId))
         .build()
 );
-
-for (Conversation conv : response.getConversationsList()) {
-    System.out.println(conv.getId());
-}
 ```
 
 ### Fork Conversation
 
 ```java
-Conversation forked = client.forkConversation(
+UUID conversationId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000");
+UUID entryId = UUID.fromString("6ba7b810-9dad-11d1-80b4-00c04fd430c8");
+
+Conversation forked = conversationsClient.forkConversation(
     ForkConversationRequest.newBuilder()
-        .setId("original-id")
-        .setNewId("forked-conversation")
-        .setAtMessage(5)
+        .setConversationId(UuidHelper.toBytes(conversationId))
+        .setEntryId(UuidHelper.toBytes(entryId))
+        .setTitle("Forked conversation")
         .build()
 );
 ```
 
-## Streaming Messages
-
-### Server Streaming - Get All Messages
+### List Forks
 
 ```java
-asyncClient.getMessages(
-    GetMessagesRequest.newBuilder()
-        .setConversationId("my-conversation")
+ListForksResponse forks = conversationsClient.listForks(
+    ListForksRequest.newBuilder()
+        .setConversationId(UuidHelper.toBytes(conversationId))
+        .build()
+);
+
+for (ConversationForkSummary fork : forks.getForksList()) {
+    System.out.println("Fork: " + fork.getTitle());
+}
+```
+
+## Entries API
+
+### List Entries
+
+```java
+ListEntriesResponse response = entriesClient.listEntries(
+    ListEntriesRequest.newBuilder()
+        .setConversationId(UuidHelper.toBytes(conversationId))
+        .setChannel(Channel.HISTORY)
+        .setEpochFilter("latest")
+        .setForks("none")
+        .setPage(PageRequest.newBuilder()
+            .setPageSize(50)
+            .build())
+        .build()
+);
+
+for (Entry entry : response.getEntriesList()) {
+    System.out.println(entry.getContentType() + ": " + entry.getContentList());
+}
+```
+
+### Append Entry
+
+```java
+import com.google.protobuf.Value;
+import com.google.protobuf.Struct;
+
+Entry entry = entriesClient.appendEntry(
+    AppendEntryRequest.newBuilder()
+        .setConversationId(UuidHelper.toBytes(conversationId))
+        .setEntry(CreateEntryRequest.newBuilder()
+            .setUserId("user123")
+            .setChannel(Channel.HISTORY)
+            .setContentType("history")
+            .addContent(Value.newBuilder()
+                .setStructValue(Struct.newBuilder()
+                    .putFields("text", Value.newBuilder()
+                        .setStringValue("Hello, how can I help?").build())
+                    .putFields("role", Value.newBuilder()
+                        .setStringValue("USER").build())
+                    .build())
+                .build())
+            .build())
+        .build()
+);
+```
+
+### Sync Agent Memory
+
+```java
+SyncEntriesResponse response = entriesClient.syncEntries(
+    SyncEntriesRequest.newBuilder()
+        .setConversationId(UuidHelper.toBytes(conversationId))
+        .setEntry(CreateEntryRequest.newBuilder()
+            .setChannel(Channel.MEMORY)
+            .setContentType("LC4J")
+            .addAllContent(memoryContent)
+            .build())
+        .build()
+);
+
+if (response.getNoOp()) {
+    System.out.println("Memory already up to date");
+} else if (response.getEpochIncremented()) {
+    System.out.println("New epoch started: " + response.getEpoch());
+}
+```
+
+## Search API
+
+### Search Conversations
+
+```java
+SearchEntriesResponse response = searchClient.searchConversations(
+    SearchEntriesRequest.newBuilder()
+        .setQuery("authentication configuration")
+        .setLimit(20)
+        .setIncludeEntry(true)
+        .build()
+);
+
+for (SearchResult result : response.getResultsList()) {
+    UUID convId = UuidHelper.fromBytes(result.getConversationId());
+    System.out.println("Score: " + result.getScore() +
+        " - " + result.getConversationTitle());
+}
+```
+
+## Response Resumer (Streaming)
+
+The `ResponseResumerService` handles streaming response resumption for interrupted connections:
+
+```java
+@GrpcClient("responseresumer")
+ResponseResumerServiceGrpc.ResponseResumerServiceStub resumerClient;
+
+// Check if response resumer is enabled
+IsEnabledResponse enabled = resumerClient.isEnabled(Empty.getDefaultInstance());
+
+// Check which conversations have responses in progress
+CheckConversationsResponse check = resumerClient.checkConversations(
+    CheckConversationsRequest.newBuilder()
+        .addConversationIds(UuidHelper.toBytes(conversationId))
+        .build()
+);
+
+// Replay response tokens
+resumerClient.replayResponseTokens(
+    ReplayResponseTokensRequest.newBuilder()
+        .setConversationId(UuidHelper.toBytes(conversationId))
         .build(),
-    new StreamObserver<Message>() {
+    new StreamObserver<ReplayResponseTokensResponse>() {
         @Override
-        public void onNext(Message message) {
-            System.out.println("Received: " + message.getContent());
+        public void onNext(ReplayResponseTokensResponse response) {
+            System.out.print(response.getToken());
         }
 
         @Override
@@ -114,38 +312,7 @@ asyncClient.getMessages(
 
         @Override
         public void onCompleted() {
-            System.out.println("Stream completed");
-        }
-    }
-);
-```
-
-### Real-time Message Updates
-
-Subscribe to new messages as they arrive:
-
-```java
-asyncClient.streamMessages(
-    StreamMessagesRequest.newBuilder()
-        .setConversationId("my-conversation")
-        .setFromSequence(lastKnownSequence)
-        .build(),
-    new StreamObserver<Message>() {
-        @Override
-        public void onNext(Message message) {
-            // Handle new message in real-time
-            updateUI(message);
-        }
-
-        @Override
-        public void onError(Throwable t) {
-            // Handle reconnection
-            reconnect();
-        }
-
-        @Override
-        public void onCompleted() {
-            // Stream ended
+            System.out.println("\nReplay completed");
         }
     }
 );
@@ -154,8 +321,10 @@ asyncClient.streamMessages(
 ## Error Handling
 
 ```java
+import io.grpc.StatusRuntimeException;
+
 try {
-    Conversation conv = client.getConversation(request);
+    Conversation conv = conversationsClient.getConversation(request);
 } catch (StatusRuntimeException e) {
     switch (e.getStatus().getCode()) {
         case NOT_FOUND:
@@ -178,20 +347,20 @@ try {
 For production, enable TLS:
 
 ```properties
-quarkus.grpc.clients.memory-service.tls.enabled=true
-quarkus.grpc.clients.memory-service.tls.trust-certificate-pem.certs=ca.pem
+quarkus.grpc.clients.conversations.tls.enabled=true
+quarkus.grpc.clients.conversations.tls.trust-certificate-pem.certs=ca.pem
 ```
 
 ## When to Use gRPC
 
 Choose gRPC over REST when you need:
 
-- **Streaming** - Real-time message updates
+- **Streaming** - Real-time response resumption with `ResponseResumerService`
 - **High throughput** - Binary protocol is more efficient
 - **Strong typing** - Generated stubs catch errors at compile time
-- **Bi-directional communication** - Full duplex streaming
+- **Bi-directional communication** - Full duplex streaming for response recording
 
 ## Next Steps
 
 - [REST Client](/docs/quarkus/rest-client/) - For simpler use cases
-- [LangChain4j Integration](/docs/quarkus/langchain4j/) - ChatMemory provider
+- [Advanced Features](/docs/quarkus/advanced-features/) - Forking, streaming, and response resumption

--- a/site/src/pages/docs/quarkus/rest-client.mdx
+++ b/site/src/pages/docs/quarkus/rest-client.mdx
@@ -12,7 +12,10 @@ export const mavenDep = `<dependency>
   <version>${PROJECT_VERSION}</version>
 </dependency>`;
 
-The Quarkus extension provides a type-safe REST client for interacting with Memory Service.
+The Quarkus extension provides two ways to interact with Memory Service via REST:
+
+1. **MemoryServiceProxy** - A helper class for building JAX-RS proxy endpoints that forward requests to the memory service
+2. **Generated API Clients** - Type-safe REST clients for direct programmatic access
 
 ## Setup
 
@@ -20,162 +23,269 @@ The REST client is included in the extension:
 
 <Code code={mavenDep} lang="xml" />
 
-## Injecting the Client
-
-```java
-@Inject
-MemoryServiceClient memoryClient;
-```
-
-## Conversations API
-
-### List Conversations
-
-```java
-ListConversationsResponse response = memoryClient.conversations()
-    .list(ListRequest.builder()
-        .limit(20)
-        .offset(0)
-        .build());
-
-for (Conversation conv : response.getConversations()) {
-    System.out.println(conv.getId());
-}
-```
-
-### Create Conversation
-
-```java
-Conversation conv = memoryClient.conversations()
-    .create(CreateConversationRequest.builder()
-        .id("my-conversation")
-        .metadata(Map.of("topic", "support"))
-        .build());
-```
-
-### Get Conversation
-
-```java
-Conversation conv = memoryClient.conversations()
-    .get("my-conversation");
-```
-
-### Update Conversation
-
-```java
-memoryClient.conversations()
-    .update("my-conversation", UpdateRequest.builder()
-        .metadata(Map.of("status", "resolved"))
-        .build());
-```
-
-### Delete Conversation
-
-```java
-memoryClient.conversations()
-    .delete("my-conversation");
-```
-
-### Fork Conversation
-
-```java
-Conversation forked = memoryClient.conversations()
-    .fork("original-id", ForkRequest.builder()
-        .newId("forked-conversation")
-        .atMessage(5)
-        .build());
-```
-
-## Messages API
-
-### Add Message
-
-```java
-Message msg = memoryClient.messages("my-conversation")
-    .add(AddMessageRequest.builder()
-        .type(MessageType.USER)
-        .content("Hello, how can you help?")
-        .metadata(Map.of("client", "web"))
-        .build());
-```
-
-### List Messages
-
-```java
-ListMessagesResponse response = memoryClient.messages("my-conversation")
-    .list(ListMessagesRequest.builder()
-        .limit(100)
-        .build());
-
-for (Message msg : response.getMessages()) {
-    System.out.println(msg.getType() + ": " + msg.getContent());
-}
-```
-
-### Get Message
-
-```java
-Message msg = memoryClient.messages("my-conversation")
-    .get("msg-123");
-```
-
-## Search API
-
-### Semantic Search
-
-```java
-SearchResponse response = memoryClient.search()
-    .query(SearchRequest.builder()
-        .query("How do I configure authentication?")
-        .limit(10)
-        .minScore(0.7)
-        .build());
-
-for (SearchResult result : response.getResults()) {
-    System.out.println(result.getScore() + ": " + result.getContent());
-}
-```
-
-### Filtered Search
-
-```java
-SearchResponse response = memoryClient.search()
-    .query(SearchRequest.builder()
-        .query("error handling")
-        .conversationIds(List.of("conv-1", "conv-2"))
-        .messageTypes(List.of(MessageType.AI))
-        .after(Instant.parse("2024-01-01T00:00:00Z"))
-        .build());
-```
-
-## Error Handling
-
-```java
-try {
-    Conversation conv = memoryClient.conversations().get("unknown-id");
-} catch (NotFoundException e) {
-    // Conversation not found
-} catch (MemoryServiceException e) {
-    // Other API error
-    System.err.println("Error: " + e.getErrorCode() + " - " + e.getMessage());
-}
-```
-
 ## Configuration
 
 ```properties
 # Memory Service URL (auto-configured with Dev Services)
-memory-service.url=http://localhost:8080
+memory-service.client.url=http://localhost:8080
 
-# Timeouts
-memory-service.connect-timeout=30s
-memory-service.read-timeout=60s
+# API key for agent authentication
+memory-service.client.api-key=your-api-key
+```
 
-# TLS
-memory-service.tls.verify=true
+These properties are aliased to `quarkus.rest-client.memory-service-client.*` automatically.
+
+## Using MemoryServiceProxy
+
+The `MemoryServiceProxy` is a helper class that makes it easier to implement JAX-RS endpoints that proxy requests to the memory service. It handles authentication and bearer token propagation automatically.
+
+### Injecting the Proxy
+
+```java
+import io.github.chirino.memory.runtime.MemoryServiceProxy;
+
+@ApplicationScoped
+public class ConversationsResource {
+
+    @Inject
+    MemoryServiceProxy proxy;
+}
+```
+
+### Conversations API
+
+```java
+import io.github.chirino.memory.client.model.Channel;
+import jakarta.ws.rs.core.Response;
+
+// List conversations
+Response response = proxy.listConversations(mode, after, limit, query);
+
+// Get a conversation
+Response response = proxy.getConversation(conversationId);
+
+// Create a conversation (body is JSON string)
+Response response = proxy.createConversation(jsonBody);
+
+// Delete a conversation
+Response response = proxy.deleteConversation(conversationId);
+
+// List conversation forks
+Response response = proxy.listConversationForks(conversationId);
+
+// Fork a conversation at an entry
+Response response = proxy.forkConversationAtEntry(conversationId, entryId, jsonBody);
+```
+
+### Entries API
+
+```java
+// List conversation entries
+// channel: Channel.HISTORY for user-visible messages, Channel.MEMORY for agent memory
+// epoch: "latest", "all", or a numeric epoch identifier
+// forks: "none" or "all"
+Response response = proxy.listConversationEntries(
+    conversationId, after, limit, Channel.HISTORY, epoch, forks);
+
+// Append an entry (body is JSON string)
+Response response = proxy.appendConversationEntry(conversationId, jsonBody);
+```
+
+### Sharing API
+
+```java
+// List memberships
+Response response = proxy.listConversationMemberships(conversationId);
+
+// Share a conversation (body is JSON string with userId and accessLevel)
+Response response = proxy.shareConversation(conversationId, jsonBody);
+
+// Update membership
+Response response = proxy.updateConversationMembership(conversationId, userId, jsonBody);
+
+// Remove membership
+Response response = proxy.deleteConversationMembership(conversationId, userId);
+```
+
+### Ownership Transfers
+
+```java
+// List pending transfers
+Response response = proxy.listPendingTransfers(role);
+
+// Create ownership transfer
+Response response = proxy.createOwnershipTransfer(jsonBody);
+
+// Get transfer details
+Response response = proxy.getTransfer(transferId);
+
+// Accept transfer
+Response response = proxy.acceptTransfer(transferId);
+
+// Delete/cancel transfer
+Response response = proxy.deleteTransfer(transferId);
+```
+
+### Search API
+
+```java
+// Search conversations (body is JSON SearchConversationsRequest)
+Response response = proxy.searchConversations(jsonBody);
+
+// Index entries (body is JSON array of IndexEntryRequest)
+Response response = proxy.indexConversations(jsonBody);
+```
+
+### Response Cancellation
+
+```java
+// Cancel an in-progress response
+Response response = proxy.cancelResponse(conversationId);
+```
+
+## Using Generated API Clients
+
+For direct programmatic access without JAX-RS proxying, you can use the generated API clients with `MemoryServiceApiBuilder`:
+
+```java
+import io.github.chirino.memory.runtime.MemoryServiceApiBuilder;
+import io.github.chirino.memory.client.api.ConversationsApi;
+import io.github.chirino.memory.client.api.SearchApi;
+import io.github.chirino.memory.client.api.SharingApi;
+import io.github.chirino.memory.client.model.*;
+
+@ApplicationScoped
+public class MyService {
+
+    @Inject
+    MemoryServiceApiBuilder apiBuilder;
+
+    public Conversation getConversation(String bearerToken, UUID conversationId) {
+        ConversationsApi api = apiBuilder
+            .withBearerAuth(bearerToken)
+            .build(ConversationsApi.class);
+
+        return api.getConversation(conversationId);
+    }
+
+    public ListConversations200Response listConversations(String bearerToken) {
+        ConversationsApi api = apiBuilder
+            .withBearerAuth(bearerToken)
+            .build(ConversationsApi.class);
+
+        return api.listConversations(
+            "latest-fork",  // mode
+            null,           // after cursor
+            20,             // limit
+            null            // query
+        );
+    }
+
+    public ListConversationEntries200Response listEntries(
+            String bearerToken, UUID conversationId) {
+        ConversationsApi api = apiBuilder
+            .withBearerAuth(bearerToken)
+            .build(ConversationsApi.class);
+
+        return api.listConversationEntries(
+            conversationId,
+            null,               // after cursor
+            50,                 // limit
+            Channel.HISTORY,    // channel
+            "latest",           // epoch
+            "none"              // forks
+        );
+    }
+}
+```
+
+### Available API Classes
+
+| API Class | Description |
+|-----------|-------------|
+| `ConversationsApi` | CRUD operations for conversations and entries |
+| `SearchApi` | Semantic search and indexing |
+| `SharingApi` | Memberships and ownership transfers |
+
+## Error Handling
+
+```java
+import jakarta.ws.rs.WebApplicationException;
+
+try {
+    Response response = proxy.getConversation(conversationId);
+    if (response.getStatus() == 404) {
+        // Conversation not found
+    }
+} catch (WebApplicationException e) {
+    int status = e.getResponse().getStatus();
+    // Handle HTTP errors
+}
+```
+
+## Complete Example
+
+Here's a complete JAX-RS resource using `MemoryServiceProxy`:
+
+```java
+package org.acme;
+
+import io.github.chirino.memory.client.model.Channel;
+import io.github.chirino.memory.runtime.MemoryServiceProxy;
+import io.smallrye.common.annotation.Blocking;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/v1/conversations")
+@ApplicationScoped
+@Blocking
+public class ConversationsResource {
+
+    @Inject
+    MemoryServiceProxy proxy;
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listConversations(
+            @QueryParam("mode") String mode,
+            @QueryParam("after") String after,
+            @QueryParam("limit") Integer limit,
+            @QueryParam("query") String query) {
+        return proxy.listConversations(mode, after, limit, query);
+    }
+
+    @GET
+    @Path("/{conversationId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getConversation(
+            @PathParam("conversationId") String conversationId) {
+        return proxy.getConversation(conversationId);
+    }
+
+    @GET
+    @Path("/{conversationId}/entries")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response listEntries(
+            @PathParam("conversationId") String conversationId,
+            @QueryParam("after") String after,
+            @QueryParam("limit") Integer limit) {
+        return proxy.listConversationEntries(
+            conversationId, after, limit, Channel.HISTORY, null, null);
+    }
+
+    @DELETE
+    @Path("/{conversationId}")
+    public Response deleteConversation(
+            @PathParam("conversationId") String conversationId) {
+        return proxy.deleteConversation(conversationId);
+    }
+}
 ```
 
 ## Next Steps
 
 - [gRPC Client](/docs/quarkus/grpc-client/) - For streaming and high-performance use cases
-- [LangChain4j Integration](/docs/quarkus/langchain4j/) - ChatMemory provider
+- [Advanced Features](/docs/quarkus/advanced-features/) - Forking, streaming, and response resumption

--- a/site/src/pages/docs/spring/advanced-features.mdx
+++ b/site/src/pages/docs/spring/advanced-features.mdx
@@ -20,12 +20,12 @@ Make sure you've completed the previous guides:
 Conversation forking lets users branch off from any point in a conversation to explore alternative paths. Add these methods to the `MemoryServiceProxyController` to enable forking and listing forks:
 
 ```java
-@PostMapping("/{conversationId}/messages/{messageId}/fork")
-public ResponseEntity<?> forkConversationAtMessage(
+@PostMapping("/{conversationId}/entries/{entryId}/fork")
+public ResponseEntity<?> forkConversationAtEntry(
         @PathVariable String conversationId,
-        @PathVariable String messageId,
+        @PathVariable String entryId,
         @RequestBody(required = false) String body) {
-    return proxy.forkConversationAtMessage(conversationId, messageId, body);
+    return proxy.forkConversationAtEntry(conversationId, entryId, body);
 }
 
 @GetMapping("/{conversationId}/forks")
@@ -35,18 +35,18 @@ public ResponseEntity<?> listConversationForks(@PathVariable String conversation
 ```
 
 The fork endpoint creates a new conversation that:
-- Copies all messages up to and excluding the specified message
+- Copies all entries up to and excluding the specified entry
 - Creates a new conversation ID for the fork
 - Links the fork back to the original conversation
 
 Test it with curl:
 
 ```bash
-# Get the id of the first message in the conversation
-FIRST_MESSAGE_ID=$(curl -sSfX GET http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/messages \
+# Get the id of the first entry in the conversation
+FIRST_ENTRY_ID=$(curl -sSfX GET http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/entries \
   -H "Authorization: Bearer $(get-token)" | jq -r '.data[0].id')
 
-curl -sSfX POST http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/messages/$FIRST_MESSAGE_ID/fork \
+curl -sSfX POST http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/entries/$FIRST_ENTRY_ID/fork \
   -H "Authorization: Bearer $(get-token)" \
   -H "Content-Type: application/json" \
   -d '{"title": "Alternative approach"}' | jq
@@ -176,7 +176,7 @@ package com.example.demo;
 
 import io.github.chirino.memoryservice.history.ResponseResumer;
 import io.github.chirino.memoryservice.security.SecurityHelper;
-import io.github.chirino.memoryservice.spring.MemoryServiceProxy;
+import io.github.chirino.memoryservice.client.MemoryServiceProxy;
 import java.io.IOException;
 import java.util.List;
 import org.springframework.beans.factory.ObjectProvider;

--- a/site/src/pages/docs/spring/conversation-history.mdx
+++ b/site/src/pages/docs/spring/conversation-history.mdx
@@ -121,6 +121,7 @@ Create a REST controller that proxies requests to Memory Service:
 package com.example.demo;
 
 import io.github.chirino.memoryservice.client.MemoryServiceProxy;
+import io.github.chirino.memoryservice.client.model.Channel;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -143,12 +144,16 @@ class MemoryServiceProxyController {
         return proxy.getConversation(conversationId);
     }
 
-    @GetMapping("/{conversationId}/messages")
-    public ResponseEntity<?> listConversationMessages(
+    @GetMapping("/{conversationId}/entries")
+    public ResponseEntity<?> listConversationEntries(
             @PathVariable String conversationId,
             @RequestParam(required = false) String after,
-            @RequestParam(required = false) Integer limit) {
-        return proxy.listConversationMessages(conversationId, after, limit);
+            @RequestParam(required = false) Integer limit,
+            @RequestParam(required = false) String channel,
+            @RequestParam(required = false) String epoch,
+            @RequestParam(required = false) String forks) {
+        Channel channelEnum = channel != null ? Channel.fromValue(channel) : Channel.HISTORY;
+        return proxy.listConversationEntries(conversationId, after, limit, channelEnum, epoch, forks);
     }
 }
 ```
@@ -162,11 +167,11 @@ curl -sSfX GET http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6e
   -H "Authorization: Bearer $(get-token)" | jq
 ```
 ```bash
-curl -sSfX GET http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/messages \
+curl -sSfX GET http://localhost:9090/v1/conversations/3579aac5-c86e-4b67-bbea-6ec1a3644942/entries \
   -H "Authorization: Bearer $(get-token)" | jq
 ```
 
-You should see the conversation and messages that were exchanged between you and the agent.
+You should see the conversation and entries that were exchanged between you and the agent.
 
 ## Expose Conversation Listing API
 


### PR DESCRIPTION
- Rename "messages" to "entries" across Quarkus and Spring guides
- Update gRPC client docs with service-based examples (ConversationsService, EntriesService, SearchService, ResponseResumerService)
- Update REST client docs for MemoryServiceProxy and generated API clients
- Fix minor typos and whitespace issues