### PR TITLE
feat: validate CreateEntryRequest.userId matches authenticated principal

### DIFF
--- a/memory-service/src/main/java/io/github/chirino/memory/grpc/EntriesGrpcService.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/grpc/EntriesGrpcService.java
@@ -135,7 +135,9 @@ public class EntriesGrpcService extends AbstractGrpcService implements EntriesSe
                             // Validate history channel entry format
                             validateHistoryEntry(request.getEntry());
                             CreateEntryRequest internal = new CreateEntryRequest();
-                            internal.setUserId(request.getEntry().getUserId());
+                            String rawUserId = request.getEntry().getUserId();
+                            internal.setUserId(
+                                    rawUserId == null || rawUserId.isBlank() ? null : rawUserId);
                             io.github.chirino.memory.model.Channel requestChannel =
                                     GrpcDtoMapper.fromProtoChannel(request.getEntry().getChannel());
                             internal.setChannel(GrpcDtoMapper.toCreateEntryChannel(requestChannel));
@@ -159,6 +161,7 @@ public class EntriesGrpcService extends AbstractGrpcService implements EntriesSe
                                                 byteStringToString(
                                                         request.getEntry().getForkedAtEntryId())));
                             }
+                            validateAndResolveUserId(internal);
                             List<io.github.chirino.memory.api.dto.EntryDto> appended =
                                     store().appendMemoryEntries(
                                                     currentUserId(),
@@ -217,6 +220,7 @@ public class EntriesGrpcService extends AbstractGrpcService implements EntriesSe
                                         .asRuntimeException();
                             }
                             CreateEntryRequest internal = toClientCreateEntry(grpcEntry);
+                            validateAndResolveUserId(internal);
                             SyncResult result =
                                     store().syncAgentEntry(
                                                     currentUserId(),

--- a/memory-service/src/main/java/io/github/chirino/memory/store/impl/MongoMemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/impl/MongoMemoryStore.java
@@ -1260,12 +1260,7 @@ public class MongoMemoryStore implements MemoryStore {
                             ? Channel.fromString(req.getChannel().value())
                             : Channel.MEMORY;
             m.channel = channel;
-            // For HISTORY entries, default userId to the authenticated user
-            String entryUserId = req.getUserId();
-            if (entryUserId == null && channel == Channel.HISTORY) {
-                entryUserId = userId;
-            }
-            m.userId = entryUserId;
+            m.userId = req.getUserId();
 
             // Set epoch based on channel type
             // INVARIANT: Memory channel entries must ALWAYS have a non-null epoch.

--- a/memory-service/src/main/java/io/github/chirino/memory/store/impl/PostgresMemoryStore.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/store/impl/PostgresMemoryStore.java
@@ -1393,12 +1393,7 @@ public class PostgresMemoryStore implements MemoryStore {
                 channel = io.github.chirino.memory.model.Channel.MEMORY;
             }
             entity.setChannel(channel);
-            // For HISTORY entries, default userId to the authenticated user
-            String entryUserId = req.getUserId();
-            if (entryUserId == null && channel == Channel.HISTORY) {
-                entryUserId = userId;
-            }
-            entity.setUserId(entryUserId);
+            entity.setUserId(req.getUserId());
 
             // Set epoch based on channel type
             // INVARIANT: Memory channel entries must ALWAYS have a non-null epoch.

--- a/memory-service/src/test/java/io/github/chirino/memory/cucumber/StepDefinitions.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/cucumber/StepDefinitions.java
@@ -475,7 +475,7 @@ public class StepDefinitions {
                 .appendMemoryEntries(
                         currentUserId,
                         conversationId,
-                        List.of(createHistoryEntry(content)),
+                        List.of(createHistoryEntry(currentUserId, content)),
                         "test-client",
                         null);
     }
@@ -503,6 +503,7 @@ public class StepDefinitions {
                 CreateEntryRequest.ChannelEnum.fromString(channel.toLowerCase());
         request.setChannel(channelEnum);
         request.setContentType(contentType);
+        request.setUserId(currentUserId);
 
         // History channel entries must use "history" contentType and {text, role} structure
         if (channelEnum == CreateEntryRequest.ChannelEnum.HISTORY) {
@@ -536,6 +537,7 @@ public class StepDefinitions {
         request.setChannel(CreateEntryRequest.ChannelEnum.MEMORY);
         // Epoch is now passed as a parameter to appendMemoryEntries, not set on request
         request.setContentType(contentType);
+        request.setUserId(currentUserId);
         memoryStoreSelector
                 .getStore()
                 .appendMemoryEntries(
@@ -3223,7 +3225,11 @@ public class StepDefinitions {
         memoryStoreSelector
                 .getStore()
                 .appendMemoryEntries(
-                        ownerId, convId, List.of(createHistoryEntry(content)), "test-client", null);
+                        ownerId,
+                        convId,
+                        List.of(createHistoryEntry(ownerId, content)),
+                        "test-client",
+                        null);
     }
 
     @io.cucumber.java.en.Given("the conversation owned by {string} is deleted")
@@ -3868,7 +3874,7 @@ public class StepDefinitions {
                 .appendMemoryEntries(
                         userId,
                         conversationId,
-                        List.of(createHistoryEntry("Entry 1")),
+                        List.of(createHistoryEntry(userId, "Entry 1")),
                         "test-client",
                         null);
         memoryStoreSelector
@@ -3876,7 +3882,7 @@ public class StepDefinitions {
                 .appendMemoryEntries(
                         userId,
                         conversationId,
-                        List.of(createHistoryEntry("Entry 2")),
+                        List.of(createHistoryEntry(userId, "Entry 2")),
                         "test-client",
                         null);
     }
@@ -4348,10 +4354,11 @@ public class StepDefinitions {
         }
     }
 
-    private static CreateEntryRequest createHistoryEntry(String text) {
+    private static CreateEntryRequest createHistoryEntry(String userId, String text) {
         CreateEntryRequest req = new CreateEntryRequest();
         req.setChannel(CreateEntryRequest.ChannelEnum.HISTORY);
         req.setContentType("history");
+        req.setUserId(userId);
         req.setContent(List.of(Map.of("role", "USER", "text", text)));
         return req;
     }


### PR DESCRIPTION
## Summary

Validates that `CreateEntryRequest.userId` matches the bearer token principal. If userId is provided but doesn't match, the request is rejected with 400 Bad Request. If userId is omitted, it defaults to the authenticated user. This closes an impersonation vector where any authenticated user could create entries attributed to someone else.

## Changes

- Add `validateAndResolveUserId()` to REST `ConversationsResource` — called in `appendEntry` and `syncMemoryEntries`
- Add `validateAndResolveUserId()` to gRPC `AbstractGrpcService` — called in `EntriesGrpcService.appendEntry` and `syncEntries`
- Remove redundant store-level userId defaulting from `PostgresMemoryStore` and `MongoMemoryStore`
- Add 4 cucumber test scenarios: mismatched userId rejected, missing userId defaults, matching userId accepted, sync mismatch rejected