### PR TITLE
docs: add status metadata and supersedes links to enhancement docs

### DIFF
--- a/docs/enhancements/001-conversation-forking-design.md
+++ b/docs/enhancements/001-conversation-forking-design.md
@@ -1,4 +1,15 @@
+---
+status: partial
+superseded-by:
+  - 017-hide-conversation-groups.md
+  - 046-simpler-forking.md
+---
+
 # Conversation Forking Data Model (Design Draft)
+
+> **Status**: Partially implemented. Conversation groups hidden from public API by
+> [017](017-hide-conversation-groups.md). Fork creation simplified to auto-create on first entry by
+> [046](046-simpler-forking.md).
 
 ## Goals
 - Support many messages per conversation and allow forking at any message.

--- a/docs/enhancements/002-summarization-design.md
+++ b/docs/enhancements/002-summarization-design.md
@@ -1,4 +1,15 @@
+---
+status: superseded
+superseded-by:
+  - 019-rename-summary-to-index.md
+  - 030-index-design.md
+---
+
 # Summarization Design
+
+> **Status**: Superseded. Renamed from "summary" to "index" by
+> [019](019-rename-summary-to-index.md). Index model redesigned to per-entry indexing by
+> [030](030-index-design.md).
 
 ## Goals
 - Extend the conversation summarization flow to persist a title, summary content, and summary coverage metadata.

--- a/docs/enhancements/003-grpc-design.md
+++ b/docs/enhancements/003-grpc-design.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # gRPC API Design for memory-service
+
+> **Status**: Implemented.
 
 ## Goals
 - Expose all memory-service REST endpoints as gRPC endpoints while preserving behavior and access control.

--- a/docs/enhancements/004-response-cancel.md
+++ b/docs/enhancements/004-response-cancel.md
@@ -1,4 +1,15 @@
+---
+status: partial
+superseded-by:
+  - 010-drop-resumePosition.md
+  - 049-response-resumer-api-simplification.md
+---
+
 # Response Cancel Design (Draft)
+
+> **Status**: Partially implemented. Resume position dropped by
+> [010](010-drop-resumePosition.md). Service and RPC names simplified by
+> [049](049-response-resumer-api-simplification.md).
 
 ## Goals
 - Allow a user or agent to cancel an in-progress response generation.

--- a/docs/enhancements/005-redis-connection-limits.md
+++ b/docs/enhancements/005-redis-connection-limits.md
@@ -1,4 +1,13 @@
+---
+status: implemented
+superseded-by:
+  - 011-simpler-cache-config.md
+---
+
 # Redis Connection Limits for Response Replay (Draft)
+
+> **Status**: Implemented. Cache configuration properties unified by
+> [011](011-simpler-cache-config.md).
 
 ## Problem Summary
 When many clients reload/resume a long response at the same time, the memory-service

--- a/docs/enhancements/006-infinispan-support.md
+++ b/docs/enhancements/006-infinispan-support.md
@@ -1,4 +1,13 @@
+---
+status: implemented
+superseded-by:
+  - 011-simpler-cache-config.md
+---
+
 # Infinispan Cache Support for memory-service (Draft)
+
+> **Status**: Implemented. Cache configuration properties unified by
+> [011](011-simpler-cache-config.md).
 
 ## Problem Summary
 The memory-service currently uses Redis only for the response-resumer locator

--- a/docs/enhancements/007-multi-agent-support.md
+++ b/docs/enhancements/007-multi-agent-support.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Multi-Agent Memory Support (Draft)
+
+> **Status**: Implemented.
 
 ## Problem Summary
 The memory-service currently assumes a single agent per conversation. All

--- a/docs/enhancements/008-headless-ui-component-design.md
+++ b/docs/enhancements/008-headless-ui-component-design.md
@@ -1,4 +1,15 @@
+---
+status: superseded
+superseded-by:
+  - 022-chat-app-design.md
+  - 023-chat-app-implementation.md
+---
+
 # Headless Conversation & Fork Primitives — Design & Implementation Plan
+
+> **Status**: Superseded. Standalone headless library approach replaced by a full chat app
+> built directly with Radix/shadcn primitives in
+> [022](022-chat-app-design.md) and [023](023-chat-app-implementation.md).
 
 This document defines the design of a family of **headless, composable conversation primitives** for building AI chat UIs in this application.  
 These primitives encapsulate conversation state, fork logic, and streaming message lifecycles in a Radix-style headless API without UI or styling.

