### PR TITLE
docs: simplify CodeFromFile usage in conversation history page

### DIFF
--- a/site/.astro/types.d.ts
+++ b/site/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/site/src/pages/docs/quarkus/conversation-history.mdx
+++ b/site/src/pages/docs/quarkus/conversation-history.mdx
@@ -103,9 +103,7 @@ Then create a REST resource that proxies requests to Memory Service:
 
 <CodeFromFile
   file="quarkus/examples/doc-checkpoints/03-with-history/src/main/java/org/acme/ConversationsResource.java"
-  lang="java"
-  after={38}
->package org.acme</CodeFromFile>
+  lang="java"/>
 
 The `MemoryServiceProxy` is helper class that makes it easier to implement a JAXRS proxy to the memory service apis.  It handles:
 - Authentication with the memory service


### PR DESCRIPTION
## Summary

Simplify the `CodeFromFile` component usage in the conversation history docs page by removing unnecessary `after` and content filter props. Also cleans up a stale astro type reference.

## Changes

- Remove `after` and content filter props from `CodeFromFile` in `conversation-history.mdx`
- Remove stale `content.d.ts` reference from `site/.astro/types.d.ts`