### PR TITLE
feat: consolidate Redis config under memory-service namespace

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,6 @@
 * Brand the project and move it to an org/foundation.
 * Add support for python langchain /w user docs similar to the quarkus/spring support.
 * move the ChatEvent json serializer to quarkus
-* fix QUARKUS_REDIS_HEALTH_ENABLED
 * make the infinispan cache name configurable (see [054-infinispan-cache-name-config.md](docs/enhancements/054-infinispan-cache-name-config.md))
 * make all common memory-service config options prefixed with "memory-service."
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -79,7 +79,7 @@ services:
       QUARKUS_OIDC_TOKEN_ISSUER: http://localhost:8081/realms/memory-service
       KEYCLOAK_CLIENT_SECRET: change-me
       MEMORY_SERVICE_CACHE_TYPE: redis
-      QUARKUS_REDIS_HOSTS: redis://redis:6379
+      MEMORY_SERVICE_REDIS_HOSTS: redis://redis:6379
 
       # To allow admin access to the memory service
       MEMORY_SERVICE_ROLES_ADMIN_OIDC_ROLE: admin

--- a/deploy/kustomize/components/cache/redis/kustomization.yaml
+++ b/deploy/kustomize/components/cache/redis/kustomization.yaml
@@ -10,4 +10,4 @@ configMapGenerator:
     behavior: merge
     literals:
       - MEMORY_SERVICE_CACHE_TYPE=redis
-      - QUARKUS_REDIS_HOSTS=redis://redis:6379
+      - MEMORY_SERVICE_REDIS_HOSTS=redis://redis:6379

--- a/docs/enhancements/054-infinispan-cache-name-config.md
+++ b/docs/enhancements/054-infinispan-cache-name-config.md
@@ -1,4 +1,10 @@
+---
+status: proposed
+---
+
 # Enhancement 054: Configurable Infinispan Cache Names
+
+> **Status**: Proposed.
 
 ## Summary
 

--- a/docs/enhancements/055-attachment-cache-headers.md
+++ b/docs/enhancements/055-attachment-cache-headers.md
@@ -1,4 +1,10 @@
+---
+status: proposed
+---
+
 # Enhancement 055: Attachment Download Cache Headers
+
+> **Status**: Proposed.
 
 ## Summary
 

--- a/memory-service/pom.xml
+++ b/memory-service/pom.xml
@@ -155,6 +155,12 @@
       <artifactId>quarkus-smallrye-context-propagation</artifactId>
     </dependency>
 
+    <!-- Health checks -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+    </dependency>
+
     <!-- OpenAPI/Swagger -->
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/memory-service/src/main/java/io/github/chirino/memory/cache/RedisHealthCheck.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/cache/RedisHealthCheck.java
@@ -1,0 +1,65 @@
+package io.github.chirino.memory.cache;
+
+import io.quarkus.redis.client.RedisClientName;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.vertx.mutiny.redis.client.Response;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.time.Duration;
+import java.util.Optional;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Readiness;
+
+@Readiness
+@ApplicationScoped
+public class RedisHealthCheck implements HealthCheck {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    @ConfigProperty(name = "memory-service.cache.type", defaultValue = "none")
+    String cacheType;
+
+    @Any @Inject Instance<ReactiveRedisDataSource> redisSources;
+
+    @ConfigProperty(name = "memory-service.cache.redis.client")
+    Optional<String> clientName;
+
+    @Override
+    public HealthCheckResponse call() {
+        if (!"redis".equalsIgnoreCase(cacheType)) {
+            return HealthCheckResponse.up("Redis");
+        }
+
+        try {
+            Instance<ReactiveRedisDataSource> selected =
+                    clientName
+                            .filter(name -> !name.isBlank())
+                            .map(name -> redisSources.select(RedisClientName.Literal.of(name)))
+                            .orElse(redisSources);
+
+            if (selected.isUnsatisfied()) {
+                return HealthCheckResponse.named("Redis")
+                        .down()
+                        .withData("reason", "No Redis client available")
+                        .build();
+            }
+
+            ReactiveRedisDataSource ds = selected.get();
+            Response response = ds.execute("PING").await().atMost(TIMEOUT);
+
+            return HealthCheckResponse.named("Redis")
+                    .up()
+                    .withData("response", response.toString())
+                    .build();
+        } catch (Exception e) {
+            return HealthCheckResponse.named("Redis")
+                    .down()
+                    .withData("error", e.getMessage())
+                    .build();
+        }
+    }
+}

--- a/memory-service/src/main/resources/application.properties
+++ b/memory-service/src/main/resources/application.properties
@@ -139,10 +139,12 @@ memory-service.tasks.stale-claim-timeout=PT5M
 memory-service.eviction.batch-size=1000
 memory-service.eviction.batch-delay-ms=100
 