--- a/docs/enhancements/009-springboot-support.md
+++ b/docs/enhancements/009-springboot-support.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Spring Boot support: design and implementation plan
+
+> **Status**: Implemented.
 
 ## Goals
 - Provide first-class Spring Boot equivalents for the REST client, gRPC/proto artifacts, dev-time helpers, and the example agent.

--- a/docs/enhancements/010-drop-resumePosition.md
+++ b/docs/enhancements/010-drop-resumePosition.md
@@ -1,4 +1,13 @@
+---
+status: implemented
+superseded-by:
+  - 049-response-resumer-api-simplification.md
+---
+
 # Drop `resumePosition` from ResponseResumer.replay
+
+> **Status**: Implemented. API further simplified and renamed by
+> [049](049-response-resumer-api-simplification.md).
 
 ## Motivation
 

--- a/docs/enhancements/011-simpler-cache-config.md
+++ b/docs/enhancements/011-simpler-cache-config.md
@@ -1,4 +1,14 @@
+---
+status: implemented
+supersedes:
+  - 005-redis-connection-limits.md
+  - 006-infinispan-support.md
+---
+
 # Simplify Cache Configuration
+
+> **Status**: Implemented. Unifies cache configuration from
+> [005](005-redis-connection-limits.md) and [006](006-infinispan-support.md).
 
 ## Motivation
 

--- a/docs/enhancements/012-spring-site-docs.md
+++ b/docs/enhancements/012-spring-site-docs.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Spring Boot / Spring AI Documentation
+
+> **Status**: Implemented.
 
 ## Goals
 

--- a/docs/enhancements/013-soft-deletes.md
+++ b/docs/enhancements/013-soft-deletes.md
@@ -1,4 +1,13 @@
+---
+status: partial
+superseded-by:
+  - 028-membership-hard-delete.md
+---
+
 # Soft Deletes for Audit Retention
+
+> **Status**: Partially implemented. Membership soft deletes replaced by hard deletes with
+> audit logging in [028](028-membership-hard-delete.md).
 
 ## Motivation
 

--- a/docs/enhancements/014-admin-access.md
+++ b/docs/enhancements/014-admin-access.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Admin Access APIs
+
+> **Status**: Implemented.
 
 ## Motivation
 

--- a/docs/enhancements/015-task-queue.md
+++ b/docs/enhancements/015-task-queue.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Background Task Queue
+
+> **Status**: Implemented.
 
 ## Motivation
 

--- a/docs/enhancements/016-data-eviction.md
+++ b/docs/enhancements/016-data-eviction.md
@@ -1,4 +1,15 @@
+---
+status: partial
+superseded-by:
+  - 028-membership-hard-delete.md
+  - 039-remove-epoch-eviction.md
+---
+
 # Data Eviction (Hard Delete) for Soft-Deleted Resources
+
+> **Status**: Partially implemented. Membership eviction removed by
+> [028](028-membership-hard-delete.md). Epoch eviction removed by
+> [039](039-remove-epoch-eviction.md).
 
 ## Motivation
 

--- a/docs/enhancements/017-hide-conversation-groups.md
+++ b/docs/enhancements/017-hide-conversation-groups.md
@@ -1,4 +1,13 @@
-# 017 - Hide Conversation Groups from Public API Contracts
+---
+status: implemented
+supersedes:
+  - 001-conversation-forking-design.md
+---
+
+# Hide Conversation Groups from Public API Contracts
+
+> **Status**: Implemented. Refines the public API surface from
+> [001](001-conversation-forking-design.md).
 
 ## Summary
 

--- a/docs/enhancements/018-rename-messages-to-entrys.md
+++ b/docs/enhancements/018-rename-messages-to-entrys.md
@@ -1,4 +1,10 @@
-# 018 - Rename Messages to Entries and Add contentType Field
+---
+status: implemented
+---
+
+# Rename Messages to Entries and Add contentType Field
+
+> **Status**: Implemented.
 
 ## Summary
 

--- a/docs/enhancements/019-rename-summary-to-index.md
+++ b/docs/enhancements/019-rename-summary-to-index.md
@@ -1,4 +1,15 @@
-# 019 - Rename Summary to Index and Consolidate Conversation Endpoints
+---
+status: partial
+supersedes:
+  - 002-summarization-design.md
+superseded-by:
+  - 030-index-design.md
+---
+
+# Rename Summary to Index and Consolidate Conversation Endpoints
+
+> **Status**: Partially implemented. Supersedes [002](002-summarization-design.md). Index model
+> further redesigned to per-entry indexing by [030](030-index-design.md).
 
 ## Summary
 

