### PR TITLE
perf: hash partition entries and entry_embeddings by conversation_group_id

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,13 +10,13 @@
 * encrypted file store (see [063-encrypted-file-store.md](docs/enhancements/063-encrypted-file-store.md))
 * move the `data.encryption.*` config properties under `memory-service.*`, default the file encryption to match data encryption. Make sure the encryption header is not being added when no encryption is enabled.
 
+# Performance Related
+
+* Think about supporting operating against postgresql read replicas.
+
 # Hardening Work
 
 * Handle syncing Memory entries with more than 1000 messages by splitting into multiple entries (client-side change).
-
-# Performance Related
-
-* Look into partitioning the messages table to improve pref. (see [059-entries-table-partitioning.md](docs/enhancements/059-entries-table-partitioning.md))
 
 # Need Dev Feedback for:
 

--- a/docs/enhancements/059-entries-table-partitioning.md
+++ b/docs/enhancements/059-entries-table-partitioning.md
@@ -1,10 +1,10 @@
 ---
-status: proposed
+status: complete
 ---
 
 # Enhancement 059: Entries and Entry Embeddings Table Partitioning
 
-> **Status**: Proposed.
+> **Status**: Complete.
 
 ## Summary
 

--- a/memory-service/src/main/resources/db/pgvector-schema.sql
+++ b/memory-service/src/main/resources/db/pgvector-schema.sql
@@ -9,14 +9,33 @@ CREATE EXTENSION IF NOT EXISTS vector;
 -- Embeddings are associated with individual entries.
 -- The embedding column is unparameterized to support any dimension.
 -- The model column records which provider/model produced each vector.
+-- Note: no FK to entries — PostgreSQL does not support FKs referencing partitioned tables.
 CREATE TABLE IF NOT EXISTS entry_embeddings (
-    entry_id              UUID PRIMARY KEY REFERENCES entries (id) ON DELETE CASCADE,
+    entry_id              UUID NOT NULL,
     conversation_id       UUID NOT NULL REFERENCES conversations (id) ON DELETE CASCADE,
     conversation_group_id UUID NOT NULL REFERENCES conversation_groups (id) ON DELETE CASCADE,
     embedding             vector NOT NULL,
     model                 VARCHAR(128) NOT NULL,
-    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (entry_id, conversation_group_id)
+) PARTITION BY HASH (conversation_group_id);
+
+CREATE TABLE IF NOT EXISTS entry_embeddings_p0  PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 0);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p1  PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 1);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p2  PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 2);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p3  PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 3);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p4  PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 4);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p5  PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 5);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p6  PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 6);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p7  PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 7);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p8  PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 8);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p9  PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 9);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p10 PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 10);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p11 PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 11);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p12 PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 12);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p13 PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 13);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p14 PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 14);
+CREATE TABLE IF NOT EXISTS entry_embeddings_p15 PARTITION OF entry_embeddings FOR VALUES WITH (MODULUS 16, REMAINDER 15);
 
 -- Index for filtering by conversation group (for access control via JOIN)
 CREATE INDEX IF NOT EXISTS idx_entry_embeddings_group


### PR DESCRIPTION
## Summary

Implements [enhancement 059](docs/enhancements/059-entries-table-partitioning.md). Hash-partitions the `entries` and `entry_embeddings` tables into 16 buckets keyed on `conversation_group_id`, enabling partition pruning on the dominant query patterns (filter by `conversation_id` or `conversation_group_id`).

## Changes

- **`entries`**: composite `PRIMARY KEY (id, conversation_group_id)`, `PARTITION BY HASH (conversation_group_id)`, `indexed_content_tsv` generated column inlined into `CREATE TABLE`, 16 partitions `entries_p0..p15` created
- **`entry_embeddings`**: composite `PRIMARY KEY (entry_id, conversation_group_id)`, `PARTITION BY HASH (conversation_group_id)`, FK to `entries` dropped (PostgreSQL ≥12 does not support FKs referencing partitioned tables), 16 partitions `entry_embeddings_p0..p15` created
- **`attachments.entry_id`**: FK to `entries` dropped for the same reason; cascade is already handled by the eviction task
- Partitions are declared as individual `CREATE TABLE … PARTITION OF` statements (rather than a `DO $$ … $$` loop) to avoid Liquibase's default semicolon-splitting breaking the PL/pgSQL block
- Enhancement doc status updated to `complete`; TODO.md entry removed
