### PR TITLE
ci(actions): scope cache keys per matrix job

### DIFF
--- a/.github/cache/go-test-go.sum
+++ b/.github/cache/go-test-go.sum
@@ -1,0 +1,1 @@
+go-cache-scope=test-go

--- a/.github/cache/go-test-site.sum
+++ b/.github/cache/go-test-site.sum
@@ -1,0 +1,1 @@
+go-cache-scope=test-site

--- a/.github/cache/go-verify-generated.sum
+++ b/.github/cache/go-verify-generated.sum
@@ -1,0 +1,1 @@
+go-cache-scope=verify-generated

--- a/.github/cache/maven-test-java.key
+++ b/.github/cache/maven-test-java.key
@@ -1,0 +1,1 @@
+maven-cache-scope=test-java

--- a/.github/cache/maven-test-site.key
+++ b/.github/cache/maven-test-site.key
@@ -1,0 +1,1 @@
+maven-cache-scope=test-site

--- a/.github/cache/maven-verify-generated.key
+++ b/.github/cache/maven-verify-generated.key
@@ -1,0 +1,1 @@
+maven-cache-scope=verify-generated

--- a/.github/cache/npm-test-java.key
+++ b/.github/cache/npm-test-java.key
@@ -1,0 +1,1 @@
+npm-cache-scope=test-java

--- a/.github/cache/npm-test-site.key
+++ b/.github/cache/npm-test-site.key
@@ -1,0 +1,1 @@
+npm-cache-scope=test-site

--- a/.github/cache/npm-verify-generated.key
+++ b/.github/cache/npm-verify-generated.key
@@ -1,0 +1,1 @@
+npm-cache-scope=verify-generated

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+          cache-dependency-path: |
+            go.sum
+            .github/cache/go-${{ matrix.job }}.sum
 
       - name: Set up Java
         if: contains('verify-generated test-java test-site', matrix.job)
@@ -49,6 +52,9 @@ jobs:
           distribution: temurin
           java-version: '21'
           cache: maven
+          cache-dependency-path: |
+            **/pom.xml
+            .github/cache/maven-${{ matrix.job }}.key
 
       - name: Set up Node
         if: contains('verify-generated test-java test-site', matrix.job)
@@ -59,6 +65,7 @@ jobs:
           cache-dependency-path: |
             frontends/chat-frontend/package-lock.json
             site/package-lock.json
+            .github/cache/npm-${{ matrix.job }}.key
 
       - name: Generate Source Code
         if: contains('verify-generated', matrix.job)
@@ -120,8 +127,8 @@ jobs:
           file: Dockerfile
           push: false
           tags: ghcr.io/chirino/memory-service:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=image-memory-service
+          cache-to: type=gha,mode=max,scope=image-memory-service
 
       - name: Build Docker image (chat-quarkus)
         if: matrix.job == 'image-chat-quarkus'
@@ -131,6 +138,5 @@ jobs:
           file: quarkus/examples/chat-quarkus/Dockerfile
           push: false
           tags: ghcr.io/chirino/memory-service-chat-quarkus:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
+          cache-from: type=gha,scope=image-chat-quarkus
+          cache-to: type=gha,mode=max,scope=image-chat-quarkus


### PR DESCRIPTION
Scope setup-go, setup-java, and setup-node caches by matrix job.

Scope docker/build-push-action GHA cache per image target.

Signed-off-by: Hiram Chirino <hiram@hiramchirino.com>
