### PR TITLE
refactor: rename ResponseResumerService to ResponseRecorderService

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,10 +4,6 @@
 * document admin apis
 * Brand the project and move it to an org/foundation.
 * Add support for python langchain /w user docs similar to the quarkus/spring support.
-* make chat-quarkus us the package/class names used in the checkpoint examples.
-* rename x-resumer-redirect-host, x-resumer-redirect-port headers.
-* StreamResponseTokenRequest.token -> StreamResponseTokenRequest.content
-* simplify the StreamResponseTokenResponse and ReplayResponseTokensResponse type.
 * config option to disable passthrough s3 signed download url (for when endpoint is private)
 * move the ChatEvent json serializer to quarkus
 
@@ -35,4 +31,3 @@
 * Allow runtime configured agents/api-keys?
 * How useful is the current index/search feature?
 * Do we need to support anonymous user conversations?
-* Better name for: ResponseResumerService ?

--- a/docs/design.md
+++ b/docs/design.md
@@ -341,7 +341,7 @@ The gRPC API (`memory_service.proto`) provides equivalent functionality to the R
 - **OwnershipTransfersService**: `ListOwnershipTransfers`, `GetOwnershipTransfer`, `CreateOwnershipTransfer`, `AcceptOwnershipTransfer`, `DeleteOwnershipTransfer`
 - **EntriesService**: `ListEntries`, `AppendEntry`, `SyncEntries`
 - **SearchService**: `SearchConversations`, `IndexConversations`, `ListUnindexedEntries`
-- **ResponseResumerService**: `StreamResponseTokens`, `ReplayResponseTokens`, `CancelResponse`, `IsEnabled`, `CheckConversations`
+- **ResponseRecorderService**: `Record`, `Replay`, `Cancel`, `IsEnabled`, `CheckRecordings`
 
 UUID fields are represented as 16-byte big-endian binary values in protobuf messages.
 