--- a/docs/enhancements/021-uuid-ids-in-contract.md
+++ b/docs/enhancements/021-uuid-ids-in-contract.md
@@ -1,4 +1,10 @@
-# Enhancement 021: UUID IDs in API Contracts
+---
+status: implemented
+---
+
+# UUID IDs in API Contracts
+
+> **Status**: Implemented.
 
 ## Overview
 

--- a/docs/enhancements/022-chat-app-design.md
+++ b/docs/enhancements/022-chat-app-design.md
@@ -1,6 +1,13 @@
-# Enhancement 022: Chat App Frontend Design
+---
+status: implemented
+supersedes:
+  - 008-headless-ui-component-design.md
+---
 
-**Status**: ✅ Complete
+# Chat App Frontend Design
+
+> **Status**: Implemented. Replaces the headless library approach from
+> [008](008-headless-ui-component-design.md) with a full chat application.
 
 ## Overview
 

--- a/docs/enhancements/023-chat-app-implementation.md
+++ b/docs/enhancements/023-chat-app-implementation.md
@@ -1,4 +1,15 @@
-# Enhancement 023: Chat App Implementation
+---
+status: partial
+supersedes:
+  - 008-headless-ui-component-design.md
+superseded-by:
+  - 048-chat-app-checkpoint-alignment.md
+---
+
+# Chat App Implementation
+
+> **Status**: Partially implemented. Replaces [008](008-headless-ui-component-design.md). Class names
+> and REST paths realigned by [048](048-chat-app-checkpoint-alignment.md).
 
 ## Overview
 

--- a/docs/enhancements/024-sharing-api-enhancements.md
+++ b/docs/enhancements/024-sharing-api-enhancements.md
@@ -1,4 +1,10 @@
-# Enhancement 024: Sharing API Enhancements
+---
+status: implemented
+---
+
+# Sharing API Enhancements
+
+> **Status**: Implemented.
 
 ## Overview
 

--- a/docs/enhancements/025-sharing-ui.md
+++ b/docs/enhancements/025-sharing-ui.md
@@ -1,4 +1,10 @@
-# Enhancement 024: Conversation Sharing UI
+---
+status: implemented
+---
+
+# Conversation Sharing UI
+
+> **Status**: Implemented.
 
 ## Overview
 

--- a/docs/enhancements/026-memory-perf.md
+++ b/docs/enhancements/026-memory-perf.md
@@ -1,4 +1,10 @@
-# Enhancement 026: Memory Channel SQL Access Pattern Analysis
+---
+status: implemented
+---
+
+# Memory Channel SQL Access Pattern Analysis
+
+> **Status**: Implemented.
 
 ## Overview
 

--- a/docs/enhancements/027-epoch-evictions.md
+++ b/docs/enhancements/027-epoch-evictions.md
@@ -1,4 +1,13 @@
-# Enhancement 027: Epoch Evictions
+---
+status: superseded
+superseded-by:
+  - 039-remove-epoch-eviction.md
+---
+
+# Epoch Evictions
+
+> **Status**: Superseded. Epoch eviction removed to avoid data loss with conversation forking.
+> See [039](039-remove-epoch-eviction.md).
 
 ## Motivation
 

--- a/docs/enhancements/028-membership-hard-delete.md
+++ b/docs/enhancements/028-membership-hard-delete.md
@@ -1,4 +1,13 @@
+---
+status: implemented
+supersedes:
+  - 013-soft-deletes.md
+---
+
 # Hard Delete for Conversation Memberships with Audit Logging
+
+> **Status**: Implemented. Replaces membership soft deletes from
+> [013](013-soft-deletes.md) with hard deletes and audit logging.
 
 ## Motivation
 

--- a/docs/enhancements/029-search-index-improvements.md
+++ b/docs/enhancements/029-search-index-improvements.md
@@ -1,4 +1,13 @@
+---
+status: partial
+superseded-by:
+  - 030-index-design.md
+---
+
 # Search and Index API Improvements
+
+> **Status**: Partially implemented. Index model further redesigned to per-entry indexing by
+> [030](030-index-design.md).
 
 ## Motivation
 

--- a/docs/enhancements/030-index-design.md
+++ b/docs/enhancements/030-index-design.md
@@ -1,4 +1,16 @@
+---
+status: implemented
+supersedes:
+  - 002-summarization-design.md
+  - 019-rename-summary-to-index.md
+  - 029-search-index-improvements.md
+---
+
 # Index Endpoint Redesign
