### PR TITLE
feat: use mongodb for attachment storage in kind mongodb-redis overlay

### DIFF
--- a/deploy/kustomize/envs/kind/overlays/mongodb-redis/kustomization.yaml
+++ b/deploy/kustomize/envs/kind/overlays/mongodb-redis/kustomization.yaml
@@ -6,3 +6,12 @@ resources:
 
 components:
   - ../../base
+
+patches:
+  - target:
+      kind: ConfigMap
+      name: memory-service-config
+    patch: |
+      - op: add
+        path: /data/MEMORY_SERVICE_ATTACHMENTS_STORE
+        value: db


### PR DESCRIPTION
## Summary

Override the MinIO component's S3 attachment store setting in the Kind mongodb-redis overlay so that attachments are stored in MongoDB instead of MinIO. Uses a kustomize patch (instead of configMapGenerator merge) to ensure the override takes effect after component generators.

## Changes

- Add a kustomize JSON patch to `deploy/kustomize/envs/kind/overlays/mongodb-redis/kustomization.yaml` that sets `MEMORY_SERVICE_ATTACHMENTS_STORE=db`