### PR TITLE
feat: rename demo-chat to chat-quarkus and improve deployment config

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,6 +9,17 @@ vars:
 
 tasks:
 
+  dev:
+    desc: Run the memoery-service and chat-quarkus apps in dev mode.
+    cmds:
+      - |
+        set -e
+        trap 'kill 0' EXIT
+        ./mvnw -T 1C install -pl ':memory-service,:memory-service-extension-deployment' -am -DskipTests
+        ./mvnw -T 1C -pl :memory-service quarkus:dev > memory-service.log 2>&1 &
+        ./mvnw -T 1C -pl :chat-quarkus quarkus:dev -Dquarkus.profile=alt
+
+
   secrets:
     desc: Create memory-service secret from current shell environment variables
     cmds:
@@ -42,8 +53,8 @@ tasks:
     desc: Load locally built app images into the kind cluster and restart their deployments
     cmds:
       - kind load docker-image ghcr.io/chirino/memory-service:latest --name {{.KIND_CLUSTER_NAME}}
-      - kind load docker-image ghcr.io/chirino/memory-service-demo-chat:latest --name {{.KIND_CLUSTER_NAME}}
-      - kubectl rollout restart deployment/memory-service deployment/demo-chat -n memory-service 2>/dev/null || true
+      - kind load docker-image ghcr.io/chirino/memory-service-chat-quarkus:latest --name {{.KIND_CLUSTER_NAME}}
+      - kubectl rollout restart deployment/memory-service deployment/chat-quarkus -n memory-service 2>/dev/null || true
 
   kind:rm:
     desc: Delete the kind cluster

--- a/compose.yaml
+++ b/compose.yaml
@@ -140,8 +140,8 @@ services:
       prometheus:
         condition: service_healthy
 
-  demo-chat:
-    image: ghcr.io/chirino/memory-service-demo-chat:latest
+  chat-quarkus:
+    image: ghcr.io/chirino/memory-service-chat-quarkus:latest
     build:
       context: .
       dockerfile: ./quarkus/examples/chat-quarkus/Dockerfile

--- a/deploy/kustomize/base/deployment.yaml
+++ b/deploy/kustomize/base/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     app: memory-service
     app.kubernetes.io/name: memory-service
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: memory-service

--- a/deploy/kustomize/components/demo/chat/deployment.yaml
+++ b/deploy/kustomize/components/demo/chat/deployment.yaml
@@ -1,24 +1,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: demo-chat
+  name: chat-quarkus
   labels:
-    app: demo-chat
-    app.kubernetes.io/name: demo-chat
+    app: chat-quarkus
+    app.kubernetes.io/name: chat-quarkus
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
-      app: demo-chat
+      app: chat-quarkus
   template:
     metadata:
       labels:
-        app: demo-chat
-        app.kubernetes.io/name: demo-chat
+        app: chat-quarkus
+        app.kubernetes.io/name: chat-quarkus
     spec:
       containers:
-        - name: demo-chat
-          image: ghcr.io/chirino/memory-service-demo-chat:latest
+        - name: chat-quarkus
+          image: ghcr.io/chirino/memory-service-chat-quarkus:latest
           ports:
             - name: http
               containerPort: 8080
@@ -29,7 +29,7 @@ spec:
             - name: MEMORY_SERVICE_CLIENT_API_KEY
               valueFrom:
                 secretKeyRef:
-                  name: demo-chat-secret
+                  name: chat-quarkus-secret
                   key: MEMORY_SERVICE_CLIENT_API_KEY
             - name: QUARKUS_OIDC_AUTH_SERVER_URL
               value: "http://keycloak:8080/realms/memory-service"
@@ -46,7 +46,7 @@ spec:
             - name: KEYCLOAK_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: demo-chat-secret
+                  name: chat-quarkus-secret
                   key: KEYCLOAK_CLIENT_SECRET
             - name: OPENAI_API_KEY
               valueFrom:

--- a/deploy/kustomize/components/demo/chat/kustomization.yaml
+++ b/deploy/kustomize/components/demo/chat/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - service.yaml
 
 secretGenerator:
-  - name: demo-chat-secret
+  - name: chat-quarkus-secret
     literals:
       - MEMORY_SERVICE_CLIENT_API_KEY=agent-api-key-1
       - KEYCLOAK_CLIENT_SECRET=change-me

--- a/deploy/kustomize/components/demo/chat/service.yaml
+++ b/deploy/kustomize/components/demo/chat/service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: demo-chat
+  name: chat-quarkus
   labels:
-    app: demo-chat
+    app: chat-quarkus
 spec:
   type: ClusterIP
   ports:
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    app: demo-chat
+    app: chat-quarkus

--- a/deploy/kustomize/components/demo/gateway/httproute-chat-quarkus.yaml
+++ b/deploy/kustomize/components/demo/gateway/httproute-chat-quarkus.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: demo-chat
+  name: chat-quarkus
   namespace: memory-service
 spec:
   parentRefs:
@@ -12,5 +12,5 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: demo-chat
+        - name: chat-quarkus
           port: 8080

--- a/deploy/kustomize/components/demo/gateway/kustomization.yaml
+++ b/deploy/kustomize/components/demo/gateway/kustomization.yaml
@@ -5,4 +5,4 @@ resources:
   - httproute-keycloak.yaml
   - httproute-grafana.yaml
   - httproute-prometheus.yaml
-  - httproute-demo-chat.yaml
+  - httproute-chat-quarkus.yaml

--- a/deploy/kustomize/envs/kind/base/kustomization.yaml
+++ b/deploy/kustomize/envs/kind/base/kustomization.yaml
@@ -49,7 +49,7 @@ patches:
   # Assign nip.io hostnames to each HTTPRoute
   - target:
       kind: HTTPRoute
-      name: demo-chat
+      name: chat-quarkus
     patch: |
       - op: add
         path: /spec/hostnames
@@ -116,7 +116,7 @@ patches:
         value: IfNotPresent
   - target:
       kind: Deployment
-      name: demo-chat
+      name: chat-quarkus
     patch: |
       - op: add
         path: /spec/template/spec/containers/0/imagePullPolicy


### PR DESCRIPTION
## Summary

Renames `demo-chat` to `chat-quarkus` across the entire deployment surface for consistency with the Quarkus module name. Also adds a convenience dev task, bumps default replicas, and improves response resumer logging.

## Changes

- Rename `demo-chat` → `chat-quarkus` in kustomize manifests, compose.yaml, and Taskfile
- Add `dev` task to Taskfile for running memory-service and chat-quarkus in dev mode
- Bump default replicas from 1 to 2 for memory-service and chat-quarkus deployments
- Add debug/info logging to `TempFileResumerBackend` and `GrpcResponseResumer` for replay, redirect, and recording flows