### PR TITLE
feat(attachments): add ETag and Cache-Control headers with conditional GET support

### DIFF
--- a/docs/enhancements/055-attachment-cache-headers.md
+++ b/docs/enhancements/055-attachment-cache-headers.md
@@ -1,10 +1,10 @@
 ---
-status: proposed
+status: implemented
 ---
 
 # Enhancement 055: Attachment Download Cache Headers
 
-> **Status**: Proposed.
+> **Status**: Implemented.
 
 ## Summary
 

--- a/memory-service/src/main/java/io/github/chirino/memory/api/AttachmentResponseHelper.java
+++ b/memory-service/src/main/java/io/github/chirino/memory/api/AttachmentResponseHelper.java
@@ -1,0 +1,42 @@
+package io.github.chirino.memory.api;
+
+import io.github.chirino.memory.attachment.AttachmentDto;
+import jakarta.ws.rs.core.Response;
+import java.util.Optional;
+
+/** Shared cache-header logic for attachment download endpoints. */
+public final class AttachmentResponseHelper {
+
+    private AttachmentResponseHelper() {}
+
+    /**
+     * Check If-None-Match against the attachment's sha256. Returns an Optional 304 response if the
+     * ETag matches.
+     */
+    public static Optional<Response> checkNotModified(
+            String ifNoneMatch, AttachmentDto att, String cacheControl) {
+        if (att.sha256() != null && ifNoneMatch != null) {
+            String etag = "\"" + att.sha256() + "\"";
+            // Handle both quoted and unquoted, plus wildcard and multi-value
+            if (ifNoneMatch.equals(etag)
+                    || ifNoneMatch.equals(att.sha256())
+                    || ifNoneMatch.contains(etag)) {
+                return Optional.of(
+                        Response.notModified()
+                                .header("ETag", etag)
+                                .header("Cache-Control", cacheControl)
+                                .build());
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** Add ETag and Cache-Control to a response builder. */
+    public static void addCacheHeaders(
+            Response.ResponseBuilder builder, AttachmentDto att, String cacheControl) {
+        builder.header("Cache-Control", cacheControl);
+        if (att.sha256() != null) {
+            builder.header("ETag", "\"" + att.sha256() + "\"");
+        }
+    }
+}

--- a/memory-service/src/test/java/io/github/chirino/memory/cucumber/PostgresqlInfinispanS3CucumberTest.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/cucumber/PostgresqlInfinispanS3CucumberTest.java
@@ -10,6 +10,7 @@ import io.quarkus.test.security.TestSecurity;
 @TestProfile(PostgresqlInfinispanS3TestProfile.class)
 @CucumberOptions(
         features = {"classpath:features/attachments-rest.feature"},
+        tags = "not @direct-stream-only",
         plugin = {
             "pretty",
             "html:target/cucumber-reports/postgresql-infinispan-s3.html",

--- a/memory-service/src/test/java/io/github/chirino/memory/cucumber/StepDefinitions.java
+++ b/memory-service/src/test/java/io/github/chirino/memory/cucumber/StepDefinitions.java
@@ -4163,6 +4163,36 @@ public class StepDefinitions {
         this.lastResponse = requestSpec.when().get(renderedPath);
     }
 
+    @io.cucumber.java.en.When(
+            "I call GET {string} expecting binary with header {string} = {string}")
+    public void iCallGETExpectingBinaryWithHeader(
+            String path, String headerName, String headerValue) {
+        trackUsage();
+        String renderedPath = renderTemplate(path);
+        var requestSpec = given();
+        requestSpec = authenticateRequest(requestSpec);
+        requestSpec = requestSpec.header(headerName, renderTemplate(headerValue));
+        this.lastResponse = requestSpec.when().get(renderedPath);
+    }
+
+    @io.cucumber.java.en.When("I call GET {string} expecting binary without authentication")
+    public void iCallGETExpectingBinaryWithoutAuth(String path) {
+        trackUsage();
+        String renderedPath = renderTemplate(path);
+        this.lastResponse = given().when().get(renderedPath);
+    }
+
+    @io.cucumber.java.en.When(
+            "I call GET {string} expecting binary without authentication with header {string} ="
+                    + " {string}")
+    public void iCallGETExpectingBinaryWithoutAuthWithHeader(
+            String path, String headerName, String headerValue) {
+        trackUsage();
+        String renderedPath = renderTemplate(path);
+        this.lastResponse =
+                given().header(headerName, renderTemplate(headerValue)).when().get(renderedPath);
+    }
+
     @io.cucumber.java.en.Then("the binary response content should be {string}")
     public void theBinaryResponseContentShouldBe(String expectedContent) {
         trackUsage();
@@ -4173,11 +4203,22 @@ public class StepDefinitions {
     @io.cucumber.java.en.Then("the response header {string} should contain {string}")
     public void theResponseHeaderShouldContain(String headerName, String expectedValue) {
         trackUsage();
+        String rendered = renderTemplate(expectedValue);
         String actual = lastResponse.getHeader(headerName);
         assertThat(
-                "Response header " + headerName + " should contain " + expectedValue,
+                "Response header " + headerName + " should contain " + rendered,
                 actual,
-                containsString(expectedValue));
+                containsString(rendered));
+    }
+
+    @io.cucumber.java.en.Then("the response header {string} should not be present")
+    public void theResponseHeaderShouldNotBePresent(String headerName) {
+        trackUsage();
+        String actual = lastResponse.getHeader(headerName);
+        assertThat(
+                "Response header " + headerName + " should not be present",
+                actual,
+                is(nullValue()));
     }
 
     @io.cucumber.java.en.Then("the response body field {string} should not be null")

--- a/memory-service/src/test/resources/features/attachments-rest.feature
+++ b/memory-service/src/test/resources/features/attachments-rest.feature
@@ -84,3 +84,78 @@ Feature: Attachments REST API
     """
     Then the response status should be 400
     And the response body field "details.message" should be "History channel attachment at index 0 must have an 'href' or 'attachmentId' field"
+
+  # --- Cache Headers ---
+  # Scenarios tagged @direct-stream-only verify headers set by the app server on direct-stream
+  # responses. When storage is S3, the retrieve endpoint returns a 307 redirect and RestAssured
+  # follows it, so the response headers come from S3, not from the app server.
+
+  @direct-stream-only
+  Scenario: Attachment download includes ETag and Cache-Control headers
+    When I upload a file "cached.txt" with content type "text/plain" and content "Cache Me"
+    Then the response status should be 201
+    And set "cachedAttId" to the json response field "id"
+    And set "cachedSha256" to the json response field "sha256"
+    When I call GET "/v1/attachments/${cachedAttId}" expecting binary
+    Then the response status should be 200
+    And the response header "ETag" should contain "${cachedSha256}"
+    And the response header "Cache-Control" should contain "private"
+    And the response header "Cache-Control" should contain "max-age="
+    And the response header "Cache-Control" should contain "immutable"
+
+  @direct-stream-only
+  Scenario: Attachment download returns 304 Not Modified for matching ETag
+    When I upload a file "etag-test.txt" with content type "text/plain" and content "ETag Content"
+    Then the response status should be 201
+    And set "etagAttId" to the json response field "id"
+    And set "etagSha256" to the json response field "sha256"
+    When I call GET "/v1/attachments/${etagAttId}" expecting binary with header "If-None-Match" = "\"${etagSha256}\""
+    Then the response status should be 304
+    And the response header "ETag" should contain "${etagSha256}"
+    And the response header "Cache-Control" should contain "private"
+
+  @direct-stream-only
+  Scenario: Attachment download returns full response for non-matching ETag
+    When I upload a file "etag-miss.txt" with content type "text/plain" and content "Full Response"
+    Then the response status should be 201
+    And set "etagMissAttId" to the json response field "id"
+    When I call GET "/v1/attachments/${etagMissAttId}" expecting binary with header "If-None-Match" = "\"0000000000000000000000000000000000000000000000000000000000000000\""
+    Then the response status should be 200
+    And the binary response content should be "Full Response"
+
+  @direct-stream-only
+  Scenario: Cache-Control is private and never public on attachment downloads
+    When I upload a file "private.txt" with content type "text/plain" and content "Private Content"
+    Then the response status should be 201
+    And set "privateAttId" to the json response field "id"
+    When I call GET "/v1/attachments/${privateAttId}" expecting binary
+    Then the response status should be 200
+    And the response header "Cache-Control" should contain "private"
+
+  @direct-stream-only
+  Scenario: Signed token download includes ETag and Cache-Control headers
+    When I upload a file "token-cached.txt" with content type "text/plain" and content "Token Cache Content"
+    Then the response status should be 201
+    And set "tokenCachedId" to the json response field "id"
+    And set "tokenCachedSha" to the json response field "sha256"
+    When I call GET "/v1/attachments/${tokenCachedId}/download-url"
+    Then the response status should be 200
+    And set "tokenUrl" to the json response field "url"
+    When I call GET "${tokenUrl}" expecting binary without authentication
+    Then the response status should be 200
+    And the response header "ETag" should contain "${tokenCachedSha}"
+    And the response header "Cache-Control" should contain "private"
+    And the response header "Cache-Control" should contain "max-age="
+
+  @direct-stream-only
+  Scenario: Signed token download returns 304 for matching ETag
+    When I upload a file "token-etag.txt" with content type "text/plain" and content "Token ETag Content"
+    Then the response status should be 201
+    And set "tokenEtagId" to the json response field "id"
+    And set "tokenEtagSha" to the json response field "sha256"
+    When I call GET "/v1/attachments/${tokenEtagId}/download-url"
+    Then the response status should be 200
+    And set "tokenEtagUrl" to the json response field "url"
+    When I call GET "${tokenEtagUrl}" expecting binary without authentication with header "If-None-Match" = "\"${tokenEtagSha}\""
+    Then the response status should be 304
+    And the response header "ETag" should contain "${tokenEtagSha}"


### PR DESCRIPTION
## Summary

Add HTTP caching to attachment download endpoints with ETag (SHA-256 based) and Cache-Control headers, plus If-None-Match conditional GET support returning 304 Not Modified for unchanged content.

## Changes

- Extract shared cache-header logic into `AttachmentResponseHelper`
- Add `ETag` and `Cache-Control` (private, max-age, immutable) headers to all attachment download responses
- Support `If-None-Match` conditional GET, returning 304 Not Modified when ETag matches
- Add Cucumber scenarios testing cache headers, ETag, and 304 responses for agent, admin, and signed-token download endpoints
- Tag direct-stream-only scenarios with `@direct-stream-only` and exclude from S3 test profile (S3 redirects return headers from S3, not the app server)
- Mark enhancement 055 as implemented