### PR TITLE
chore: symlink ~/.m2 in devcontainer and update Astro type references

### DIFF
--- a/.devcontainer/post-start.sh
+++ b/.devcontainer/post-start.sh
@@ -24,6 +24,11 @@ if [ -d "$USER_HOME/.ssh" ]; then
   chmod 644 "$USER_HOME/.ssh/config" 2>/dev/null || true
 fi
 
+# Link to the ~/.m2 dir
+if [ -d "/home/vscode/.m2" ]; then
+  ln -s /home/vscode/.m2 "$USER_HOME/.m2"
+fi
+
 # Generate bash completions for tools installed by devcontainer features
 COMP_DIR="/etc/bash_completion.d"
 kubectl completion bash | sudo tee "$COMP_DIR/kubectl" > /dev/null 2>/dev/null || true

--- a/site/.astro/types.d.ts
+++ b/site/.astro/types.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="astro/client" />
+/// <reference path="content.d.ts" />


### PR DESCRIPTION
## Summary
Small maintenance changes to the devcontainer setup and Astro type declarations.

## Changes
- Link `/home/vscode/.m2` to `$USER_HOME/.m2` in `post-start.sh` so the Maven local cache is accessible in the devcontainer
- Add `content.d.ts` reference to `site/.astro/types.d.ts` (auto-generated Astro type update)