-# Satisfy Redis extension validation in prod when Redis is not deployed
-# (overridden by QUARKUS_REDIS_HOSTS env var when Redis kustomize component is used)
-%prod.quarkus.redis.hosts=redis://localhost:6379
-%prod.quarkus.redis.health.enabled=false
+# Redis configuration: users set MEMORY_SERVICE_REDIS_HOSTS instead of QUARKUS_REDIS_HOSTS
+# Only wired in prod so dev/test Redis dev services still auto-start
+memory-service.redis.hosts=redis://localhost:6379
+%prod.quarkus.redis.hosts=${memory-service.redis.hosts}
+# Always disabled; replaced by custom RedisHealthCheck that is conditional on cache type
+quarkus.redis.health.enabled=false
 
 %test.quarkus.datasource.db-kind=postgresql
 %test.quarkus.redis.devservices.enabled=true

--- a/memory-service/src/test/java/io/github/chirino/memory/cache/RedisHealthCheckTest.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/cache/RedisHealthCheckTest.java
@@ -1,0 +1,69 @@
+package io.github.chirino.memory.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.github.chirino.memory.config.TestInstance;
+import io.quarkus.redis.datasource.ReactiveRedisDataSource;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.redis.client.Response;
+import java.util.Optional;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.junit.jupiter.api.Test;
+
+class RedisHealthCheckTest {
+
+    @Test
+    void returnsUpWhenCacheTypeIsNone() {
+        RedisHealthCheck check = createCheck("none", null);
+        HealthCheckResponse response = check.call();
+        assertEquals(HealthCheckResponse.Status.UP, response.getStatus());
+    }
+
+    @Test
+    void returnsUpWhenCacheTypeIsInfinispan() {
+        RedisHealthCheck check = createCheck("infinispan", null);
+        HealthCheckResponse response = check.call();
+        assertEquals(HealthCheckResponse.Status.UP, response.getStatus());
+    }
+
+    @Test
+    void returnsDownWhenRedisClientUnavailable() {
+        RedisHealthCheck check = createCheck("redis", null);
+        check.redisSources = TestInstance.unsatisfied();
+        HealthCheckResponse response = check.call();
+        assertEquals(HealthCheckResponse.Status.DOWN, response.getStatus());
+    }
+
+    @Test
+    void returnsUpWhenRedisIsHealthy() {
+        ReactiveRedisDataSource mockDs = mock(ReactiveRedisDataSource.class);
+        Response mockResponse = mock(Response.class);
+        when(mockResponse.toString()).thenReturn("PONG");
+        when(mockDs.execute("PING")).thenReturn(Uni.createFrom().item(mockResponse));
+
+        RedisHealthCheck check = createCheck("redis", mockDs);
+        HealthCheckResponse response = check.call();
+        assertEquals(HealthCheckResponse.Status.UP, response.getStatus());
+    }
+
+    @Test
+    void returnsDownWhenRedisPingFails() {
+        ReactiveRedisDataSource mockDs = mock(ReactiveRedisDataSource.class);
+        when(mockDs.execute("PING"))
+                .thenReturn(Uni.createFrom().failure(new RuntimeException("Connection refused")));
+
+        RedisHealthCheck check = createCheck("redis", mockDs);
+        HealthCheckResponse response = check.call();
+        assertEquals(HealthCheckResponse.Status.DOWN, response.getStatus());
+    }
+
+    private RedisHealthCheck createCheck(String cacheType, ReactiveRedisDataSource ds) {
+        RedisHealthCheck check = new RedisHealthCheck();
+        check.cacheType = cacheType;
+        check.clientName = Optional.empty();
+        check.redisSources = ds != null ? TestInstance.of(ds) : TestInstance.unsatisfied();
+        return check;
+    }
+}

--- a/memory-service/src/test/java/io/github/chirino/memory/config/TestInstance.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/config/TestInstance.java
@@ -7,43 +7,54 @@ import java.util.Iterator;
 import java.util.List;
 
 /** Minimal {@link Instance} wrapper for unit tests that returns a fixed value from {@link #get()}. */
