### PR TITLE
feat(cache): make Infinispan cache names configurable

### DIFF
--- a/memory-service/src/test/java/io/github/chirino/memory/PostgresqlInfinispanS3TestProfile.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/PostgresqlInfinispanS3TestProfile.java
@@ -12,11 +12,17 @@ public class PostgresqlInfinispanS3TestProfile implements QuarkusTestProfile {
                 Map.entry("memory-service.vector.type", "pgvector"),
                 Map.entry("memory-service.cache.type", "infinispan"),
                 Map.entry(
-                        "quarkus.infinispan-client.cache.response-recordings.configuration",
+                        "memory-service.cache.infinispan.memory-entries-cache-name",
+                        "test-memory-entries"),
+                Map.entry(
+                        "memory-service.cache.infinispan.response-recordings-cache-name",
+                        "test-response-recordings"),
+                Map.entry(
+                        "quarkus.infinispan-client.cache.test-response-recordings.configuration",
                         "<distributed-cache><encoding"
                             + " media-type=\"application/x-protostream\"/></distributed-cache>"),
                 Map.entry(
-                        "quarkus.infinispan-client.cache.memory-entries.configuration",
+                        "quarkus.infinispan-client.cache.test-memory-entries.configuration",
                         "<distributed-cache><encoding"
                                 + " media-type=\"text/plain\"/></distributed-cache>"),
                 Map.entry("quarkus.datasource.devservices.enabled", "true"),

--- a/memory-service/src/test/java/io/github/chirino/memory/PostgresqlInfinispanTestProfile.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/PostgresqlInfinispanTestProfile.java
@@ -12,11 +12,17 @@ public class PostgresqlInfinispanTestProfile implements QuarkusTestProfile {
                 Map.entry("memory-service.vector.type", "pgvector"),
                 Map.entry("memory-service.cache.type", "infinispan"),
                 Map.entry(
-                        "quarkus.infinispan-client.cache.response-recordings.configuration",
+                        "memory-service.cache.infinispan.memory-entries-cache-name",
+                        "test-memory-entries"),
+                Map.entry(
+                        "memory-service.cache.infinispan.response-recordings-cache-name",
+                        "test-response-recordings"),
+                Map.entry(
+                        "quarkus.infinispan-client.cache.test-response-recordings.configuration",
                         "<distributed-cache><encoding"
                             + " media-type=\"application/x-protostream\"/></distributed-cache>"),
                 Map.entry(
-                        "quarkus.infinispan-client.cache.memory-entries.configuration",
+                        "quarkus.infinispan-client.cache.test-memory-entries.configuration",
                         "<distributed-cache><encoding"
                                 + " media-type=\"text/plain\"/></distributed-cache>"),
                 Map.entry("quarkus.datasource.devservices.enabled", "true"),

--- a/memory-service/src/test/java/io/github/chirino/memory/cache/InfinispanMemoryEntriesCacheConfigTest.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/cache/InfinispanMemoryEntriesCacheConfigTest.java
@@ -1,0 +1,52 @@
+package io.github.chirino.memory.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.chirino.memory.config.TestInstance;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.Optional;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.junit.jupiter.api.Test;
+
+class InfinispanMemoryEntriesCacheConfigTest {
+
+    @Test
+    void defaultCacheNameIsUsed() {
+        InfinispanMemoryEntriesCache cache =
+                new InfinispanMemoryEntriesCache(
+                        Optional.of("infinispan"),
+                        Duration.ofSeconds(30),
+                        "memory-entries",
+                        Duration.ofMinutes(10),
+                        TestInstance.<RemoteCacheManager>unsatisfied(),
+                        new ObjectMapper(),
+                        new SimpleMeterRegistry());
+
+        assertEquals("memory-entries", cache.getCacheName());
+    }
+
+    @Test
+    void customCacheNameIsUsed() {
+        InfinispanMemoryEntriesCache cache =
+                new InfinispanMemoryEntriesCache(
+                        Optional.of("infinispan"),
+                        Duration.ofSeconds(30),
+                        "prod-memory-entries",
+                        Duration.ofMinutes(10),
+                        TestInstance.<RemoteCacheManager>unsatisfied(),
+                        new ObjectMapper(),
+                        new SimpleMeterRegistry());
+
+        assertEquals("prod-memory-entries", cache.getCacheName());
+    }
+
+    @Test
+    void cacheConfigXmlContainsCacheName() {
+        String name = "my-custom-cache";
+        String xml = InfinispanMemoryEntriesCache.buildCacheConfigXml(name);
+        assertTrue(xml.contains("name=\"my-custom-cache\""));
+    }
+}

--- a/memory-service/src/test/java/io/github/chirino/memory/resumer/InfinispanResponseResumerLocatorStoreConfigTest.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/resumer/InfinispanResponseResumerLocatorStoreConfigTest.java
@@ -1,0 +1,44 @@
+package io.github.chirino.memory.resumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.github.chirino.memory.config.TestInstance;
+import java.time.Duration;
+import java.util.Optional;
+import org.infinispan.client.hotrod.RemoteCacheManager;
+import org.junit.jupiter.api.Test;
+
+class InfinispanResponseResumerLocatorStoreConfigTest {
+
+    @Test
+    void defaultCacheNameIsUsed() {
+        InfinispanResponseResumerLocatorStore store =
+                new InfinispanResponseResumerLocatorStore(
+                        Optional.of("infinispan"),
+                        Duration.ofSeconds(30),
+                        "response-recordings",
+                        TestInstance.<RemoteCacheManager>unsatisfied());
+
+        assertEquals("response-recordings", store.getCacheName());
+    }
+
+    @Test
+    void customCacheNameIsUsed() {
+        InfinispanResponseResumerLocatorStore store =
+                new InfinispanResponseResumerLocatorStore(
+                        Optional.of("infinispan"),
+                        Duration.ofSeconds(30),
+                        "staging-response-recordings",
+                        TestInstance.<RemoteCacheManager>unsatisfied());
+
+        assertEquals("staging-response-recordings", store.getCacheName());
+    }
+
+    @Test
+    void cacheConfigXmlContainsCacheName() {
+        String name = "my-custom-cache";
+        String xml = InfinispanResponseResumerLocatorStore.buildCacheConfigXml(name);
+        assertTrue(xml.contains("name=\"my-custom-cache\""));
+    }
+}

--- a/site/src/pages/docs/configuration.mdx
+++ b/site/src/pages/docs/configuration.mdx
@@ -75,6 +75,8 @@ Memory Service uses a unified cache configuration for all cache-dependent featur
 | <Cfg p="memory-service.redis.hosts" /> | Redis URL | `redis://localhost:6379` | Redis connection URL |
 | <Cfg p="memory-service.cache.redis.client" /> | client name | default | Optional: specify a named Redis client |
 | <Cfg p="memory-service.cache.infinispan.startup-timeout" /> | duration | `PT30S` | Startup timeout for Infinispan connection |
+| <Cfg p="memory-service.cache.infinispan.memory-entries-cache-name" /> | string | `memory-entries` | Infinispan cache name for memory entries |
+| <Cfg p="memory-service.cache.infinispan.response-recordings-cache-name" /> | string | `response-recordings` | Infinispan cache name for response recordings |
 
 ### Memory Entries Cache
 
@@ -127,6 +129,10 @@ quarkus.infinispan-client.password=password
 
 # Optional: startup timeout for Infinispan connection
 memory-service.cache.infinispan.startup-timeout=PT30S
+
+# Optional: custom cache names (useful for multi-tenant or multi-environment clusters)
+# memory-service.cache.infinispan.memory-entries-cache-name=my-memory-entries
+# memory-service.cache.infinispan.response-recordings-cache-name=my-response-recordings
 
 # Optional: disable response resumer even with cache enabled
 memory-service.response-resumer.enabled=false`} />


### PR DESCRIPTION
## Summary

Make Infinispan cache names configurable via `memory-service.cache.infinispan.*` properties, allowing multiple environments or tenants sharing an Infinispan cluster to use distinct cache names.

## Changes

- Replace hardcoded `CACHE_NAME`/`CACHE_CONFIG` constants in `InfinispanMemoryEntriesCache` and `InfinispanResponseResumerLocatorStore` with `@ConfigProperty`-injected fields
- Add `memory-service.cache.infinispan.memory-entries-cache-name` (default: `memory-entries`)
- Add `memory-service.cache.infinispan.response-recordings-cache-name` (default: `response-recordings`)
- Add unit tests for config wiring and XML generation
- Update integration test profiles to exercise custom cache names end-to-end
- Document new properties in `configuration.mdx`