### PR TITLE
ci: add npm dependency caching to CI workflows

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -29,6 +29,14 @@ jobs:
           java-version: 21
           cache: maven
 
+      - name: Cache npm packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('common/chat-frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+
       - name: Build and test with Maven
         run: ./mvnw -B verify
 

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -30,9 +30,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-
-      - name: Build memory-service
-        run: ./mvnw clean install -DskipTests
+          cache: 'npm'
+          cache-dependency-path: site/package-lock.json
 
       - name: Start Docker services
         run: docker compose up -d
@@ -46,7 +45,7 @@ jobs:
           timeout 240 bash -c 'until curl -sf http://localhost:8081/health/ready; do sleep 2; done'
 
       - name: Run documentation tests (builds site and runs tests)
-        run: ./mvnw test -pl site-tests -Ptest-docs
+        run: ./mvnw -B test -pl site-tests -Ptest-docs
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
Cache npm packages in pr-check (for chat-frontend) and test-documentation (for site) to speed up CI builds.