### PR TITLE
ci: skip pr checks for docs-only and config-only changes

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,10 +5,20 @@ on:
     branches: [main]
     paths-ignore:
       - 'site/**'
+      - 'docs/**'
+      - '*.md'
+      - '.skills/**'
+      - '.github/**'
+      - '.devconainer/**'
   push:
     branches: [main]
     paths-ignore:
       - 'site/**'
+      - 'docs/**'
+      - '*.md'
+      - '.skills/**'
+      - '.github/**'
+      - '.devconainer/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Adds path-ignore rules to the PR check workflow so that CI is not triggered for changes limited to documentation, markdown files, skills, GitHub config, or devcontainer config.

## Changes
- Add `docs/**`, `*.md`, `.skills/**`, `.github/**`, and `.devcontainer/**` to `paths-ignore` for both `pull_request` and `push` triggers in `pr-check.yml`