### PR TITLE
ci: reorder CI steps, fix Dockerfile

### DIFF
--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -12,6 +12,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Start Docker services
+        run: docker compose build && docker compose up -d
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: site/package-lock.json
+
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
@@ -25,16 +35,6 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-m2-
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: site/package-lock.json
-
-      - name: Start Docker services
-        run: docker compose up -d
 
       - name: Wait for memory-service
         run: |

--- a/quarkus/examples/chat-quarkus/Dockerfile
+++ b/quarkus/examples/chat-quarkus/Dockerfile
@@ -37,7 +37,6 @@ COPY ./spring/examples/chat-spring/pom.xml ./spring/examples/chat-spring/pom.xml
 COPY ./spring/examples/pom.xml ./spring/examples/pom.xml
 COPY ./spring/memory-service-proto-spring/pom.xml ./spring/memory-service-proto-spring/pom.xml
 COPY ./spring/memory-service-rest-spring/pom.xml ./spring/memory-service-rest-spring/pom.xml
-COPY ./spring/memory-service-rest-spring/target/generated-sources/openapi/pom.xml ./spring/memory-service-rest-spring/target/generated-sources/openapi/pom.xml
 COPY ./spring/memory-service-spring-boot-autoconfigure/pom.xml ./spring/memory-service-spring-boot-autoconfigure/pom.xml
 COPY ./spring/memory-service-spring-boot-docker-compose-starter/pom.xml ./spring/memory-service-spring-boot-docker-compose-starter/pom.xml
 COPY ./spring/memory-service-spring-boot-starter/pom.xml ./spring/memory-service-spring-boot-starter/pom.xml


### PR DESCRIPTION
Start Docker services earlier in CI so images build in parallel with JDK/Node setup. Remove stale generated-sources pom.xml COPY from Dockerfile.