--- a/docs/enhancements/049-response-resumer-api-simplification.md
+++ b/docs/enhancements/049-response-resumer-api-simplification.md
@@ -1,0 +1,304 @@
+# Simplify ResponseResumerService gRPC API
+
+## Motivation
+
+The current ResponseResumerService gRPC API has accumulated naming inconsistencies and unnecessary complexity:
+
+1. **Verbose RPC and service names**: `ResponseResumerService` → `ResponseRecorderService`; `StreamResponseTokens`, `ReplayResponseTokens`, `CancelResponse` should be simpler `Record`, `Replay`, `Cancel`
+2. **"token" field name is misleading**: The `token` field carries content (text chunks), not authentication tokens. Rename to `content`.
+3. **Unnecessary offset fields**: `current_offset` and `offset` are tracked but never consumed by any client.
+4. **Bidirectional streaming is overkill for Record**: `StreamResponseTokens` uses bidirectional streaming (`stream -> stream`) primarily to push `cancel_requested` signals, but this can be handled with a unary response + status enum.
+5. **Redirect via gRPC trailing metadata is fragile**: Custom `x-resumer-redirect-host` / `x-resumer-redirect-port` headers require trailer parsing. Better to use explicit response fields.
+6. **Boolean success/cancel_requested flags are ambiguous**: Replace with a clear `RecordStatus` enum.
+
+## New Proto Contract
+
+### Service Definition
+
+```protobuf
+service ResponseRecorderService {
+  // Record response content for a conversation (client streaming, unary response)
+  rpc Record(stream RecordRequest) returns (RecordResponse);
+
+  // Replay a recording of a conversation
+  rpc Replay(ReplayRequest) returns (stream ReplayResponse);
+
+  // Cancel an in-progress recording
+  rpc Cancel(CancelRecordRequest) returns (CancelRecordResponse);
+
+  // Check if response resumer is enabled
+  rpc IsEnabled(google.protobuf.Empty) returns (IsEnabledResponse);
+
+  // Check which conversations have active recordings
+  rpc CheckRecordings(CheckRecordingsRequest) returns (CheckRecordingsResponse);
+}
+```
+
+### Message Definitions
+
+```protobuf
+enum RecordStatus {
+  RECORD_STATUS_UNSPECIFIED = 0;
+  RECORD_STATUS_SUCCESS = 1;
+  RECORD_STATUS_CANCELLED = 2;
+  RECORD_STATUS_ERROR = 3;
+}
+
+message RecordRequest {
+  bytes conversation_id = 1;  // UUID (16-byte big-endian), required in first message
+  string content = 2;         // Content chunk (was "token")
+  bool complete = 3;          // Set to true in final message
+}
+
+message RecordResponse {
+  RecordStatus status = 1;
+  string error_message = 2;   // Only set when status = ERROR
+}
+
+message ReplayRequest {
+  bytes conversation_id = 1;  // UUID (16-byte big-endian)
+}
+
+message ReplayResponse {
+  string content = 1;            // Content chunk (was "token"; removed "offset" field)
+  string redirect_address = 2;   // Set when redirect is needed (format: "host:port")
+}
+
+message CancelRecordRequest {
+  bytes conversation_id = 1;  // UUID (16-byte big-endian)
+}
+
+message CancelRecordResponse {
+  bool accepted = 1;
+  string redirect_address = 2;   // Set when redirect is needed (format: "host:port")
+}
+
+message CheckRecordingsRequest {
+  // Conversation identifiers (UUID as 16-byte big-endian binary each)
+  repeated bytes conversation_ids = 1;
+}
+
+message CheckRecordingsResponse {
+  // Conversation IDs with active recordings (UUID as 16-byte big-endian binary each)
+  repeated bytes conversation_ids = 1;
+}
+
+// IsEnabledResponse unchanged
+```
+
+### Name Mapping
+
+| Old | New |
+|-----|-----|
+| `StreamResponseTokens` (RPC) | `Record` |
+| `ReplayResponseTokens` (RPC) | `Replay` |
+| `CancelResponse` (RPC) | `Cancel` |
+| `StreamResponseTokenRequest` | `RecordRequest` |
+| `StreamResponseTokenResponse` | `RecordResponse` |
+| `ReplayResponseTokensRequest` | `ReplayRequest` |
+| `ReplayResponseTokensResponse` | `ReplayResponse` |
+| `CancelResponseRequest` | `CancelRecordRequest` |
+| `CancelResponseResponse` | `CancelRecordResponse` |
+| `CheckConversations` (RPC) | `CheckRecordings` |
+| `CheckConversationsRequest` | `CheckRecordingsRequest` |
+| `CheckConversationsResponse` | `CheckRecordingsResponse` |
+| `ResponseResumerService` (service) | `ResponseRecorderService` |
+
+### Field Changes
+
+| Message | Old Field | New Field | Notes |
+|---------|-----------|-----------|-------|
+| `RecordRequest` | `token` | `content` | Rename only |
+| `RecordResponse` | `success`, `cancel_requested` | `status` (enum) | Replaces boolean flags |
+| `RecordResponse` | `current_offset` | *(removed)* | Unused by all clients |
+| `ReplayResponse` | `token` | `content` | Rename only |
+| `ReplayResponse` | `offset` | *(removed)* | Unused by all clients |
+| `ReplayResponse` | *(new)* | `redirect_address` | Replaces gRPC trailing metadata |
+| `CancelRecordResponse` | *(new)* | `redirect_address` | Replaces gRPC trailing metadata |
+
+### Redirect Mechanism Change
+
+**Old approach**: Server throws `ResponseResumerRedirectException` which is converted to gRPC `Status.UNAVAILABLE` with custom trailing metadata headers (`x-resumer-redirect-host`, `x-resumer-redirect-port`). Clients must parse error trailers to extract redirect target.
+
+**New approach**: Server returns a normal response with `redirect_address` field set (format: `"host:port"`). For `Replay`, the server emits a single `ReplayResponse` with only `redirect_address` set and completes the stream. For `Cancel`, the server returns `CancelRecordResponse` with `accepted=false` and `redirect_address` set. Clients check the field and retry against the redirect target.
+
+Benefits:
+- No custom gRPC metadata parsing
+- Redirect is part of the explicit API contract
+- Easier to understand, test, and document
+- Works naturally with any gRPC client (no need for trailer interceptors)
+
+### Record Streaming Change
+
+**Old**: Bidirectional streaming (`stream RecordRequest -> stream RecordResponse`). Server pushes `cancel_requested=true` mid-stream.
+
+**New**: Client streaming with unary response (`stream RecordRequest -> RecordResponse`). When the server detects a cancel request, it terminates the call early by returning `RecordResponse` with `status=CANCELLED`. The gRPC call completion signals the client to stop sending.
+
+In gRPC client-streaming RPCs, the server CAN send the response before the client finishes streaming. This effectively terminates the call. The client detects call completion and stops.
+
+### Service Rename Impact
+
+Renaming the proto service from `ResponseResumerService` to `ResponseRecorderService` affects:
+
+- **Generated gRPC stubs**: `ResponseResumerServiceGrpc` → `ResponseRecorderServiceGrpc`, `MutinyResponseResumerServiceGrpc` → `MutinyResponseRecorderServiceGrpc`
+- **Server interface**: `implements ResponseResumerService` → `implements ResponseRecorderService`
+- **Quarkus gRPC client config**: `@GrpcClient("responseresumer")` and `quarkus.grpc.clients.responseresumer.*` properties → `@GrpcClient("responserecorder")` and `quarkus.grpc.clients.responserecorder.*`
+- **Spring gRPC client**: `MemoryServiceGrpcClients` stubs factory method name
+- **Feature test RPC paths**: `ResponseResumerService/Record` → `ResponseRecorderService/Record`
+
+Internal Java classes (`ResponseResumerBackend`, `ResponseResumerSelector`, `GrpcResponseResumer`, `ResponseResumer` interface, etc.) are NOT renamed in this change. They could be renamed in a follow-up for consistency, but are not part of the public gRPC API contract.
+
+## Scope of Changes
+
+### 1. Proto Contract
+
+**File**: `memory-service-contracts/src/main/resources/memory/v1/memory_service.proto`
+
+- Replace service definition (lines 422-437) with new RPCs
+- Replace all message definitions (lines 439-485) with new messages
+- Add `RecordStatus` enum
+- Add `redirect_address` fields to `ReplayResponse` and `CancelRecordResponse`
+- Remove `offset`, `current_offset`, `success`, `cancel_requested` fields
+
+### 2. Server gRPC Implementation
+
+**File**: `memory-service/src/main/java/io/github/chirino/memory/grpc/ResponseResumerGrpcService.java`
+
+**Record method** (biggest change):
+- Method signature: `Multi<StreamResponseTokenResponse> streamResponseTokens(Multi<StreamResponseTokenRequest>)` becomes `Uni<RecordResponse> record(Multi<RecordRequest>)`
+- Use `Uni.createFrom().emitter()` instead of `Multi.createFrom().emitter()`
+- Cancel signal handling: When `backend.cancelStream()` fires, complete the `Uni` with `RecordResponse(status=CANCELLED)` instead of emitting a response with `cancel_requested=true`
+- Success handling: When client sends `complete=true` or stream ends, complete with `RecordResponse(status=SUCCESS)`
+- Error handling: For access/validation errors, either fail the Uni with gRPC status (for `PERMISSION_DENIED`, `NOT_FOUND`) or complete with `RecordResponse(status=ERROR, error_message=...)` for application errors
+- Remove all `currentOffset` tracking
+
+**Replay method**:
+- Rename `replayResponseTokens` to `replay`, update types
+- Remove `currentOffset` / `offset` tracking entirely
+- Redirect handling: Instead of `toRedirectStatus(redirect)`, catch `ResponseResumerRedirectException` and emit a single `ReplayResponse` with `redirect_address` set, then complete the stream
+- Field: `.setToken(token)` becomes `.setContent(token)`
+
+**Cancel method**:
+- Rename `cancelResponse` to `cancel`, update types
+- Redirect handling: Instead of `toRedirectStatus(redirect)`, return `CancelRecordResponse` with `accepted=false` and `redirect_address` set
+
+**Remove**:
+- `REDIRECT_HOST_HEADER` and `REDIRECT_PORT_HEADER` constants (no longer needed)
+- `toRedirectStatus()` helper method (no longer needed)
+
+### 3. Quarkus Client
+
+**File**: `quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/GrpcResponseResumer.java`
+
+**Replay with redirect**:
+- `replayWithRedirect()`: Instead of catching `StatusRuntimeException` and parsing trailers, check each `ReplayResponse` for `redirect_address`. If set, collect it and retry with a new channel to that address.
+- Implementation: Use `transformToMultiAndMerge` or `onItem().transformToMulti()` to intercept a redirect response, create a new stub, and retry.
+- Remove `REDIRECT_HOST_HEADER`, `REDIRECT_PORT_HEADER` constants
+- Remove `resolveRedirect(Throwable)` method
+
+**Cancel with redirect**:
+- `cancelWithRedirect()`: Check `CancelRecordResponse.redirect_address`. If set, retry against redirect target.
+- Simpler than error-based approach since it's a normal response field.
+
+**GrpcResponseRecorder** (inner class):
+- `resumerService.streamResponseTokens(requestStream)` returning `Multi` becomes `resumerService.record(requestStream)` returning `Uni<RecordResponse>`
+- Subscribe to the `Uni` completion: if `status=CANCELLED` → emit cancel signal; if `status=SUCCESS` → complete; if `status=ERROR` → log error
+- `.setToken(token)` becomes `.setContent(content)` in `record()` and `complete()` methods
+- Update request/response types throughout
+
+### 4. Spring Client
+
+**File**: `spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/GrpcResponseResumer.java`
+
+**Replay**:
+- Update types, rename `.replayResponseTokens()` to `.replay()`
+- `response.getToken()` becomes `response.getContent()`
+- No redirect handling exists in Spring client currently (confirmed by search)
+
+**Cancel**:
+- Update types, rename `.cancelResponse()` to `.cancel()`
+
+**GrpcResponseRecorder** (inner class):
+- `service.streamResponseTokens(responseObserver)` becomes `service.record(responseObserver)` where `responseObserver` is now `StreamObserver<RecordResponse>` (unary)
+- `onNext(RecordResponse response)` is called exactly once; check `status` for cancel signal
+- `.setToken(token)` becomes `.setContent(content)`
+
+### 5. Backend Interface
+
+**File**: `memory-service/src/main/java/io/github/chirino/memory/resumer/ResponseResumerBackend.java`
+
+No changes required. The `ResponseRecorder.record(String token)` parameter name is internal Java, not proto-visible. The backend continues to throw `ResponseResumerRedirectException` internally; only the gRPC layer changes how it surfaces to clients.
+
+### 6. Tests
+
+**Feature file**: `memory-service/src/test/resources/features/response-resumer-grpc.feature`
+
+- Rename all RPC references:
+  - `ResponseResumerService/StreamResponseTokens` → `ResponseRecorderService/Record`
+  - `ResponseResumerService/ReplayResponseTokens` → `ResponseRecorderService/Replay`
+  - `ResponseResumerService/CancelResponse` → `ResponseRecorderService/Cancel`
+  - `ResponseResumerService/CheckConversations` → `ResponseRecorderService/CheckRecordings`
+  - `ResponseResumerService/IsEnabled` → `ResponseRecorderService/IsEnabled`
+- Rename field in request bodies: `token:` → `content:`
+- Remove assertion: `the gRPC response field "currentOffset" should be 5`
+- Add assertion: `the gRPC response field "status" should be "RECORD_STATUS_SUCCESS"`
+
+**Step definitions**: `memory-service/src/test/java/io/github/chirino/memory/cucumber/StepDefinitions.java`
+
+- Update all type references (`StreamResponseTokenRequest` → `RecordRequest`, `CheckConversationsRequest` → `CheckRecordingsRequest`, etc.)
+- `.setToken()` → `.setContent()`, `.getToken()` → `.getContent()`
+- `streamResponseTokens()` → `record()`, `replayResponseTokens()` → `replay()`, `cancelResponse()` → `cancel()`, `checkConversations()` → `checkRecordings()`
+- For streaming steps: `resumerService.streamResponseTokens(requestStream)` returns `Multi` → `resumerService.record(requestStream)` returns `Uni`. Adjust subscriptions accordingly.
+- For replay steps: `response.getToken()` → `response.getContent()`
+- Update the generic `callResponseResumerService()` dispatch method with new case names and types
+
+### 7. Documentation
+
+**File**: `site/src/pages/docs/concepts/response-resumption.md`
+
+- Update all RPC names, message names, field names
+- Replace redirect header documentation with redirect response field documentation
+- Update sequence diagrams
+- Update bidirectional streaming description to client streaming + unary response
+- Replace cancel signaling explanation (no more `cancel_requested` in stream, now `RecordStatus.CANCELLED` in unary response)
+
+### 8. Cleanup
+
+**File**: `TODO.md`
+- Remove completed items related to this refactoring
+
+**Server code to delete**:
+- `REDIRECT_HOST_HEADER`, `REDIRECT_PORT_HEADER` constants in `ResponseResumerGrpcService`
+- `toRedirectStatus()` method in `ResponseResumerGrpcService`
+
+**Client code to delete**:
+- `REDIRECT_HOST_HEADER`, `REDIRECT_PORT_HEADER` constants in Quarkus `GrpcResponseResumer`
+- `resolveRedirect(Throwable)` method in Quarkus `GrpcResponseResumer`
+
+## Implementation Order
+
+1. Update proto file and compile (`./mvnw clean compile`)
+2. Update server `ResponseResumerGrpcService` (most complex: Record method rewrite + redirect changes)
+3. Update Quarkus client `GrpcResponseResumer` (redirect + Record changes)
+4. Update Spring client `GrpcResponseResumer` (type renames + Record changes)
+5. Update tests (feature file + step definitions)
+6. Update documentation
+7. Full build and test verification
+
+## Verification
+
+```bash
+# Compile everything
+./mvnw clean compile
+
+# Run all tests (redirect to file for analysis)
+./mvnw test > test.log 2>&1
+# Search test.log for failures
+
+# Specifically verify the response resumer tests
+grep -A5 "response-resumer-grpc" test.log
+
+# Verify client modules compile
+./mvnw compile -pl quarkus/memory-service-extension/runtime
+./mvnw compile -pl spring/memory-service-spring-boot-autoconfigure
+```

