### PR TITLE
docs: add architecture and database design pages

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,339 @@
+# Architecture
+
+Memory Service is a stateless backend service that stores and indexes AI agent conversations. It exposes both REST and gRPC APIs, supports pluggable datastores and caching, and is designed for horizontal scaling.
+
+## System Context
+
+The following diagram shows how Memory Service fits into a typical deployment. Agent applications sit between end users and the memory service, mediating all interactions.
+
+```mermaid
+C4Context
+    title System Context
+
+    Person(user, "End User", "Interacts via chat UI")
+    System(agent, "Agent Application", "AI agent (Quarkus / Spring Boot)")
+    System(memory, "Memory Service", "Conversation storage, search, access control")
+    System_Ext(llm, "LLM Provider", "OpenAI, Ollama, etc.")
+    SystemDb(db, "Datastore", "PostgreSQL or MongoDB")
+    SystemDb(cache, "Cache", "Redis or Infinispan")
+
+    Rel(user, agent, "Chat messages")
+    Rel(agent, llm, "Inference requests")
+    Rel(agent, memory, "REST / gRPC")
+    Rel(memory, db, "Read / write")
+    Rel(memory, cache, "Epoch cache")
+
+    UpdateLayoutConfig($c4ShapeInRow="3", $c4BoundaryInRow="1")
+```
+
+## Component Overview
+
+Inside the memory-service, requests flow through API layers into a shared service core that delegates to pluggable store implementations.
+
+```mermaid
+block-beta
+    columns 3
+
+    block:api["API Layer"]:3
+        REST["REST (JAX-RS)"]
+        gRPC["gRPC"]
+    end
+
+    block:security["Security"]:3
+        OIDC["OIDC Auth"]
+        APIKey["API Key Auth"]
+        RBAC["Role-Based Access"]
+    end
+
+    block:core["Service Core"]:3
+        Conv["Conversations"]
+        Entries["Entries"]
+        Search["Search &amp; Indexing"]
+        Attach["Attachments"]
+        Resumer["Response Resumption"]
+        Admin["Admin &amp; Eviction"]
+    end
+
+    block:stores["Pluggable Stores"]:3
+        MemStore["MemoryStore"]
+        VecStore["VectorStore"]
+        AttStore["AttachmentStore / FileStore"]
+        CacheStore["MemoryEntriesCache"]
+    end
+
+    block:impl["Implementations"]:3
+        PG["PostgreSQL"]
+        Mongo["MongoDB"]
+        PGV["pgvector"]
+        Redis["Redis"]
+        Infinispan["Infinispan"]
+        S3["S3"]
+    end
+
+    api --> security
+    security --> core
+    core --> stores
+    stores --> impl
+```
+
+## Store Abstraction
+
+Memory Service uses interface-based abstractions so that datastores, caches, and file storage can be swapped via configuration. Each interface has two or more implementations selected at startup.
+
+```mermaid
+classDiagram
+    class MemoryStore {
+        <<interface>>
+        +createConversation()
+        +getEntries()
+        +appendMemoryEntries()
+        +listConversations()
+        ...()
+    }
+    class PostgresMemoryStore
+    class MongoMemoryStore
+    class MeteredMemoryStore {
+        -delegate : MemoryStore
+        +Prometheus metrics
+    }
+    MemoryStore <|.. PostgresMemoryStore
+    MemoryStore <|.. MongoMemoryStore
+    MemoryStore <|.. MeteredMemoryStore
+    MeteredMemoryStore o-- MemoryStore : wraps
+
+    class VectorStore {
+        <<interface>>
+        +search()
+        +adminSearch()
+        +upsertTranscriptEmbedding()
+        +deleteByConversationGroupId()
+    }
+    class PgVectorStore
+    class MongoVectorStore
+    VectorStore <|.. PgVectorStore
+    VectorStore <|.. MongoVectorStore
+
+    class MemoryEntriesCache {
+        <<interface>>
+        +get()
+        +put()
+        +evict()
+    }
+    class RedisMemoryEntriesCache
+    class InfinispanMemoryEntriesCache
+    class NoopMemoryEntriesCache
+    MemoryEntriesCache <|.. RedisMemoryEntriesCache
+    MemoryEntriesCache <|.. InfinispanMemoryEntriesCache
+    MemoryEntriesCache <|.. NoopMemoryEntriesCache
+
+    class FileStore {
+        <<interface>>
+        +store()
+        +retrieve()
+        +delete()
+        +getSignedUrl()
+    }
+    class DatabaseFileStore
+    class S3FileStore
+    FileStore <|.. DatabaseFileStore
+    FileStore <|.. S3FileStore
+```
+
+## Request Flow
+
+A typical agent interaction — appending a conversation entry — flows through these layers:
+
+```mermaid
+sequenceDiagram
+    participant Agent as Agent App
+    participant API as REST / gRPC
+    participant Auth as Auth Filter
+    participant Svc as Service Core
+    participant Store as MemoryStore
+    participant Cache as EntriesCache
+    participant DB as Database
+
+    Agent->>API: POST /v1/conversations/{id}/entries
+    API->>Auth: Validate token / API key
+    Auth->>Svc: Authorized request
+    Svc->>Store: appendMemoryEntries()
+    Store->>DB: INSERT entry
+    DB-->>Store: OK
+    Store-->>Svc: Entry created
+    Svc->>Cache: evict(conversationId, clientId)
+    Cache-->>Svc: OK
+    Svc-->>API: 200 Entry
+    API-->>Agent: Response
+```
+
+## Search & Indexing Pipeline
+
+Entries can be indexed asynchronously. The agent (or a background job) calls the indexing endpoint, which extracts text, generates embeddings, and stores them for later search.
+
+```mermaid
+sequenceDiagram
+    participant Agent as Agent App
+    participant API as REST / gRPC
+    participant Svc as Service Core
+    participant Embed as EmbeddingService
+    participant Vec as VectorStore
+    participant FTS as Full-Text Index
+    participant Tasks as Task Queue
+
+    Agent->>API: POST /v1/conversations/index
+    API->>Svc: Index entries
+    Svc->>Svc: Extract indexedContent from entries
+    Svc->>Embed: Generate embeddings (all-MiniLM-L6-v2)
+    Embed-->>Svc: 384-dim vectors
+
+    alt Success
+        Svc->>Vec: upsertTranscriptEmbedding()
+        Svc->>FTS: Update indexed_content / tsvector
+        Svc->>Svc: Set indexedAt timestamp
+    else Failure
+        Svc->>Tasks: Create retry task
+    end
+
+    Svc-->>API: 200 OK
+    API-->>Agent: Response
+
+    Note over Agent,API: Later — search
+    Agent->>API: GET /v1/conversations/search?q=...
+    API->>Svc: Search(query)
+
+    alt Semantic search
+        Svc->>Embed: Embed query
+        Embed-->>Svc: Query vector
+        Svc->>Vec: Nearest-neighbor search
+        Vec-->>Svc: Matching entries
+    else Full-text search
+        Svc->>FTS: ts_rank query
+        FTS-->>Svc: Matching entries
+    end
+
+    Svc-->>API: Search results
+    API-->>Agent: Response
+```
+
+## Conversation Forking
+
+When a conversation is forked, the new conversation shares the same conversation group and inherits all access-control memberships. Entries before the fork point are shared; new entries diverge.
+
+```mermaid
+flowchart LR
+    subgraph Group["Conversation Group"]
+        direction TB
+        M["Memberships<br/>(shared)"]
+
+        subgraph Original["Original Conversation"]
+            A["Entry A"] --> B["Entry B<br/>(fork point)"] --> C["Entry C"]
+        end
+
+        subgraph Fork["Forked Conversation"]
+            B2["Modified Entry B"] --> D["Entry D"] 
+        end
+    end
+
+    B2 -.->|forked at| B
+```
+
+## Access Control Model
+
+Access control is enforced at the conversation group level, so all conversations in a fork tree share the same permissions.
+
+```mermaid
+classDiagram
+    class AccessLevel {
+        <<enumeration>>
+        OWNER
+        MANAGER
+        WRITER
+        READER
+    }
+
+    class ConversationGroup {
+        +UUID id
+    }
+
+    class Membership {
+        +UUID conversationGroupId
+        +String userId
+        +AccessLevel accessLevel
+    }
+
+    class Conversation {
+        +UUID id
+        +String ownerUserId
+    }
+
+    ConversationGroup "1" --> "*" Membership : grants
+    ConversationGroup "1" --> "1..*" Conversation : contains
+    Membership --> AccessLevel : level
+
+    note for AccessLevel "OWNER: full control, transfer ownership\nMANAGER: manage memberships\nWRITER: append entries\nREADER: read only"
+```
+
+## Attachment Lifecycle
+
+Attachments are uploaded independently, then linked to entries. Unlinked attachments expire automatically.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Uploaded : POST /attachments
+    Uploaded --> Linked : Referenced in entry content
+    Uploaded --> Expired : TTL exceeded (default 1h)
+    Linked --> SoftDeleted : Entry or conversation deleted
+    Expired --> Cleaned : AttachmentCleanupJob
+    SoftDeleted --> HardDeleted : Eviction job
+    Cleaned --> [*]
+    HardDeleted --> [*]
+
+    note right of Linked
+        Content-addressed by SHA-256.
+        Multiple attachments may share
+        the same blob in FileStore.
+    end note
+```
+
+## Module Structure
+
+The project is organized into a core service module plus framework-specific integration modules for Quarkus and Spring Boot.
+
+```mermaid
+flowchart BT
+    contracts["memory-service-contracts<br/><small>OpenAPI + Proto specs</small>"]
+
+    restQ["rest-quarkus<br/><small>generated REST client</small>"]
+    protoQ["proto-quarkus<br/><small>generated gRPC stubs</small>"]
+    restS["rest-spring<br/><small>generated REST client</small>"]
+    protoS["proto-spring<br/><small>generated gRPC stubs</small>"]
+
+    encryption["data-encryption<br/><small>DEK / Vault</small>"]
+    extension["quarkus extension<br/><small>Dev Services</small>"]
+
+    core["memory-service<br/><small>API implementation</small>"]
+
+    starter["spring-boot-starter<br/><small>compose integration</small>"]
+    chatQ["chat-quarkus<br/><small>demo agent</small>"]
+    chatS["chat-spring<br/><small>demo agent</small>"]
+    frontend["chat-frontend<br/><small>React SPA</small>"]
+
+    restQ --> contracts
+    protoQ --> contracts
+    restS --> contracts
+    protoS --> contracts
+
+    core --> restQ
+    core --> protoQ
+    core --> encryption
+
+    extension --> restQ
+    extension --> protoQ
+    chatQ --> extension
+
+    starter --> restS
+    starter --> protoS
+    chatS --> starter
+    frontend --> chatQ 
+    frontend --> chatS 
+```

--- a/docs/db-design.md
+++ b/docs/db-design.md
@@ -1,0 +1,210 @@
+# Database Design
+
+Memory Service uses a relational schema designed around conversation groups as the unit of access control,
+with support for soft deletes, encrypted content, full-text search, and optional vector search.
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+    conversation_groups {
+        UUID id PK
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ deleted_at
+    }
+
+    conversations {
+        UUID id PK
+        BYTEA title
+        TEXT owner_user_id
+        JSONB metadata
+        UUID conversation_group_id FK
+        UUID forked_at_entry_id
+        UUID forked_at_conversation_id FK
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+        TIMESTAMPTZ vectorized_at
+        TIMESTAMPTZ deleted_at
+    }
+
+    conversation_memberships {
+        UUID conversation_group_id PK, FK
+        TEXT user_id PK
+        TEXT access_level
+        TIMESTAMPTZ created_at
+    }
+
+    entries {
+        UUID id PK
+        UUID conversation_id FK
+        UUID conversation_group_id FK
+        TEXT user_id
+        TEXT client_id
+        TEXT channel
+        BIGINT epoch
+        TEXT content_type
+        BYTEA content
+        TEXT indexed_content
+        TSVECTOR indexed_content_tsv
+        TIMESTAMPTZ indexed_at
+        TIMESTAMPTZ created_at
+    }
+
+    attachments {
+        UUID id PK
+        VARCHAR storage_key
+        VARCHAR filename
+        VARCHAR content_type
+        BIGINT size
+        VARCHAR sha256
+        TEXT user_id
+        UUID entry_id FK
+        TIMESTAMPTZ expires_at
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ deleted_at
+    }
+
+    conversation_ownership_transfers {
+        UUID id PK
+        UUID conversation_group_id FK
+        TEXT from_user_id
+        TEXT to_user_id
+        TIMESTAMPTZ created_at
+    }
+
+    tasks {
+        UUID id PK
+        TEXT task_name UK
+        TEXT task_type
+        JSONB task_body
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ retry_at
+        TEXT last_error
+        INT retry_count
+    }
+
+    entry_embeddings {
+        UUID entry_id PK, FK
+        UUID conversation_id FK
+        UUID conversation_group_id FK
+        VECTOR embedding
+        TIMESTAMPTZ created_at
+    }
+
+    conversation_groups ||--o{ conversations : "contains"
+    conversation_groups ||--o{ conversation_memberships : "grants access"
+    conversation_groups ||--o{ conversation_ownership_transfers : "transfer of"
+    conversations ||--o{ entries : "contains"
+    conversations o|--o{ conversations : "forked from"
+    entries ||--o{ attachments : "has"
+    entries ||--o| entry_embeddings : "embedded as"
+    conversation_groups ||--o{ entries : "scoped to"
+    conversation_groups ||--o{ entry_embeddings : "scoped to"
+    conversations ||--o{ entry_embeddings : "scoped to"
+```
+
+## Tables
+
+### conversation_groups
+
+The top-level grouping entity. Every conversation belongs to exactly one group, and all access control
+(memberships) is defined at the group level. When a conversation is forked, the fork shares the same
+group as the original, so all members retain access to the entire fork tree.
+
+- Soft-deleted via `deleted_at`.
+
+### conversations
+
+Stores conversation metadata. Titles are stored as `BYTEA` to support encryption at rest.
+The `metadata` column is a free-form `JSONB` field for agent-defined tags and properties.
+
+- `conversation_group_id` links to the owning group.
+- `forked_at_conversation_id` and `forked_at_entry_id` record the fork point when a conversation is created by forking.
+- `vectorized_at` tracks when entries were last sent for vector embedding.
+- Soft-deleted via `deleted_at`.
+
+### conversation_memberships
+
+Per-user access grants scoped to a conversation group. The composite primary key
+`(conversation_group_id, user_id)` ensures one membership per user per group.
+
+- `access_level` is one of: `owner`, `manager`, `writer`, `reader`.
+- Exactly one `owner` row must exist per group.
+- Hard-deleted (not soft-deleted) with audit logging.
+
+### entries
+
+Individual messages, memory records, and transcript items within a conversation.
+
+- `channel` categorizes the entry: `history`, `memory`, or `transcript`.
+- `epoch` supports memory compaction versioning (see [entry-data-model.md](entry-data-model.md)).
+- `content` is stored as `BYTEA` (encrypted).
+- `indexed_content` is a plaintext copy used for full-text search.
+- `indexed_content_tsv` is a generated `tsvector` column maintained automatically by PostgreSQL, indexed with a GIN index for fast full-text queries.
+
+### attachments
+
+File attachments linked to entries.
+
+- `storage_key` references the file in the configured blob store.
+- `expires_at` enables automatic cleanup of temporary uploads.
+- `sha256` provides integrity verification.
+- Soft-deleted via `deleted_at`.
+
+### conversation_ownership_transfers
+
+Tracks pending ownership transfer requests. A conversation group can have at most one pending transfer
+(enforced by a unique constraint on `conversation_group_id`). Accepted or rejected transfers are
+hard-deleted.
+
+- `from_user_id != to_user_id` is enforced by a check constraint.
+
+### tasks
+
+A lightweight background task queue with retry support.
+
+- `task_name` is an optional unique identifier for singleton tasks (partial unique index allows multiple `NULL` values).
+- `task_body` stores task parameters as `JSONB`.
+- `retry_at` and `retry_count` support exponential backoff.
+
+### entry_embeddings (optional, pgvector)
+
+Vector embeddings for semantic search, created when the pgvector extension is enabled.
+
+- Uses 384-dimensional vectors (all-MiniLM-L6-v2 model).
+- HNSW index for fast approximate nearest-neighbor search with cosine similarity.
+- `conversation_group_id` enables access-controlled search via join.
+
+## Design Patterns
+
+### Conversation Groups as the Access Control Boundary
+
+Rather than attaching memberships directly to individual conversations, access is controlled at
+the **group** level. A conversation group contains one or more conversations (a root plus its forks).
+This means forking a conversation does not require copying membership rows &mdash; the fork
+automatically inherits all access grants from the group.
+
+### Soft Deletes with Retention Indexes
+
+Conversations, conversation groups, and attachments use a `deleted_at` timestamp for soft deletion.
+Partial indexes on `deleted_at IS NULL` and `deleted_at IS NOT NULL` keep queries efficient for
+both active-record lookups and retention/eviction jobs that clean up expired soft-deleted rows.
+
+### Encrypted Content Storage
+
+Conversation titles and entry content are stored as `BYTEA`, allowing the application layer to
+encrypt data before persistence. A separate `indexed_content` text column holds the plaintext
+needed for full-text search, decoupling search indexing from content encryption.
+
+### Full-Text Search
+
+PostgreSQL's built-in `tsvector`/`tsquery` is used for keyword search. The `indexed_content_tsv`
+column is a generated stored column that automatically stays in sync with `indexed_content`.
+A GIN index on this column provides fast full-text queries without requiring an external search engine.
+
+### Background Task Queue
+
+The `tasks` table implements a simple, database-backed job queue. The `retry_at` column acts as
+a visibility timeout &mdash; workers poll for tasks where `retry_at <= NOW()` and update the
+timestamp on failure. This avoids the need for an external message broker for lightweight
+background work like vectorization and cleanup.

--- a/docs/design.md
+++ b/docs/design.md
@@ -6,7 +6,9 @@ This document describes the API and data model of the Memory Service. The goal i
 
 For detailed design specifications on specific features, see:
 
+- **[Architecture](architecture.md)**: System context, component overview, store abstractions, request flows, and module structure.
 - **[Entry Data Model](entry-data-model.md)**: Detailed documentation of how entries are stored and retrieved, including channels, memory epochs, conversation forking, and multi-agent support.
+- **[Database Design](db-design.md)**: PostgreSQL schema UML diagram, table descriptions, and key design patterns (access control, soft deletes, encryption, full-text search).
 
 ## High-level Responsibilities
 


### PR DESCRIPTION
## Summary

Adds two new documentation pages covering the system architecture and PostgreSQL database design, and links them from the main design page.

## Changes

- Add `docs/architecture.md` — system context diagram, component overview, store abstractions, request flows, and module structure
- Add `docs/db-design.md` — PostgreSQL schema ERD, table descriptions, and key design patterns (access control, soft deletes, encryption, full-text search)
- Update `docs/design.md` with links to both new pages