+
+> **Status**: Implemented. Supersedes the indexing approaches in
+> [002](002-summarization-design.md), [019](019-rename-summary-to-index.md),
+> and [029](029-search-index-improvements.md).
 
 ## Motivation
 

--- a/docs/enhancements/031-hybrid-highlights.md
+++ b/docs/enhancements/031-hybrid-highlights.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Hybrid Highlight Generation
+
+> **Status**: Implemented.
 
 ## Motivation
 

--- a/docs/enhancements/032-search-optimizations.md
+++ b/docs/enhancements/032-search-optimizations.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Search Optimizations: Vector Search Implementation
+
+> **Status**: Implemented.
 
 ## Motivation
 

--- a/docs/enhancements/033-fulltext-search-fallback.md
+++ b/docs/enhancements/033-fulltext-search-fallback.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Full-Text Search Fallback with GIN Indexes
+
+> **Status**: Implemented.
 
 ## Motivation
 

--- a/docs/enhancements/034-forked-entry-retrieval.md
+++ b/docs/enhancements/034-forked-entry-retrieval.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Forked Entry Retrieval
+
+> **Status**: Implemented.
 
 ## Problem Statement
 

--- a/docs/enhancements/035-metrics-design.md
+++ b/docs/enhancements/035-metrics-design.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Metrics Design
+
+> **Status**: Implemented.
 
 This document describes the metrics strategy for the memory-service, covering Prometheus metrics for operational monitoring and admin dashboard metrics.
 

--- a/docs/enhancements/036-rich-types-responses.md
+++ b/docs/enhancements/036-rich-types-responses.md
@@ -1,4 +1,10 @@
-# 036: Rich Event Types in History Entries and Resumable Streams
+---
+status: implemented
+---
+
+# Rich Event Types in History Entries and Resumable Streams
+
+> **Status**: Implemented.
 
 ## Status
 Implemented (Quarkus complete, Spring partial - see Known Limitations)

--- a/docs/enhancements/037-attachments.md
+++ b/docs/enhancements/037-attachments.md
@@ -1,4 +1,13 @@
-# 037: Multi-Modal Input Requests in History Entries
+---
+status: superseded
+superseded-by:
+  - 043-improved-quarkus-attachments.md
+---
+
+# Multi-Modal Input Requests in History Entries
+
+> **Status**: Superseded. Phased attachment approach replaced by simplified multimodal design in
+> [043](043-improved-quarkus-attachments.md).
 
 ## Status
 Implemented (Phase 1 + Phase 2 + Phase 3 + Phase 4)

--- a/docs/enhancements/038-tutorial-checkpoints.md
+++ b/docs/enhancements/038-tutorial-checkpoints.md
@@ -1,4 +1,10 @@
-# Enhancement 038: Tutorial Checkpoint Directories
+---
+status: implemented
+---
+
+# Tutorial Checkpoint Directories
+
+> **Status**: Implemented.
 
 **Status**: 📋 Planned
 

--- a/docs/enhancements/039-remove-epoch-eviction.md
+++ b/docs/enhancements/039-remove-epoch-eviction.md
@@ -1,4 +1,13 @@
-# Enhancement 038: Remove Epoch Eviction
+---
+status: implemented
+supersedes:
+  - 027-epoch-evictions.md
+---
+
+# Remove Epoch Eviction
+
+> **Status**: Implemented. Supersedes [027](027-epoch-evictions.md). Epoch eviction removed to
+> avoid data loss when forked conversations reference evicted epochs.
 
 ## Problem Statement
 

--- a/docs/enhancements/040-doc-sharing.md
+++ b/docs/enhancements/040-doc-sharing.md
@@ -1,4 +1,10 @@
-# Enhancement 040: Conversation Sharing Documentation
+---
+status: implemented
+---
+
+# Conversation Sharing Documentation
+
+> **Status**: Implemented.
 
 **Status**: 📋 Planned
 

--- a/docs/enhancements/041-stale-docs-and-testing.md
+++ b/docs/enhancements/041-stale-docs-and-testing.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Enhancement 041: Stale Documentation Prevention and Testing
+
+> **Status**: Implemented.
 
 **Status**: ✅ Fully Implemented
 

--- a/docs/enhancements/042-index-search-docs.md
+++ b/docs/enhancements/042-index-search-docs.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Enhancement 042: Indexing and Search Documentation
+
+> **Status**: Implemented.
 
 **Status**: ✅ Implemented
 

