### PR TITLE
chore: resolve merge conflict in TODO.md, add hierarchical memory item

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,7 @@
 * bug: delete a fork, restore: it does not show up restored.
 * encrypted file store (see [063-encrypted-file-store.md](docs/enhancements/063-encrypted-file-store.md))
 * ~~move the `data.encryption.*` config properties under `memory-service.*`, default the file encryption to match data encryption. Make sure the encryption header is not being added when no encryption is enabled.~~ (done, see [064-unified-encryption-config.md](docs/enhancements/064-unified-encryption-config.md))
+* ponder how to implement hierarchical memory and what the access control rules should be for it.
 
 # Performance Related
 

--- a/site/src/pages/docs/configuration.mdx
+++ b/site/src/pages/docs/configuration.mdx
@@ -182,12 +182,12 @@ Memory Service supports transparent encryption of all stored data — conversati
 
 | Property | Values | Default | Description |
 |----------|--------|---------|-------------|
-| `memory-service.encryption.providers` | comma-separated provider IDs | `plain` | Ordered list of providers; first active provider encrypts new data |
-| `memory-service.encryption.provider.<id>.type` | `plain`, `dek`, `vault` | _(required)_ | Provider type for the named ID |
-| `memory-service.encryption.provider.<id>.enabled` | `true`, `false` | `true` | Whether this provider is active |
-| `memory-service.encryption.dek.key` | base64 string | _(required for dek)_ | Primary AES-256-GCM key (base64-encoded 32 bytes) |
-| `memory-service.encryption.dek.decryption-keys` | comma-separated base64 strings | _(none)_ | Additional old keys for decryption during key rotation |
-| `memory-service.encryption.vault.transit-key` | string | _(required for vault)_ | Vault transit key name |
+| <Cfg p="memory-service.encryption.providers" /> | comma-separated provider IDs | `plain` | Ordered list of providers; first active provider encrypts new data |
+| <Cfg p="memory-service.encryption.provider.<id>.type" /> | `plain`, `dek`, `vault` | _(required)_ | Provider type for the named ID |
+| <Cfg p="memory-service.encryption.provider.<id>.enabled" /> | `true`, `false` | `true` | Whether this provider is active |
+| <Cfg p="memory-service.encryption.dek.key" /> | base64 string | _(required for dek)_ | Primary AES-256-GCM key (base64-encoded 32 bytes) |
+| <Cfg p="memory-service.encryption.dek.decryption-keys" /> | comma-separated base64 strings | _(none)_ | Additional old keys for decryption during key rotation |
+| <Cfg p="memory-service.encryption.vault.transit-key" /> | string | _(required for vault)_ | Vault transit key name |
 
 ### AES-256-GCM (DEK provider)
 


### PR DESCRIPTION
## Summary

Resolves a merge conflict in TODO.md that arose between upstream changes and stashed local changes, and updates the configuration documentation to use the `<Cfg>` component.

## Changes

- Resolved merge conflict in TODO.md by combining both sides: kept the strikethrough for the completed encryption config task and added the new hierarchical memory item from stashed changes
- Preserved the new "Performance Related" section with the PostgreSQL read replica item
- Updated `site/src/pages/docs/configuration.mdx` to use `<Cfg>` component for encryption config property names in the table