-class TestInstance<T> implements Instance<T> {
+public class TestInstance<T> implements Instance<T> {
 
     private final T value;
+    private final boolean unsatisfied;
 
-    private TestInstance(T value) {
+    private TestInstance(T value, boolean unsatisfied) {
         this.value = value;
+        this.unsatisfied = unsatisfied;
     }
 
-    static <T> Instance<T> of(T value) {
-        return new TestInstance<>(value);
+    public static <T> Instance<T> of(T value) {
+        return new TestInstance<>(value, false);
+    }
+
+    public static <T> Instance<T> unsatisfied() {
+        return new TestInstance<>(null, true);
     }
 
     @Override
     public T get() {
+        if (unsatisfied) {
+            throw new IllegalStateException("Unsatisfied instance");
+        }
         return value;
     }
 
-    // -- remaining Instance methods are unused in tests --
+    // -- remaining Instance methods delegate back to this instance --
 
     @Override
     public Instance<T> select(Annotation... qualifiers) {
-        throw new UnsupportedOperationException();
+        return this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
-        throw new UnsupportedOperationException();
+        return (Instance<U>) this;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
-        throw new UnsupportedOperationException();
+        return (Instance<U>) this;
     }
 
     @Override
     public boolean isUnsatisfied() {
-        return false;
+        return unsatisfied;
     }
 
     @Override
@@ -53,7 +64,7 @@ class TestInstance<T> implements Instance<T> {
 
     @Override
     public boolean isResolvable() {
-        return true;
+        return !unsatisfied;
     }
 
     @Override
@@ -71,6 +82,9 @@ class TestInstance<T> implements Instance<T> {
 
     @Override
     public Iterator<T> iterator() {
+        if (unsatisfied) {
+            return List.<T>of().iterator();
+        }
         return List.of(value).iterator();
     }
 }

--- a/site/src/pages/docs/configuration.mdx
+++ b/site/src/pages/docs/configuration.mdx
@@ -72,6 +72,7 @@ Memory Service uses a unified cache configuration for all cache-dependent featur
 | Property | Values | Default | Description |
 |----------|--------|---------|-------------|
 | <Cfg p="memory-service.cache.type" /> | `none`, `redis`, `infinispan` | `none` | Cache backend for distributed caching |
+| <Cfg p="memory-service.redis.hosts" /> | Redis URL | `redis://localhost:6379` | Redis connection URL |
 | <Cfg p="memory-service.cache.redis.client" /> | client name | default | Optional: specify a named Redis client |
 | <Cfg p="memory-service.cache.infinispan.startup-timeout" /> | duration | `PT30S` | Startup timeout for Infinispan connection |
 
@@ -106,7 +107,7 @@ The Response Resumer enables clients to reconnect to in-progress streaming respo
 memory-service.cache.type=redis
 
 # Redis connection
-quarkus.redis.hosts=redis://localhost:6379
+memory-service.redis.hosts=redis://localhost:6379
 
 # Optional: specify a named Redis client
 memory-service.cache.redis.client=my-redis-client
@@ -544,7 +545,7 @@ services:
 
       # Cache with Redis (response resumer and memory entries cache automatically enabled)
       MEMORY_SERVICE_CACHE_TYPE: redis
-      QUARKUS_REDIS_HOSTS: redis://redis:6379
+      MEMORY_SERVICE_REDIS_HOSTS: redis://redis:6379
       # Optional: memory entries cache TTL (default: 10 minutes)
       # MEMORY_SERVICE_CACHE_EPOCH_TTL: PT10M
 

--- a/site/src/pages/docs/spring/docker-compose.mdx
+++ b/site/src/pages/docs/spring/docker-compose.mdx
@@ -94,7 +94,7 @@ services:
       QUARKUS_OIDC_TOKEN_ISSUER: http://localhost:8081/realms/memory-service
       KEYCLOAK_CLIENT_SECRET: change-me
       MEMORY_SERVICE_CACHE_TYPE: redis
-      QUARKUS_REDIS_HOSTS: redis://redis:6379
+      MEMORY_SERVICE_REDIS_HOSTS: redis://redis:6379
     depends_on:
       postgres:
         condition: service_healthy

--- a/spring/examples/chat-spring/compose.yaml
+++ b/spring/examples/chat-spring/compose.yaml
@@ -116,7 +116,7 @@ services:
       QUARKUS_OIDC_TOKEN_ISSUER: http://localhost:8081/realms/memory-service
       KEYCLOAK_CLIENT_SECRET: change-me
       MEMORY_SERVICE_CACHE_TYPE: redis
-      QUARKUS_REDIS_HOSTS: redis://redis:6379
+      MEMORY_SERVICE_REDIS_HOSTS: redis://redis:6379
 
       # To allow admin access to the memory service
       MEMORY_SERVICE_ROLES_ADMIN_OIDC_ROLE: admin


### PR DESCRIPTION
## Summary

Consolidate Redis configuration under the `memory-service.*` namespace so all user-facing config uses `MEMORY_SERVICE_*` environment variables. Adds a custom `@Readiness` health check that auto-activates based on `memory-service.cache.type`, replacing the built-in Quarkus Redis health check.

## Changes

- Add `memory-service.redis.hosts` property wired to `quarkus.redis.hosts` in prod profile (dev services still auto-start in dev/test)
- Add custom `RedisHealthCheck` that returns UP when cache type isn't redis, pings Redis when it is
- Disable built-in Quarkus Redis health check globally (replaced by custom check)
- Add `quarkus-smallrye-health` dependency
- Replace `QUARKUS_REDIS_HOSTS` with `MEMORY_SERVICE_REDIS_HOSTS` in all compose.yaml files, kustomize config, and documentation
- Add `RedisHealthCheckTest` unit tests (5 tests covering all branches)
- Update `TestInstance` test helper: make public, add `unsatisfied()` factory, delegate `select()` calls
- Remove `fix QUARKUS_REDIS_HEALTH_ENABLED` item from TODO.md
- Mark enhancement 053 as implemented

Implements [enhancement 053](docs/enhancements/053-redis-config-consolidation.md).