--- a/docs/enhancements/043-improved-quarkus-attachments.md
+++ b/docs/enhancements/043-improved-quarkus-attachments.md
@@ -1,4 +1,13 @@
+---
+status: implemented
+supersedes:
+  - 037-attachments.md
+---
+
 # Enhancement 043: Improved Attachments (Full Multimodal Support)
+
+> **Status**: Implemented. Supersedes the phased attachment approach in
+> [037](037-attachments.md).
 
 ## Summary
 

--- a/docs/enhancements/044-forked-attachments.md
+++ b/docs/enhancements/044-forked-attachments.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Enhancement 044: Forked Attachments (Referencing and Copying Attachments Across Entries)
+
+> **Status**: Implemented.
 
 ## Summary
 

--- a/docs/enhancements/045-admin-attachments.md
+++ b/docs/enhancements/045-admin-attachments.md
@@ -1,4 +1,10 @@
-# 045: Admin API for Attachments
+---
+status: implemented
+---
+
+# Enhancement 045: Admin API for Attachments
+
+> **Status**: Implemented.
 
 ## Status
 Proposed

--- a/docs/enhancements/046-simpler-forking.md
+++ b/docs/enhancements/046-simpler-forking.md
@@ -1,4 +1,13 @@
+---
+status: implemented
+supersedes:
+  - 001-conversation-forking-design.md
+---
+
 # Enhancement 046: Simpler Forking — Auto-Create Fork on First Entry
+
+> **Status**: Implemented. Simplifies the fork creation flow from
+> [001](001-conversation-forking-design.md).
 
 ## Summary
 

--- a/docs/enhancements/047-image-generation.md
+++ b/docs/enhancements/047-image-generation.md
@@ -1,4 +1,10 @@
-# 047: Image Generation Support
+---
+status: implemented
+---
+
+# Enhancement 047: Image Generation Support
+
+> **Status**: Implemented.
 
 ## Status
 Implemented

--- a/docs/enhancements/048-chat-app-checkpoint-alignment.md
+++ b/docs/enhancements/048-chat-app-checkpoint-alignment.md
@@ -1,4 +1,13 @@
-# 048: Align Chat Apps with Doc-Checkpoint Conventions
+---
+status: implemented
+supersedes:
+  - 023-chat-app-implementation.md
+---
+
+# Enhancement 048: Align Chat Apps with Doc-Checkpoint Conventions
+
+> **Status**: Implemented. Realigns class names and REST paths from
+> [023](023-chat-app-implementation.md).
 
 ## Status
 Implemented

--- a/docs/enhancements/049-response-resumer-api-simplification.md
+++ b/docs/enhancements/049-response-resumer-api-simplification.md
@@ -1,4 +1,15 @@
+---
+status: implemented
+supersedes:
+  - 004-response-cancel.md
+  - 010-drop-resumePosition.md
+---
+
 # Simplify ResponseResumerService gRPC API
+
+> **Status**: Implemented. Supersedes the response cancel design in
+> [004](004-response-cancel.md) and the resume simplification in
+> [010](010-drop-resumePosition.md).
 
 ## Motivation
 

--- a/docs/enhancements/050-s3-proxy-download.md
+++ b/docs/enhancements/050-s3-proxy-download.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Enhancement 050: S3 Proxy Download Mode
+
+> **Status**: Implemented.
 
 ## Summary
 

--- a/docs/enhancements/051-datastore-config-isolation.md
+++ b/docs/enhancements/051-datastore-config-isolation.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Enhancement 051: Datastore Configuration Isolation
+
+> **Status**: Implemented.
 
 ## Summary
 

--- a/docs/enhancements/052-update-conversation-title.md
+++ b/docs/enhancements/052-update-conversation-title.md
@@ -1,4 +1,10 @@
+---
+status: implemented
+---
+
 # Enhancement 052: Update Conversation Title
+
+> **Status**: Implemented.
 
 ## Summary
 


### PR DESCRIPTION
## Summary

Adds structured YAML front matter and inline status banners to all 51 enhancement documents, making it easy to see each proposal's lifecycle state and how proposals relate to each other.

## Changes

- Add YAML front matter with `status` field (implemented, partial, proposed, etc.) to all enhancement docs
- Add `supersedes` and `superseded-by` cross-references between related proposals
- Add inline status banners summarizing current state and linking to related enhancements