### PR TITLE
feat: validate attachment content types and surface upload errors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,7 @@
 * review all config key names: keep them consistent and simple.
 * test/find the message size limits of the app.
     * use that info to protect against DOS: huge api requests .
+* define maxium lengths for all fields.
 
 # Performance Related
 

--- a/common/chat-frontend/src/components/conversations-ui/index.tsx
+++ b/common/chat-frontend/src/components/conversations-ui/index.tsx
@@ -381,11 +381,19 @@ function ConversationsUIMessageRow({
                         </div>
                       )}
                       {imageAtts.length > 0 && (
-                        <div className="mb-2 flex flex-wrap gap-2">
-                          {imageAtts.map((att, i) => (
-                            <ImageAttachmentPreview key={i} attachment={att} isUserMessage={isUser} />
-                          ))}
-                        </div>
+                        isUser ? (
+                          <div className="mb-2 flex flex-wrap gap-1.5">
+                            {imageAtts.map((att, i) => (
+                              <AttachmentPreview key={i} attachment={att} isUserMessage={isUser} />
+                            ))}
+                          </div>
+                        ) : (
+                          <div className="mb-2 flex flex-wrap gap-2">
+                            {imageAtts.map((att, i) => (
+                              <ImageAttachmentPreview key={i} attachment={att} isUserMessage={isUser} />
+                            ))}
+                          </div>
+                        )
                       )}
                     </>
                   );
