### PR TITLE
docs: add link checking, update getting-started, and add image generation proposal

### DIFF
--- a/site-tests/.lychee.toml
+++ b/site-tests/.lychee.toml
@@ -1,0 +1,8 @@
+# Lychee link checker configuration for site-tests
+# See https://lychee.cli.rs/configuration/
+
+# Exclude patterns for links that are valid in production but not in local builds
+exclude = [
+    # GitHub Pages base path — only exists in deployed builds
+    "file:///input/memory-service/",
+]

--- a/site-tests/pom.xml
+++ b/site-tests/pom.xml
@@ -170,6 +170,34 @@
             </configuration>
           </execution>
 
+          <!-- Validate links in the built site -->
+          <execution>
+            <id>lychee-link-check</id>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>generate-test-resources</phase>
+            <configuration>
+              <executable>docker</executable>
+              <arguments>
+                <argument>run</argument>
+                <argument>--rm</argument>
+                <argument>-v</argument>
+                <argument>${project.basedir}/../site/dist:/input</argument>
+                <argument>-v</argument>
+                <argument>${project.basedir}/.lychee.toml:/lychee.toml</argument>
+                <argument>lycheeverse/lychee</argument>
+                <argument>--no-progress</argument>
+                <argument>--offline</argument>
+                <argument>--root-dir</argument>
+                <argument>/input</argument>
+                <argument>--config</argument>
+                <argument>/lychee.toml</argument>
+                <argument>/input</argument>
+              </arguments>
+            </configuration>
+          </execution>
+
           <!-- Generate Cucumber feature files from test-scenarios.json -->
           <execution>
             <id>generate-features</id>

--- a/site/src/pages/docs/configuration.md
+++ b/site/src/pages/docs/configuration.md
@@ -8,9 +8,9 @@ Memory Service is configured entirely through environment variables. This approa
 
 > **Note:** Environment variables follow Quarkus conventions. Property names like `memory-service.datastore.type` become `MEMORY_SERVICE_DATASTORE_TYPE` as environment variables (dots and hyphens become underscores, all uppercase).
 
-## Memory Service Configuration
+## Server Configuration
 
-These are the core Memory Service configuration options:
+These are the core server configuration options:
 
 | Property | Values | Default | Description |
 |----------|--------|---------|-------------|

--- a/site/src/pages/docs/getting-started.md
+++ b/site/src/pages/docs/getting-started.md
@@ -35,6 +35,7 @@ echo "OPENAI_API_KEY=your-api-key-here" > .env
 ### 3. Deploy with Docker Compose
 
 ```bash
+docker compose build
 docker compose up -d
 ```
 
@@ -44,6 +45,8 @@ This will start:
 - **Keycloak** for authentication (used by the memory service and demo chat app)
 - **PostgreSQL** for data and vector storage (used by the memory service)
 - **Redis** for caching (used by the memory service)
+- **Prometheus** for metrics collection
+- **Grafana** for metrics dashboards
 
 ### 4. Access the Demo Chat App
 
@@ -58,18 +61,20 @@ Keycloak is pre-configured with these test users:
 | Username | Password | Role |
 |----------|----------|------|
 | bob | bob | user |
-| alice | alice | user |
+| alice | alice | user, admin |
+| charlie | charlie | user |
 
 ## Things to notice in the Demo.
 
 * You can fork any user entry and switch between forks
-* Agent memory stays consistent with the fork your on.  Ask it to recall previous fact you have told it.
-* Streaming responses survice browser page reloads.  You can even switch to a diferent device and still view the response that is currently being generated.
+* Agent memory stays consistent with the fork you're on.  Ask it to recall previous fact you have told it.
+* Streaming responses survive browser page reloads.  You can even switch to a different device and still view the response that is currently being generated.
 * Users can see a list of all their previous conversations.
 
 ## Next Steps
 
-- Learn about [Configuration Options](/docs/configuration/)
-- Understand [Core Concepts](/docs/concepts/conversations/)
-- Explore [Framework Integrations](/docs/apis/frameworks/quarkus/)
-- Review [Deployment Options](/docs/deployment/kubernetes/)
+- Understand [Core Concepts](/docs/concepts/)
+- Explore Developer Guides for
+  * [Quarkus Langchain4j](/docs/quarkus/)
+  * [Spring AI](/docs/spring/)
+- Learn about [Server Configuration Options](/docs/configuration/)


### PR DESCRIPTION
## Summary

Documentation improvements: adds automated link checking to the site-tests build pipeline, updates the getting-started guide with corrected instructions and additional details, and adds an enhancement proposal for image generation support.

## Changes

- Add lychee link checker (via Docker) to site-tests Maven build to validate links in the built site
- Add `.lychee.toml` config to exclude GitHub Pages base path links
- Rename "Memory Service Configuration" → "Server Configuration" in configuration docs
- Update getting-started guide:
  - Add `docker compose build` step before `docker compose up`
  - List Prometheus and Grafana as deployed services
  - Add charlie as a test user, mark alice as admin
  - Fix typos ("survice" → "survive", "diferent" → "different", "your on" → "you're on")
  - Update Next Steps links to match current doc structure
- Add enhancement proposal 047: image generation support for chat demo apps