--- a/memory-service-contracts/src/main/resources/memory/v1/memory_service.proto
+++ b/memory-service-contracts/src/main/resources/memory/v1/memory_service.proto
@@ -419,68 +419,73 @@ service SearchService {
   rpc ListUnindexedEntries(ListUnindexedEntriesRequest) returns (ListUnindexedEntriesResponse);
 }
 
-service ResponseResumerService {
-  // Stream response tokens for a conversation
-  rpc StreamResponseTokens(stream StreamResponseTokenRequest) returns (stream StreamResponseTokenResponse);
+service ResponseRecorderService {
+  // Record response content for a conversation (client streaming, unary response)
+  rpc Record(stream RecordRequest) returns (RecordResponse);
 
-  // Replay cached response tokens from a resume position
-  rpc ReplayResponseTokens(ReplayResponseTokensRequest) returns (stream ReplayResponseTokensResponse);
+  // Replay a recording of a conversation
+  rpc Replay(ReplayRequest) returns (stream ReplayResponse);
 
-  // Cancel an in-progress response
-  rpc CancelResponse(CancelResponseRequest) returns (CancelResponseResponse);
+  // Cancel an in-progress recording
+  rpc Cancel(CancelRecordRequest) returns (CancelRecordResponse);
 
-  // Check if response resumer is enabled
+  // Check if response recorder is enabled
   rpc IsEnabled(google.protobuf.Empty) returns (IsEnabledResponse);
 
-  // Check which conversations have responses in progress
-  rpc CheckConversations(CheckConversationsRequest) returns (CheckConversationsResponse);
+  // Check which conversations have active recordings
+  rpc CheckRecordings(CheckRecordingsRequest) returns (CheckRecordingsResponse);
 }
 
-message StreamResponseTokenRequest {
-  // Conversation identifier (UUID as 16-byte big-endian binary, only in first message)
+enum RecordStatus {
+  RECORD_STATUS_UNSPECIFIED = 0;
+  RECORD_STATUS_SUCCESS = 1;
+  RECORD_STATUS_CANCELLED = 2;
+  RECORD_STATUS_ERROR = 3;
+}
+
+message RecordRequest {
+  // Conversation identifier (UUID as 16-byte big-endian binary, required in first message)
   bytes conversation_id = 1;
-  string token = 2;            // Token content
+  string content = 2;          // Content chunk
   bool complete = 3;           // Set to true in final message
 }
 
-message StreamResponseTokenResponse {
-  bool success = 1;
-  string error_message = 2;    // Only set if success=false
-  int64 current_offset = 3;    // Current cumulative byte offset
-  bool cancel_requested = 4;   // True if server requests cancellation
+message RecordResponse {
+  RecordStatus status = 1;
+  string error_message = 2;    // Only set when status = ERROR
 }
 
-message ReplayResponseTokensRequest {
-  // Conversation identifier (UUID as 16-byte big-endian binary)
-  bytes conversation_id = 1;
-  // Field 2 (resume_position) removed - always replays from beginning
-}
-
-message ReplayResponseTokensResponse {
-  string token = 1;
-  int64 offset = 2;            // Cumulative byte offset after this token
-}
-
-message CancelResponseRequest {
+message ReplayRequest {
   // Conversation identifier (UUID as 16-byte big-endian binary)
   bytes conversation_id = 1;
 }
 
-message CancelResponseResponse {
+message ReplayResponse {
+  string content = 1;              // Content chunk
+  string redirect_address = 2;    // Set when redirect is needed (format: "host:port")
+}
+
+message CancelRecordRequest {
+  // Conversation identifier (UUID as 16-byte big-endian binary)
+  bytes conversation_id = 1;
+}
+
+message CancelRecordResponse {
   bool accepted = 1;
+  string redirect_address = 2;    // Set when redirect is needed (format: "host:port")
 }
 
 message IsEnabledResponse {
   bool enabled = 1;
 }
 
-message CheckConversationsRequest {
+message CheckRecordingsRequest {
   // Conversation identifiers (UUID as 16-byte big-endian binary each)
   repeated bytes conversation_ids = 1;
 }
 
-message CheckConversationsResponse {
-  // Conversation IDs with responses in progress (UUID as 16-byte big-endian binary each)
+message CheckRecordingsResponse {
+  // Conversation IDs with active recordings (UUID as 16-byte big-endian binary each)
   repeated bytes conversation_ids = 1;
 }
 

--- a/quarkus/memory-service-extension/deployment/src/main/java/io/github/chirino/memory/deployment/MemoryServiceDevServicesProcessor.java
+++ b/quarkus/memory-service-extension/deployment/src/main/java/io/github/chirino/memory/deployment/MemoryServiceDevServicesProcessor.java
@@ -59,19 +59,21 @@ public class MemoryServiceDevServicesProcessor {
                     if (apiKey != null) {
                         config.put("memory-service.client.api-key", apiKey);
                     }
-                    String grpcHost = resultConfig.get("quarkus.grpc.clients.responseresumer.host");
+                    String grpcHost =
+                            resultConfig.get("quarkus.grpc.clients.responserecorder.host");
                     if (grpcHost != null) {
-                        config.put("quarkus.grpc.clients.responseresumer.host", grpcHost);
+                        config.put("quarkus.grpc.clients.responserecorder.host", grpcHost);
                     }
-                    String grpcPort = resultConfig.get("quarkus.grpc.clients.responseresumer.port");
+                    String grpcPort =
+                            resultConfig.get("quarkus.grpc.clients.responserecorder.port");
                     if (grpcPort != null) {
-                        config.put("quarkus.grpc.clients.responseresumer.port", grpcPort);
+                        config.put("quarkus.grpc.clients.responserecorder.port", grpcPort);
                     }
                     String grpcPlainText =
-                            resultConfig.get("quarkus.grpc.clients.responseresumer.plain-text");
+                            resultConfig.get("quarkus.grpc.clients.responserecorder.plain-text");
                     if (grpcPlainText != null) {
                         config.put(
-                                "quarkus.grpc.clients.responseresumer.plain-text", grpcPlainText);
+                                "quarkus.grpc.clients.responserecorder.plain-text", grpcPlainText);
                     }
                 }
             }
@@ -171,13 +173,13 @@ public class MemoryServiceDevServicesProcessor {
         // Configure gRPC client using host, port, and TLS settings (as per Quarkus gRPC client
         // configuration)
         configProviders.put(
-                "quarkus.grpc.clients.responseresumer.host",
+                "quarkus.grpc.clients.responserecorder.host",
                 (Function<Startable, String>) s -> parseHost(getConnectionInfo(s)));
         configProviders.put(
-                "quarkus.grpc.clients.responseresumer.port",
+                "quarkus.grpc.clients.responserecorder.port",
                 (Function<Startable, String>) s -> parsePort(getConnectionInfo(s)));
         configProviders.put(
-                "quarkus.grpc.clients.responseresumer.plain-text",
+                "quarkus.grpc.clients.responserecorder.plain-text",
                 (Function<Startable, String>) s -> parsePlainText(getConnectionInfo(s)));
 
         if (generatedApiKey) {

--- a/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/runtime/GrpcFromUrlConfigSource.java
+++ b/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/runtime/GrpcFromUrlConfigSource.java
@@ -14,16 +14,16 @@ import org.eclipse.microprofile.config.spi.ConfigSource;
  *
  * <p>This source has ordinal 150 - higher than application.properties (100)
  * but lower than environment variables (300), so explicit env var overrides
- * like {@code QUARKUS_GRPC_CLIENTS_RESPONSERESUMER_HOST} still take precedence.
+ * like {@code QUARKUS_GRPC_CLIENTS_RESPONSERECORDER_HOST} still take precedence.
  *
  * @see GrpcFromUrlConfigSourceFactory
  * @see <a href="https://quarkus.io/guides/grpc-service-consumption">Quarkus gRPC Client Guide</a>
  */
 public class GrpcFromUrlConfigSource implements ConfigSource {
 
-    static final String GRPC_HOST = "quarkus.grpc.clients.responseresumer.host";
-    static final String GRPC_PORT = "quarkus.grpc.clients.responseresumer.port";
-    static final String GRPC_PLAIN_TEXT = "quarkus.grpc.clients.responseresumer.plain-text";
+    static final String GRPC_HOST = "quarkus.grpc.clients.responserecorder.host";
+    static final String GRPC_PORT = "quarkus.grpc.clients.responserecorder.port";
+    static final String GRPC_PLAIN_TEXT = "quarkus.grpc.clients.responserecorder.plain-text";
     static final Set<String> PROPERTY_NAMES = Set.of(GRPC_HOST, GRPC_PORT, GRPC_PLAIN_TEXT);
 
     private final Map<String, String> properties;

--- a/quarkus/memory-service-extension/runtime/src/test/java/io/github/chirino/memory/runtime/GrpcFromUrlConfigSourceTest.java
+++ b/quarkus/memory-service-extension/runtime/src/test/java/io/github/chirino/memory/runtime/GrpcFromUrlConfigSourceTest.java
@@ -10,9 +10,10 @@ import org.junit.jupiter.api.Test;
  */
 class GrpcFromUrlConfigSourceTest {
 
-    private static final String GRPC_HOST = "quarkus.grpc.clients.responseresumer.host";
-    private static final String GRPC_PORT = "quarkus.grpc.clients.responseresumer.port";
-    private static final String GRPC_PLAIN_TEXT = "quarkus.grpc.clients.responseresumer.plain-text";
+    private static final String GRPC_HOST = "quarkus.grpc.clients.responserecorder.host";
+    private static final String GRPC_PORT = "quarkus.grpc.clients.responserecorder.port";
+    private static final String GRPC_PLAIN_TEXT =
+            "quarkus.grpc.clients.responserecorder.plain-text";
 
     private GrpcFromUrlConfigSource createSource(String url) {
         Map<String, String> props = GrpcFromUrlConfigSource.parseUrl(url);

--- a/site/src/pages/docs/quarkus/grpc-client.mdx
+++ b/site/src/pages/docs/quarkus/grpc-client.mdx
@@ -45,7 +45,7 @@ The Memory Service gRPC API is split into multiple services:
 | `ConversationMembershipsService` | Sharing and membership management |
 | `OwnershipTransfersService` | Ownership transfer operations |
 | `SearchService` | Semantic search and indexing |
-| `ResponseResumerService` | Streaming response resumption |
+| `ResponseRecorderService` | Streaming response recording and resumption |
 | `SystemService` | Health checks |
 
 ## UUID Handling
@@ -261,33 +261,33 @@ for (SearchResult result : response.getResultsList()) {
 }
 ```
 
-## Response Resumer (Streaming)
+## Response Recorder (Streaming)
 
-The `ResponseResumerService` handles streaming response resumption for interrupted connections:
+The `ResponseRecorderService` handles streaming response recording and resumption for interrupted connections:
 
 ```java
-@GrpcClient("responseresumer")
-ResponseResumerServiceGrpc.ResponseResumerServiceStub resumerClient;
+@GrpcClient("responserecorder")
+ResponseRecorderServiceGrpc.ResponseRecorderServiceStub recorderClient;
 
-// Check if response resumer is enabled
-IsEnabledResponse enabled = resumerClient.isEnabled(Empty.getDefaultInstance());
+// Check if response recorder is enabled
+IsEnabledResponse enabled = recorderClient.isEnabled(Empty.getDefaultInstance());
 
-// Check which conversations have responses in progress
-CheckConversationsResponse check = resumerClient.checkConversations(
-    CheckConversationsRequest.newBuilder()
+// Check which conversations have recordings in progress
+CheckRecordingsResponse check = recorderClient.checkRecordings(
+    CheckRecordingsRequest.newBuilder()
         .addConversationIds(UuidHelper.toBytes(conversationId))
         .build()
 );
 
 // Replay response tokens
-resumerClient.replayResponseTokens(
-    ReplayResponseTokensRequest.newBuilder()
+recorderClient.replay(
+    ReplayRequest.newBuilder()
         .setConversationId(UuidHelper.toBytes(conversationId))
         .build(),
-    new StreamObserver<ReplayResponseTokensResponse>() {
+    new StreamObserver<ReplayResponse>() {
         @Override
-        public void onNext(ReplayResponseTokensResponse response) {
-            System.out.print(response.getToken());
+        public void onNext(ReplayResponse response) {
+            System.out.print(response.getContent());
         }
 
         @Override
@@ -340,7 +340,7 @@ quarkus.grpc.clients.conversations.tls.trust-certificate-pem.certs=ca.pem
 
 Choose gRPC over REST when you need:
 
-- **Streaming** - Real-time response resumption with `ResponseResumerService`
+- **Streaming** - Real-time response recording and resumption with `ResponseRecorderService`
 - **High throughput** - Binary protocol is more efficient
 - **Strong typing** - Generated stubs catch errors at compile time
 - **Bi-directional communication** - Full duplex streaming for response recording

--- a/site/src/pages/docs/spring/grpc-client.mdx
+++ b/site/src/pages/docs/spring/grpc-client.mdx
@@ -192,25 +192,25 @@ messages.streamMessages(request, new StreamObserver<Message>() {
 
 ## Response Resumption
 
-The `responseResumerService()` provides async streaming for response resumption. This is used internally by the `ResponseResumer` bean, but you can also use it directly:
+The `responseRecorderService()` provides async streaming for response recording and resumption. This is used internally by the `ResponseResumer` bean, but you can also use it directly:
 
 ```java
-import io.github.chirino.memory.grpc.v1.ResponseResumerServiceGrpc;
-import io.github.chirino.memory.grpc.v1.ReplayResponseRequest;
+import io.github.chirino.memory.grpc.v1.ResponseRecorderServiceGrpc;
+import io.github.chirino.memory.grpc.v1.ReplayRequest;
 import reactor.core.publisher.Flux;
 
-ResponseResumerServiceGrpc.ResponseResumerServiceStub resumer = 
-    stubs.responseResumerService();
+ResponseRecorderServiceGrpc.ResponseRecorderServiceStub recorder =
+    stubs.responseRecorderService();
 
-ReplayResponseRequest request = ReplayResponseRequest.newBuilder()
-    .setConversationId("my-conversation")
+ReplayRequest request = ReplayRequest.newBuilder()
+    .setConversationId(UuidHelper.toBytes(conversationId))
     .build();
 
 // Convert gRPC stream to Reactor Flux
 Flux<String> responseFlux = Flux.create(sink -> {
-    resumer.replayResponse(request, new StreamObserver<ReplayResponseResponse>() {
+    recorder.replay(request, new StreamObserver<ReplayResponse>() {
         @Override
-        public void onNext(ReplayResponseResponse response) {
+        public void onNext(ReplayResponse response) {
             sink.next(response.getContent());
         }
 

--- a/spring/memory-service-proto-spring/src/main/java/io/github/chirino/memoryservice/grpc/MemoryServiceGrpcClients.java
+++ b/spring/memory-service-proto-spring/src/main/java/io/github/chirino/memoryservice/grpc/MemoryServiceGrpcClients.java
@@ -3,7 +3,7 @@ package io.github.chirino.memoryservice.grpc;
 import io.github.chirino.memory.grpc.v1.ConversationMembershipsServiceGrpc;
 import io.github.chirino.memory.grpc.v1.ConversationsServiceGrpc;
 import io.github.chirino.memory.grpc.v1.EntriesServiceGrpc;
-import io.github.chirino.memory.grpc.v1.ResponseResumerServiceGrpc;
+import io.github.chirino.memory.grpc.v1.ResponseRecorderServiceGrpc;
 import io.github.chirino.memory.grpc.v1.SearchServiceGrpc;
 import io.github.chirino.memory.grpc.v1.SystemServiceGrpc;
 import io.grpc.ManagedChannel;
@@ -62,7 +62,8 @@ public final class MemoryServiceGrpcClients {
                 membershipsService;
         private final EntriesServiceGrpc.EntriesServiceBlockingStub entriesService;
         private final SearchServiceGrpc.SearchServiceBlockingStub searchService;
-        private final ResponseResumerServiceGrpc.ResponseResumerServiceStub responseResumerService;
+        private final ResponseRecorderServiceGrpc.ResponseRecorderServiceStub
+                responseRecorderService;
 
         public MemoryServiceStubs(ManagedChannel channel) {
             this.channel = channel;
@@ -71,7 +72,7 @@ public final class MemoryServiceGrpcClients {
             this.membershipsService = ConversationMembershipsServiceGrpc.newBlockingStub(channel);
             this.entriesService = EntriesServiceGrpc.newBlockingStub(channel);
             this.searchService = SearchServiceGrpc.newBlockingStub(channel);
-            this.responseResumerService = ResponseResumerServiceGrpc.newStub(channel);
+            this.responseRecorderService = ResponseRecorderServiceGrpc.newStub(channel);
         }
 
         public SystemServiceGrpc.SystemServiceBlockingStub systemService() {
@@ -95,8 +96,8 @@ public final class MemoryServiceGrpcClients {
             return searchService;
         }
 
-        public ResponseResumerServiceGrpc.ResponseResumerServiceStub responseResumerService() {
-            return responseResumerService;
+        public ResponseRecorderServiceGrpc.ResponseRecorderServiceStub responseRecorderService() {
+            return responseRecorderService;
         }
 
         @Override


### PR DESCRIPTION
## Summary

Simplifies and clarifies the gRPC API for response recording and resumption by renaming the service, RPCs, messages, and fields to better reflect their purpose. Changes the `Record` RPC from bidirectional streaming to client streaming with a unary response, and replaces gRPC trailing metadata redirects with response-level `redirect_address` fields.

## Changes

- Rename gRPC service: `ResponseResumerService` → `ResponseRecorderService`
- Rename RPCs: `StreamResponseTokens` → `Record`, `ReplayResponseTokens` → `Replay`, `CancelResponse` → `Cancel`, `CheckConversations` → `CheckRecordings`
- Rename messages: `StreamResponseTokenRequest` → `RecordRequest`, `ReplayResponseTokensResponse` → `ReplayResponse`, etc.
- Rename fields: `token` → `content`, remove unused `offset`/`current_offset` fields
- Change `Record` from bidirectional streaming to client streaming + unary response
- Add `RecordStatus` enum (`SUCCESS`, `CANCELLED`, `ERROR`) replacing boolean flags
- Replace gRPC trailing metadata redirect (`x-resumer-redirect-host`/`x-resumer-redirect-port`) with `redirect_address` response field
- Update server implementation, Quarkus client, Spring client, config keys (`responseresumer` → `responserecorder`)
- Update Cucumber tests (all 317 tests pass)
- Update documentation: concepts page, Quarkus/Spring gRPC client guides, design doc
- Add enhancement design doc: `docs/enhancements/049-response-resumer-api-simplification.md`