@@ -651,12 +659,14 @@ function AttachmentChip({
 
   return (
     <div
-      className={`relative flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs ${
+      className={`group relative flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs ${
         isError ? "border-terracotta/40 bg-terracotta/5 text-terracotta" : "border-stone/20 bg-mist text-ink"
       }`}
     >
       <FileIcon contentType={attachment.contentType} className="h-3.5 w-3.5 shrink-0 opacity-60" />
-      <span className="max-w-[120px] truncate">{attachment.name}</span>
+      <span className="max-w-[120px] truncate group-hover:max-w-none">
+        {isError && attachment.error ? attachment.error : attachment.name}
+      </span>
       <button
         type="button"
         onClick={() => onRemove(attachment.localId)}

--- a/common/chat-frontend/src/components/rich-event-renderer.tsx
+++ b/common/chat-frontend/src/components/rich-event-renderer.tsx
@@ -212,36 +212,14 @@ type ToolCallPendingProps = {
 /**
  * Displays a tool call in progress with spinning indicator.
  */
-function ToolCallPending({ name, input }: ToolCallPendingProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const hasInput = input !== undefined && input !== null;
-
+function ToolCallPending({ name }: ToolCallPendingProps) {
   return (
     <div className="my-2 rounded-lg border border-sage/30 bg-sage/5">
-      <button
-        type="button"
-        onClick={() => hasInput && setIsExpanded(!isExpanded)}
-        disabled={!hasInput}
-        className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm ${
-          hasInput ? "cursor-pointer hover:bg-sage/10" : "cursor-default"
-        }`}
-      >
+      <div className="flex items-center gap-2 px-3 py-2 text-sm">
         <Loader2 className="h-4 w-4 animate-spin text-sage" />
         <Wrench className="h-4 w-4 text-sage" />
         <span className="font-medium text-ink">{getToolDisplayName(name)}</span>
-        {hasInput &&
-          (isExpanded ? (
-            <ChevronDown className="ml-auto h-4 w-4 text-stone" />
-          ) : (
-            <ChevronRight className="ml-auto h-4 w-4 text-stone" />
-          ))}
-      </button>
-      {isExpanded && hasInput && (
-        <div className="border-t border-sage/20 px-3 py-2">
-          <div className="text-xs text-stone">Input:</div>
-          <pre className="mt-1 overflow-x-auto rounded bg-mist/50 p-2 text-xs text-ink">{formatJson(input)}</pre>
-        </div>
-      )}
+      </div>
     </div>
   );
 }
@@ -255,47 +233,15 @@ type ToolCallResultProps = {
 /**
  * Displays a completed tool call with expandable input/output.
  */
-function ToolCallResult({ name, input, output }: ToolCallResultProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const hasDetails = (input !== undefined && input !== null) || (output !== undefined && output !== null);
-
+function ToolCallResult({ name }: ToolCallResultProps) {
   return (
     <div className="my-2 rounded-lg border border-sage/30 bg-sage/10">
-      <button
-        type="button"
-        onClick={() => hasDetails && setIsExpanded(!isExpanded)}
-        disabled={!hasDetails}
-        className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm ${
-          hasDetails ? "cursor-pointer hover:bg-sage/20" : "cursor-default"
-        }`}
-      >
+      <div className="flex items-center gap-2 px-3 py-2 text-sm">
         <CheckCircle2 className="h-4 w-4 text-sage" />
         <Wrench className="h-4 w-4 text-sage" />
         <span className="font-medium text-ink">{getToolDisplayName(name)}</span>
         <span className="text-xs text-stone">completed</span>
-        {hasDetails &&
-          (isExpanded ? (
-            <ChevronDown className="ml-auto h-4 w-4 text-stone" />
-          ) : (
-            <ChevronRight className="ml-auto h-4 w-4 text-stone" />
-          ))}
-      </button>
-      {isExpanded && (
-        <div className="space-y-2 border-t border-sage/20 px-3 py-2">
-          {input !== undefined && input !== null && (
-            <div>
-              <div className="text-xs text-stone">Input:</div>
-              <pre className="mt-1 overflow-x-auto rounded bg-mist/50 p-2 text-xs text-ink">{formatJson(input)}</pre>
-            </div>
-          )}
-          {output !== undefined && output !== null && (
-            <div>
-              <div className="text-xs text-stone">Output:</div>
-              <pre className="mt-1 overflow-x-auto rounded bg-cream p-2 text-xs text-ink">{formatJson(output)}</pre>
-            </div>
-          )}
-        </div>
-      )}
+      </div>
     </div>
   );
 }
@@ -339,19 +285,3 @@ function ContentFetchedBlock({ source, content }: ContentFetchedBlockProps) {
   );
 }
 
-function formatJson(value: unknown): string {
-  try {
-    if (typeof value === "string") {
-      // Try to parse as JSON for pretty printing
-      try {
-        const parsed = JSON.parse(value);
-        return JSON.stringify(parsed, null, 2);
-      } catch {
-        return value;
-      }
-    }
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return String(value);
-  }
-}

--- a/common/chat-frontend/src/hooks/useAttachments.ts
+++ b/common/chat-frontend/src/hooks/useAttachments.ts
@@ -140,12 +140,19 @@ export function useAttachments() {
               );
             }
           } else {
+            let errorMsg = `Upload failed (${xhr.status})`;
+            try {
+              const body = JSON.parse(xhr.responseText);
+              if (body.error) errorMsg = body.error;
+            } catch {
+              // ignore parse errors, use default message
+            }
             internalsRef.current = internalsRef.current.map((a) =>
               a.localId === localId
                 ? {
                     ...a,
                     status: "error" as const,
-                    error: `Upload failed (${xhr.status})`,
+                    error: errorMsg,
                     xhr: undefined,
                   }
                 : a,

--- a/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/AttachmentResolver.java
+++ b/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/AttachmentResolver.java
@@ -156,6 +156,26 @@ public class AttachmentResolver {
         return Paths.get(System.getProperty("java.io.tmpdir"));
     }
 
+    /**
+     * Returns true if the given content type is supported for LLM delivery.
+     */
+    public static boolean isSupportedContentType(String contentType) {
+        if (contentType == null) {
+            return false;
+        }
+        return contentType.startsWith("image/")
+                || contentType.startsWith("audio/")
+                || contentType.startsWith("video/")
+                || contentType.equals("application/pdf");
+    }
+
+    /**
+     * Returns a human-readable description of supported content types for error messages.
+     */
+    public static String supportedContentTypesDescription() {
+        return "images (image/*), audio (audio/*), video (video/*), and PDF (application/pdf)";
+    }
+
     static Content toContentFromUrl(String contentType, String url) {
         if (contentType == null) {
             // Default to image for URL-based content (most common case for S3 redirects)


### PR DESCRIPTION
## Summary

Add server-side content type validation for attachment uploads, rejecting unsupported types with a 400 response. Parse server error messages in the frontend upload handler and display them in the attachment chip.

## Changes

- Add content type validation on the server side for attachment uploads
- Return 400 response for unsupported content types
- Surface server error messages in the frontend attachment chip UI