### PR TITLE
docs: add instruction to update enhancement docs during implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,4 +57,6 @@ When you discover something meaningful about this project during your work—arc
 
 **Pre-release**: Changes do not need backward compatibility.  Don't deprecate, just delete.  The datastores are reset frequently.
 
+**Enhancement docs**: When implementing work from `docs/enhancements/`, update the corresponding enhancement doc as you complete each phase. If the implementation diverges from the original design, update the doc to reflect what was actually implemented.
+
 ## Learned Facts


### PR DESCRIPTION
## Summary

Adds a guideline to CLAUDE.md instructing AI assistants to update enhancement docs as implementation progresses, ensuring documentation stays in sync with what was actually built.

## Changes

- Added "Enhancement docs" note to CLAUDE.md reminding to update `docs/enhancements/` files when implementation diverges from the original design