### PR TITLE
docs(site): format mdx documentation

### DIFF
--- a/site/.astro/types.d.ts
+++ b/site/.astro/types.d.ts
@@ -1,2 +1,1 @@
 /// <reference types="astro/client" />
-/// <reference path="content.d.ts" />

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -4119,7 +4119,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4140,7 +4139,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4161,7 +4159,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4182,7 +4179,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4203,7 +4199,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4224,7 +4219,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4245,7 +4239,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4266,7 +4259,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4287,7 +4279,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4308,7 +4299,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4329,7 +4319,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/site/package.json
+++ b/site/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "prettier": "prettier -w \"src/**/*.{ts,tsx,js,astro,md}\"",
+    "prettier": "prettier -w \"src/**/*.{ts,tsx,js,astro,md,mdx}\"",
     "preview": "astro preview",
     "astro": "astro"
   },

--- a/site/src/pages/docs/concepts/admin-apis.mdx
+++ b/site/src/pages/docs/concepts/admin-apis.mdx
@@ -12,23 +12,23 @@ The regular Agent APIs are scoped to the authenticated caller: a user can only s
 
 Key differences:
 
-| Aspect | Regular APIs | Admin APIs |
-|--------|-------------|------------|
-| Scope | Caller's own resources | All users |
-| Deleted resources | Hidden | Visible (with `includeDeleted`) |
-| Role required | Any authenticated user | `admin` or `auditor` |
-| Audit logging | No | Yes — every call is logged |
-| Justification | Not applicable | Optional (or required, if configured) |
+| Aspect            | Regular APIs           | Admin APIs                            |
+| ----------------- | ---------------------- | ------------------------------------- |
+| Scope             | Caller's own resources | All users                             |
+| Deleted resources | Hidden                 | Visible (with `includeDeleted`)       |
+| Role required     | Any authenticated user | `admin` or `auditor`                  |
+| Audit logging     | No                     | Yes — every call is logged            |
+| Justification     | Not applicable         | Optional (or required, if configured) |
 
 ## Roles
 
 There are three admin roles, each granting a different level of privilege:
 
-| Role | Access | Description |
-|------|--------|-------------|
-| `admin` | Read + Write | Full administrative access across all users. Implies `auditor` and `indexer`. |
-| `auditor` | Read-only | View any user's conversations and search system-wide. Cannot modify data. |
-| `indexer` | Index only | Index any conversation's transcript for search. Cannot view or modify other data. |
+| Role      | Access       | Description                                                                       |
+| --------- | ------------ | --------------------------------------------------------------------------------- |
+| `admin`   | Read + Write | Full administrative access across all users. Implies `auditor` and `indexer`.     |
+| `auditor` | Read-only    | View any user's conversations and search system-wide. Cannot modify data.         |
+| `indexer` | Index only   | Index any conversation's transcript for search. Cannot view or modify other data. |
 
 Roles can be assigned via OIDC token roles, explicit user lists, or API key client IDs. See the [Admin Access Configuration](/docs/configuration/#admin-access-configuration) section of the configuration guide for details.
 
@@ -59,6 +59,7 @@ By default, `justification` is optional. Set `memory-service.admin.require-justi
 ### Audit Log Format
 
 Each audit log entry includes:
+
 - The admin's user ID (or API key client ID)
 - The HTTP method and path
 - The justification (if provided)
@@ -134,12 +135,12 @@ curl -X POST "http://localhost:8080/v1/admin/evict" \
 
 The `retentionPeriod` is an ISO 8601 duration. Common values:
 
-| Value | Meaning |
-|-------|---------|
-| `P90D` | 90 days |
-| `P1Y` | 1 year |
-| `PT24H` | 24 hours |
-| `P0D` | Immediately (all soft-deleted) |
+| Value   | Meaning                        |
+| ------- | ------------------------------ |
+| `P90D`  | 90 days                        |
+| `P1Y`   | 1 year                         |
+| `PT24H` | 24 hours                       |
+| `P0D`   | Immediately (all soft-deleted) |
 
 ### Streaming Eviction (SSE)
 

--- a/site/src/pages/docs/concepts/attachments.mdx
+++ b/site/src/pages/docs/concepts/attachments.mdx
@@ -87,18 +87,19 @@ Response:
 }
 ```
 
-| Field | Description |
-|-------|-------------|
-| `id` | Unique attachment identifier (use as `attachmentId` when appending entries) |
-| `href` | Server path to download the attachment |
-| `contentType` | Detected MIME type |
-| `filename` | Original filename |
-| `size` | File size in bytes |
-| `sha256` | SHA-256 hash of the file contents |
-| `expiresAt` | When the unlinked attachment will be cleaned up |
-| `status` | Processing status (`ready` when upload is complete) |
+| Field         | Description                                                                 |
+| ------------- | --------------------------------------------------------------------------- |
+| `id`          | Unique attachment identifier (use as `attachmentId` when appending entries) |
+| `href`        | Server path to download the attachment                                      |
+| `contentType` | Detected MIME type                                                          |
+| `filename`    | Original filename                                                           |
+| `size`        | File size in bytes                                                          |
+| `sha256`      | SHA-256 hash of the file contents                                           |
+| `expiresAt`   | When the unlinked attachment will be cleaned up                             |
+| `status`      | Processing status (`ready` when upload is complete)                         |
 
 **Notes:**
+
 - `expiresIn` is an ISO 8601 duration (default `PT1H`, max `PT24H`)
 - Maximum file size is [10 MB by default (configurable)](/docs/configuration/#attachment-storage)
 - The uploaded attachment is unlinked until referenced in an entry
@@ -129,6 +130,7 @@ curl -X POST "http://localhost:8080/v1/conversations/{conversationId}/entries" \
 ```
 
 On persistence, the server:
+
 1. Links the attachment to the entry (clears the TTL)
 2. Rewrites `attachmentId` to an `href` in the stored content
 3. Auto-populates `contentType`, `name`, `size`, and `sha256` from the attachment record
@@ -153,27 +155,27 @@ The stored entry content will look like:
 
 ### Attachment Properties
 
-| Property | Required | Description |
-|----------|----------|-------------|
-| `attachmentId` | One of `href` or `attachmentId` | ID of a server-stored attachment |
-| `href` | One of `href` or `attachmentId` | URL to an external resource |
-| `contentType` | Required with `href` | MIME type (auto-populated for `attachmentId`) |
-| `name` | No | Display name |
-| `description` | No | Alt text or description |
-| `size` | No | File size in bytes (auto-populated for `attachmentId`) |
-| `sha256` | No | SHA-256 hash (auto-populated for `attachmentId`) |
+| Property       | Required                        | Description                                            |
+| -------------- | ------------------------------- | ------------------------------------------------------ |
+| `attachmentId` | One of `href` or `attachmentId` | ID of a server-stored attachment                       |
+| `href`         | One of `href` or `attachmentId` | URL to an external resource                            |
+| `contentType`  | Required with `href`            | MIME type (auto-populated for `attachmentId`)          |
+| `name`         | No                              | Display name                                           |
+| `description`  | No                              | Alt text or description                                |
+| `size`         | No                              | File size in bytes (auto-populated for `attachmentId`) |
+| `sha256`       | No                              | SHA-256 hash (auto-populated for `attachmentId`)       |
 
 ## Multi-Modal Content
 
 The Memory Service stores and serves all file types. How attachments are rendered is determined by the consuming application (agent framework or frontend). Common patterns:
 
-| Content Type | Typical Use |
-|-------------|-------------|
-| `image/*` | Inline image display, vision model input |
-| `audio/*` | Audio player, speech-to-text input |
-| `video/*` | Video player, video analysis |
-| `application/pdf` | PDF viewer, document analysis |
-| Other | Generic file download |
+| Content Type      | Typical Use                              |
+| ----------------- | ---------------------------------------- |
+| `image/*`         | Inline image display, vision model input |
+| `audio/*`         | Audio player, speech-to-text input       |
+| `video/*`         | Video player, video analysis             |
+| `application/pdf` | PDF viewer, document analysis            |
+| Other             | Generic file download                    |
 
 Agent frameworks like LangChain4j and Spring AI map these content types to their native multi-modal content objects when building LLM requests.
 
@@ -190,6 +192,7 @@ curl "http://localhost:8080/v1/attachments/{id}" \
 ```
 
 Access control:
+
 - **Unlinked attachments** — Only the original uploader can download
 - **Linked attachments** — Anyone with read access to the conversation can download
 
@@ -214,6 +217,7 @@ Response:
 The returned URL requires no authentication — it can be used directly in HTML tags or opened in a browser. The URL expires after 5 minutes by default.
 
 How signed URLs are generated depends on the storage backend:
+
 - **S3 storage** — Returns an S3 pre-signed URL pointing directly to the object
 - **Database storage** — Returns an HMAC-signed token URL served by the Memory Service
 
@@ -244,15 +248,14 @@ Include the parent's `attachmentId` in the forked entry just like any other atta
     {
       "role": "USER",
       "text": "Let me try a different question about that image",
-      "attachments": [
-        { "attachmentId": "{attachmentIdFromParent}" }
-      ]
+      "attachments": [{ "attachmentId": "{attachmentIdFromParent}" }]
     }
   ]
 }
 ```
 
 **Key details:**
+
 - The source attachment must belong to the same conversation group (fork tree). Cross-group references are rejected.
 - Multiple attachment records can share the same blob via reference counting. The stored file is only deleted when the last record referencing it is removed.
 - You can mix references to parent attachments with fresh uploads in the same entry.
@@ -262,6 +265,7 @@ Include the parent's `attachmentId` in the forked entry just like any other atta
 ### Unlinked Attachments (Temporary)
 
 Uploaded files that are never referenced in an entry expire automatically:
+
 - Default TTL: 1 hour (`PT1H`)
 - Maximum TTL: 24 hours (`PT24H`)
 - A cleanup job runs periodically (every 5 minutes by default) to delete expired files

--- a/site/src/pages/docs/concepts/index.mdx
+++ b/site/src/pages/docs/concepts/index.mdx
@@ -9,25 +9,33 @@ These pages explain the foundational ideas and APIs behind Memory Service. Under
 ## Concepts
 
 ### [Conversations](/docs/concepts/conversations/)
+
 The fundamental unit of organization. A conversation is a container for a sequence of entries, identified by a unique ID and owned by a user for access control.
 
 ### [Entries](/docs/concepts/entries/)
+
 The individual units of communication within a conversation. Entries are organized into channels (`history` and `memory`) and stored with full metadata.
 
 ### [Attachments](/docs/concepts/attachments/)
+
 Include binary files — images, audio, video, documents — in conversation entries with server-managed upload, access control, signed download URLs, and automatic lifecycle management.
 
 ### [Forking](/docs/concepts/forking/)
+
 Create a new conversation branch from any point in an existing conversation, preserving the original while exploring alternative paths.
 
 ### [Indexing & Search](/docs/concepts/indexing-and-search/)
+
 Find relevant messages across conversations using full-text keyword matching or semantic similarity search.
 
 ### [Response Recording and Resumption](/docs/concepts/response-resumption/)
+
 Reconnect after a disconnect and pick up a streaming response where it left off, with automatic token buffering and multi-instance redirect.
 
 ### [Sharing & Access Control](/docs/concepts/sharing/)
+
 Share conversations among multiple users with hierarchical permission levels — read, write, manager, and owner.
 
 ### [Admin APIs](/docs/concepts/admin-apis/)
+
 Administrative APIs for cross-user access, audit logging, and data lifecycle management. Covers admin and auditor roles, justification fields, and eviction of soft-deleted data.

--- a/site/src/pages/docs/concepts/sharing.mdx
+++ b/site/src/pages/docs/concepts/sharing.mdx
@@ -9,6 +9,7 @@ The Memory Service provides a comprehensive access control system that allows co
 ## Overview
 
 Every conversation has:
+
 - **One owner** - The user who created the conversation or received ownership through a transfer
 - **Zero or more members** - Users who have been granted access with specific permission levels
 - **Access levels** - Hierarchical permissions that control what each member can do
@@ -17,14 +18,15 @@ Every conversation has:
 
 The Memory Service uses four hierarchical access levels:
 
-| Access Level | Can Read | Can Write | Can Share | Can Transfer Ownership | Notes |
-|-------------|----------|-----------|-----------|------------------------|-------|
-| **owner** | ✅ | ✅ | ✅ | ✅ | Only one owner per conversation |
-| **manager** | ✅ | ✅ | ✅ (limited) | ❌ | Can add/remove writer/reader members |
-| **writer** | ✅ | ✅ | ❌ | ❌ | Can participate in conversations |
-| **reader** | ✅ | ❌ | ❌ | ❌ | Read-only access |
+| Access Level | Can Read | Can Write | Can Share    | Can Transfer Ownership | Notes                                |
+| ------------ | -------- | --------- | ------------ | ---------------------- | ------------------------------------ |
+| **owner**    | ✅       | ✅        | ✅           | ✅                     | Only one owner per conversation      |
+| **manager**  | ✅       | ✅        | ✅ (limited) | ❌                     | Can add/remove writer/reader members |
+| **writer**   | ✅       | ✅        | ❌           | ❌                     | Can participate in conversations     |
+| **reader**   | ✅       | ❌        | ❌           | ❌                     | Read-only access                     |
 
 **Sharing constraints:**
+
 - Owners can assign any level except owner (manager, writer, reader)
 - Managers can only assign writer or reader levels
 - Writers and readers cannot share conversations
@@ -33,6 +35,7 @@ The Memory Service uses four hierarchical access levels:
 ### Owner
 
 The owner has full control over the conversation:
+
 - ✅ Read conversation entries
 - ✅ Write new entries (participate in the conversation)
 - ✅ Share with others at any level (manager, writer, reader)
@@ -40,6 +43,7 @@ The owner has full control over the conversation:
 - ✅ Delete the conversation
 
 **Key constraints:**
+
 - Only **one owner** per conversation
 - Ownership can only be transferred through a two-step process
 - When ownership is transferred, the previous owner automatically becomes a manager
@@ -47,6 +51,7 @@ The owner has full control over the conversation:
 ### Manager
 
 Managers can collaborate and invite others, but cannot transfer ownership:
+
 - ✅ Read conversation entries
 - ✅ Write new entries
 - ✅ Share with others (limited to writer and reader levels only)
@@ -55,6 +60,7 @@ Managers can collaborate and invite others, but cannot transfer ownership:
 - ❌ Cannot delete the conversation
 
 **Use cases:**
+
 - Team leads who can invite team members
 - Administrators who manage access but don't own the conversation
 - Trusted collaborators who can bring others into the conversation
@@ -62,6 +68,7 @@ Managers can collaborate and invite others, but cannot transfer ownership:
 ### Writer
 
 Writers can actively participate but cannot share:
+
 - ✅ Read conversation entries
 - ✅ Write new entries
 - ❌ Cannot share with others
@@ -69,6 +76,7 @@ Writers can actively participate but cannot share:
 - ❌ Cannot transfer ownership
 
 **Use cases:**
+
 - Regular participants in a conversation
 - Contributors who should not have administrative privileges
 - Team members who collaborate but don't manage access
@@ -76,12 +84,14 @@ Writers can actively participate but cannot share:
 ### Reader
 
 Readers have read-only access:
+
 - ✅ Read conversation entries
 - ❌ Cannot write entries
 - ❌ Cannot share with others
 - ❌ Cannot modify anything
 
 **Use cases:**
+
 - Observers who need visibility but shouldn't participate
 - Auditors or reviewers
 - Users being onboarded before being given write access
@@ -91,10 +101,12 @@ Readers have read-only access:
 ### Adding Members
 
 Owners and managers can add new members to a conversation by specifying:
+
 - **User ID** - The identifier of the user to add
 - **Access Level** - The permission level to grant
 
 **Constraints:**
+
 - Owners can assign: manager, writer, or reader
 - Managers can assign: writer or reader only
 - Writers and readers cannot add members
@@ -102,6 +114,7 @@ Owners and managers can add new members to a conversation by specifying:
 ### Updating Access Levels
 
 Members' access levels can be promoted or demoted:
+
 - Owners can change any member to manager, writer, or reader
 - Managers can change writer/reader members between those two levels
 - Cannot promote someone to owner (use ownership transfer instead)
@@ -109,6 +122,7 @@ Members' access levels can be promoted or demoted:
 ### Removing Members
 
 Owners and managers can remove members from conversations:
+
 - Once removed, the user loses all access
 - Removed users can be re-added later if needed
 - Cannot remove the owner (must transfer ownership first)
@@ -120,6 +134,7 @@ Ownership transfer is a **two-step process** to ensure both parties consent:
 ### Step 1: Initiate Transfer
 
 The current owner creates a transfer request:
+
 - Specifies the conversation and the new owner (recipient)
 - Recipient must be an existing member of the conversation
 - Only one pending transfer can exist per conversation
@@ -128,6 +143,7 @@ The current owner creates a transfer request:
 ### Step 2: Accept or Decline
 
 The recipient can then:
+
 - **Accept** the transfer:
   - Becomes the new owner immediately
   - Previous owner automatically becomes a manager
@@ -167,6 +183,7 @@ Either party can cancel the transfer before acceptance.
 ### Permission Enforcement
 
 All API operations enforce access levels:
+
 - Read operations require at least reader access
 - Write operations require at least writer access
 - Sharing operations require manager or owner access
@@ -175,6 +192,7 @@ All API operations enforce access levels:
 ### Preventing Privilege Escalation
 
 The system prevents users from granting themselves higher privileges:
+
 - Managers cannot promote themselves to owner
 - Managers cannot grant manager level to anyone
 - Users cannot modify their own access level
@@ -183,6 +201,7 @@ The system prevents users from granting themselves higher privileges:
 ### Audit Trail
 
 The system maintains records of:
+
 - Who shared the conversation
 - What access level was granted
 - When ownership transfers occurred
@@ -231,6 +250,7 @@ For framework-specific implementations and code examples:
 - [Quarkus Implementation](/docs/quarkus/sharing/) - Complete guide with Quarkus code examples
 
 Both guides include:
+
 - REST endpoint implementations
 - Working curl examples with authentication
 - Multi-user testing scenarios
@@ -241,12 +261,14 @@ Both guides include:
 The Memory Service provides these sharing and ownership APIs:
 
 ### Membership APIs
+
 - `GET /v1/conversations/{id}/memberships` - List all members
 - `POST /v1/conversations/{id}/memberships` - Add a member
 - `PATCH /v1/conversations/{id}/memberships/{userId}` - Update access level
 - `DELETE /v1/conversations/{id}/memberships/{userId}` - Remove a member
 
 ### Ownership Transfer APIs
+
 - `GET /v1/ownership-transfers?role={role}` - List pending transfers
 - `POST /v1/ownership-transfers` - Initiate a transfer
 - `GET /v1/ownership-transfers/{id}` - Get transfer details

--- a/site/src/pages/docs/configuration.mdx
+++ b/site/src/pages/docs/configuration.mdx
@@ -4,9 +4,9 @@ title: Configuration
 description: Configure Memory Service databases, vector stores, and authentication using CLI flags or environment variables.
 ---
 
-import ConfigToggle from '../../components/ConfigToggle.astro';
-import Cfg from '../../components/Cfg.astro';
-import ConfigBlock from '../../components/ConfigBlock.astro';
+import ConfigToggle from "../../components/ConfigToggle.astro";
+import Cfg from "../../components/Cfg.astro";
+import ConfigBlock from "../../components/ConfigBlock.astro";
 
 Memory Service is configured through CLI flags or environment variables. Use the toggle below to switch between formats.
 
@@ -16,78 +16,81 @@ Memory Service is configured through CLI flags or environment variables. Use the
 
 ## Server Configuration
 
-| Flag | Values | Default | Description |
-|------|--------|---------|-------------|
-| <Cfg p="--tls-cert-file" e="MEMORY_SERVICE_TLS_CERT_FILE" /> | path | _(none)_ | TLS certificate file (self-signed if omitted) |
-| <Cfg p="--tls-key-file" e="MEMORY_SERVICE_TLS_KEY_FILE" /> | path | _(none)_ | TLS private key file (self-signed if omitted) |
-| <Cfg p="--advertised-address" e="MEMORY_SERVICE_ADVERTISED_ADDRESS" /> | `host:port` | auto-detected | Advertised address for client redirects |
-| <Cfg p="--read-header-timeout-seconds" e="MEMORY_SERVICE_READ_HEADER_TIMEOUT_SECONDS" /> | integer | `5` | HTTP read header timeout in seconds |
-| <Cfg p="--temp-dir" e="MEMORY_SERVICE_TEMP_DIR" /> | path | system temp dir | Directory for temporary files |
-| <Cfg p="--management-access-log" e="MEMORY_SERVICE_MANAGEMENT_ACCESS_LOG" /> | `true`, `false` | `false` | Enable HTTP access logging for `/health`, `/ready`, `/metrics` |
+| Flag                                                                                     | Values          | Default         | Description                                                    |
+| ---------------------------------------------------------------------------------------- | --------------- | --------------- | -------------------------------------------------------------- |
+| <Cfg p="--tls-cert-file" e="MEMORY_SERVICE_TLS_CERT_FILE" />                             | path            | _(none)_        | TLS certificate file (self-signed if omitted)                  |
+| <Cfg p="--tls-key-file" e="MEMORY_SERVICE_TLS_KEY_FILE" />                               | path            | _(none)_        | TLS private key file (self-signed if omitted)                  |
+| <Cfg p="--advertised-address" e="MEMORY_SERVICE_ADVERTISED_ADDRESS" />                   | `host:port`     | auto-detected   | Advertised address for client redirects                        |
+| <Cfg p="--read-header-timeout-seconds" e="MEMORY_SERVICE_READ_HEADER_TIMEOUT_SECONDS" /> | integer         | `5`             | HTTP read header timeout in seconds                            |
+| <Cfg p="--temp-dir" e="MEMORY_SERVICE_TEMP_DIR" />                                       | path            | system temp dir | Directory for temporary files                                  |
+| <Cfg p="--management-access-log" e="MEMORY_SERVICE_MANAGEMENT_ACCESS_LOG" />             | `true`, `false` | `false`         | Enable HTTP access logging for `/health`, `/ready`, `/metrics` |
 
 ### Network Listener
 
-| Flag | Values | Default | Description |
-|------|--------|---------|-------------|
-| <Cfg p="--port" e="MEMORY_SERVICE_PORT" /> | integer | `8080` | HTTP/gRPC server port |
-| <Cfg p="--plain-text" e="MEMORY_SERVICE_PLAIN_TEXT" /> | `true`, `false` | `true` | Enable plaintext HTTP/1.1 + h2c + gRPC |
-| <Cfg p="--tls" e="MEMORY_SERVICE_TLS" /> | `true`, `false` | `true` | Enable TLS HTTP/1.1 + HTTP/2 + gRPC |
+| Flag                                                   | Values          | Default | Description                            |
+| ------------------------------------------------------ | --------------- | ------- | -------------------------------------- |
+| <Cfg p="--port" e="MEMORY_SERVICE_PORT" />             | integer         | `8080`  | HTTP/gRPC server port                  |
+| <Cfg p="--plain-text" e="MEMORY_SERVICE_PLAIN_TEXT" /> | `true`, `false` | `true`  | Enable plaintext HTTP/1.1 + h2c + gRPC |
+| <Cfg p="--tls" e="MEMORY_SERVICE_TLS" />               | `true`, `false` | `true`  | Enable TLS HTTP/1.1 + HTTP/2 + gRPC    |
 
 ### Management Network Listener
 
 By default, `/health`, `/ready`, and `/metrics` are served on the main port alongside the API. Set `--management-port` to move them onto a dedicated port, keeping them out of the main API's auth middleware — and making Prometheus scrape configuration more straightforward.
 
-| Flag | Values | Default | Description |
-|------|--------|---------|-------------|
-| <Cfg p="--management-port" e="MEMORY_SERVICE_MANAGEMENT_PORT" /> | integer | _(unset)_ | Dedicated port for health and metrics. When unset, served on the main port. |
-| <Cfg p="--management-plain-text" e="MEMORY_SERVICE_MANAGEMENT_PLAIN_TEXT" /> | `true`, `false` | `true` | Enable plaintext HTTP for management server |
-| <Cfg p="--management-tls" e="MEMORY_SERVICE_MANAGEMENT_TLS" /> | `true`, `false` | `true` | Enable TLS for management server (uses same cert/key as main listener) |
+| Flag                                                                         | Values          | Default   | Description                                                                 |
+| ---------------------------------------------------------------------------- | --------------- | --------- | --------------------------------------------------------------------------- |
+| <Cfg p="--management-port" e="MEMORY_SERVICE_MANAGEMENT_PORT" />             | integer         | _(unset)_ | Dedicated port for health and metrics. When unset, served on the main port. |
+| <Cfg p="--management-plain-text" e="MEMORY_SERVICE_MANAGEMENT_PLAIN_TEXT" /> | `true`, `false` | `true`    | Enable plaintext HTTP for management server                                 |
+| <Cfg p="--management-tls" e="MEMORY_SERVICE_MANAGEMENT_TLS" />               | `true`, `false` | `true`    | Enable TLS for management server (uses same cert/key as main listener)      |
 
 ## DB Configuration
 
 Memory Service supports PostgreSQL and MongoDB as database backends. The database URL uses standard connection string formats (not JDBC).
 
-| Flag | Values | Default | Description |
-|------|--------|---------|-------------|
-| <Cfg p="--db-kind" e="MEMORY_SERVICE_DB_KIND" /> | `postgres`, `mongo` | `postgres` | Database backend |
-| <Cfg p="--db-url" e="MEMORY_SERVICE_DB_URL" /> | URL | _(required)_ | Database connection URL |
-| <Cfg p="--db-max-open-conns" e="MEMORY_SERVICE_DB_MAX_OPEN_CONNS" /> | integer | `25` | Maximum number of open database connections (see backend notes below) |
-| <Cfg p="--db-max-idle-conns" e="MEMORY_SERVICE_DB_MAX_IDLE_CONNS" /> | integer | `5` | Idle/minimum connections (see backend notes below) |
-| `MEMORY_SERVICE_DB_MIGRATE_AT_START` | `true`, `false` | `true` | Run database migrations at startup |
+| Flag                                                                 | Values              | Default      | Description                                                           |
+| -------------------------------------------------------------------- | ------------------- | ------------ | --------------------------------------------------------------------- |
+| <Cfg p="--db-kind" e="MEMORY_SERVICE_DB_KIND" />                     | `postgres`, `mongo` | `postgres`   | Database backend                                                      |
+| <Cfg p="--db-url" e="MEMORY_SERVICE_DB_URL" />                       | URL                 | _(required)_ | Database connection URL                                               |
+| <Cfg p="--db-max-open-conns" e="MEMORY_SERVICE_DB_MAX_OPEN_CONNS" /> | integer             | `25`         | Maximum number of open database connections (see backend notes below) |
+| <Cfg p="--db-max-idle-conns" e="MEMORY_SERVICE_DB_MAX_IDLE_CONNS" /> | integer             | `5`          | Idle/minimum connections (see backend notes below)                    |
+| `MEMORY_SERVICE_DB_MIGRATE_AT_START`                                 | `true`, `false`     | `true`       | Run database migrations at startup                                    |
 
 ### DB: PostgreSQL Configuration
 
 PostgreSQL is the recommended database backend for Memory Service.
 
 - <Cfg p="--db-max-open-conns" e="MEMORY_SERVICE_DB_MAX_OPEN_CONNS" /> sets the maximum number of open connections.
-- <Cfg p="--db-max-idle-conns" e="MEMORY_SERVICE_DB_MAX_IDLE_CONNS" /> sets the maximum number of idle connections kept in the pool.
+- <Cfg p="--db-max-idle-conns" e="MEMORY_SERVICE_DB_MAX_IDLE_CONNS" /> sets the maximum number of idle connections kept
+  in the pool.
 
 <ConfigBlock property={`# Select PostgreSQL as the datastore
 --db-kind=postgres
 
 # PostgreSQL connection (standard URL format)
+
 --db-url=postgresql://postgres:postgres@localhost:5432/memoryservice`} />
 
 ### DB: MongoDB Configuration
 
 - <Cfg p="--db-max-open-conns" e="MEMORY_SERVICE_DB_MAX_OPEN_CONNS" /> sets the maximum connection pool size.
-- <Cfg p="--db-max-idle-conns" e="MEMORY_SERVICE_DB_MAX_IDLE_CONNS" /> sets the **minimum** pool size — connections MongoDB keeps open proactively. This is _not_ an idle-connection cap.
+- <Cfg p="--db-max-idle-conns" e="MEMORY_SERVICE_DB_MAX_IDLE_CONNS" /> sets the **minimum** pool size — connections
+  MongoDB keeps open proactively. This is _not_ an idle-connection cap.
 
 <ConfigBlock property={`# Select MongoDB as the datastore
 --db-kind=mongo
 
 # MongoDB connection
---db-url=mongodb://localhost:27017/memoryservice`} />
 
+--db-url=mongodb://localhost:27017/memoryservice`} />
 
 ## Cache Configuration
 
 Memory Service uses a unified cache configuration for all cache-dependent features, including the response recording manager and memory entries cache. Configure the cache backend once, and all features will use it automatically.
 
-| Flag | Values | Default | Description |
-|------|--------|---------|-------------|
-| <Cfg p="--cache-kind" e="MEMORY_SERVICE_CACHE_KIND" /> | `none`, `redis`, `infinispan` | `none` | Cache backend for distributed caching |
-| `MEMORY_SERVICE_CACHE_EPOCH_TTL` | duration | `PT10M` | TTL for cached memory entries (sliding window) |
+| Flag                                                   | Values                        | Default | Description                                    |
+| ------------------------------------------------------ | ----------------------------- | ------- | ---------------------------------------------- |
+| <Cfg p="--cache-kind" e="MEMORY_SERVICE_CACHE_KIND" /> | `none`, `redis`, `infinispan` | `none`  | Cache backend for distributed caching          |
+| `MEMORY_SERVICE_CACHE_EPOCH_TTL`                       | duration                      | `PT10M` | TTL for cached memory entries (sliding window) |
 
 ### Memory Entries Cache
 
@@ -104,28 +107,30 @@ Features of the memory entries cache:
 
 The Response Resumer enables clients to reconnect to in-progress streaming responses after a network interruption. It automatically uses the configured cache backend — enabled when cache is `redis` or `infinispan`.
 
-| Env Var | Values | Default | Description |
-|---------|--------|---------|-------------|
+| Env Var                                               | Values   | Default | Description                   |
+| ----------------------------------------------------- | -------- | ------- | ----------------------------- |
 | `MEMORY_SERVICE_RESPONSE_RESUMER_TEMP_FILE_RETENTION` | duration | `PT30M` | How long to retain temp files |
 
 ### Cache: Redis Configuration
 
 Redis provides a fast, distributed cache with full support for the memory entries cache and response recording manager.
 
-| Flag | Values | Default | Description |
-|------|--------|---------|-------------|
-| <Cfg p="--redis-hosts" e="MEMORY_SERVICE_REDIS_HOSTS" /> | Redis URL | `redis://localhost:6379` | Redis connection URL |
-| `MEMORY_SERVICE_CACHE_REDIS_CLIENT` | client name | default | Optional: specify a named Redis client |
+| Flag                                                     | Values      | Default                  | Description                            |
+| -------------------------------------------------------- | ----------- | ------------------------ | -------------------------------------- |
+| <Cfg p="--redis-hosts" e="MEMORY_SERVICE_REDIS_HOSTS" /> | Redis URL   | `redis://localhost:6379` | Redis connection URL                   |
+| `MEMORY_SERVICE_CACHE_REDIS_CLIENT`                      | client name | default                  | Optional: specify a named Redis client |
 
 <ConfigBlock property={`# Enable Redis cache (response recording manager will automatically use it)
 --cache-kind=redis
 
 # Redis connection
+
 --redis-hosts=redis://localhost:6379`}
   env={`# Enable Redis cache (response recording manager will automatically use it)
 MEMORY_SERVICE_CACHE_KIND=redis
 
 # Redis connection
+
 MEMORY_SERVICE_REDIS_HOSTS=redis://localhost:6379`}
 />
 
@@ -133,19 +138,20 @@ MEMORY_SERVICE_REDIS_HOSTS=redis://localhost:6379`}
 
 Infinispan provides a distributed cache with configurable cache names for memory entries and response recordings.
 
-| Flag | Values | Default | Description |
-|------|--------|---------|-------------|
-| <Cfg p="--infinispan-host" e="MEMORY_SERVICE_INFINISPAN_HOST" /> | `host:port` | `localhost:11222` | Infinispan server host |
-| <Cfg p="--infinispan-username" e="MEMORY_SERVICE_INFINISPAN_USERNAME" /> | string | _(none)_ | Infinispan username |
-| <Cfg p="--infinispan-password" e="MEMORY_SERVICE_INFINISPAN_PASSWORD" /> | string | _(none)_ | Infinispan password |
-| `MEMORY_SERVICE_CACHE_INFINISPAN_STARTUP_TIMEOUT` | duration | `PT30S` | Startup timeout for Infinispan connection |
-| `MEMORY_SERVICE_CACHE_INFINISPAN_MEMORY_ENTRIES_CACHE_NAME` | string | `memory-entries` | Infinispan cache name for memory entries |
-| `MEMORY_SERVICE_CACHE_INFINISPAN_RESPONSE_RECORDINGS_CACHE_NAME` | string | `response-recordings` | Infinispan cache name for response recordings |
+| Flag                                                                     | Values      | Default               | Description                                   |
+| ------------------------------------------------------------------------ | ----------- | --------------------- | --------------------------------------------- |
+| <Cfg p="--infinispan-host" e="MEMORY_SERVICE_INFINISPAN_HOST" />         | `host:port` | `localhost:11222`     | Infinispan server host                        |
+| <Cfg p="--infinispan-username" e="MEMORY_SERVICE_INFINISPAN_USERNAME" /> | string      | _(none)_              | Infinispan username                           |
+| <Cfg p="--infinispan-password" e="MEMORY_SERVICE_INFINISPAN_PASSWORD" /> | string      | _(none)_              | Infinispan password                           |
+| `MEMORY_SERVICE_CACHE_INFINISPAN_STARTUP_TIMEOUT`                        | duration    | `PT30S`               | Startup timeout for Infinispan connection     |
+| `MEMORY_SERVICE_CACHE_INFINISPAN_MEMORY_ENTRIES_CACHE_NAME`              | string      | `memory-entries`      | Infinispan cache name for memory entries      |
+| `MEMORY_SERVICE_CACHE_INFINISPAN_RESPONSE_RECORDINGS_CACHE_NAME`         | string      | `response-recordings` | Infinispan cache name for response recordings |
 
 <ConfigBlock property={`# Enable Infinispan cache (response recording manager will automatically use it)
 --cache-kind=infinispan
 
 # Infinispan connection
+
 --infinispan-host=localhost:11222
 --infinispan-username=admin
 --infinispan-password=password`}
@@ -153,6 +159,7 @@ Infinispan provides a distributed cache with configurable cache names for memory
 MEMORY_SERVICE_CACHE_KIND=infinispan
 
 # Infinispan connection
+
 MEMORY_SERVICE_INFINISPAN_HOST=localhost:11222
 MEMORY_SERVICE_INFINISPAN_USERNAME=admin
 MEMORY_SERVICE_INFINISPAN_PASSWORD=password`}
@@ -162,21 +169,22 @@ MEMORY_SERVICE_INFINISPAN_PASSWORD=password`}
 
 Configure file attachment storage, size limits, and lifecycle.
 
-| Flag / Env Var | Values | Default | Description |
-|----------------|--------|---------|-------------|
-| <Cfg p="--attachments-kind" e="MEMORY_SERVICE_ATTACHMENTS_KIND" /> | `db`, `s3` | `db` | Storage backend for uploaded files |
-| `MEMORY_SERVICE_ATTACHMENTS_MAX_SIZE` | memory size | `10M` | Maximum file size per upload (e.g., `10M`, `512K`, `1G`) |
-| `MEMORY_SERVICE_ATTACHMENTS_DEFAULT_EXPIRES_IN` | duration | `PT1H` | Default TTL for unlinked attachments |
-| `MEMORY_SERVICE_ATTACHMENTS_MAX_EXPIRES_IN` | duration | `PT24H` | Maximum allowed TTL clients can request |
-| `MEMORY_SERVICE_ATTACHMENTS_CLEANUP_INTERVAL` | duration | `PT5M` | How often the cleanup job runs |
-| `MEMORY_SERVICE_ATTACHMENTS_DOWNLOAD_URL_EXPIRES_IN` | duration | `PT5M` | Signed download URL expiry |
-| — | — | — | Signed download URLs are enabled automatically when `--encryption-dek-key` is set; the signing key is derived from it via HKDF-SHA256. |
+| Flag / Env Var                                                     | Values      | Default | Description                                                                                                                            |
+| ------------------------------------------------------------------ | ----------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| <Cfg p="--attachments-kind" e="MEMORY_SERVICE_ATTACHMENTS_KIND" /> | `db`, `s3`  | `db`    | Storage backend for uploaded files                                                                                                     |
+| `MEMORY_SERVICE_ATTACHMENTS_MAX_SIZE`                              | memory size | `10M`   | Maximum file size per upload (e.g., `10M`, `512K`, `1G`)                                                                               |
+| `MEMORY_SERVICE_ATTACHMENTS_DEFAULT_EXPIRES_IN`                    | duration    | `PT1H`  | Default TTL for unlinked attachments                                                                                                   |
+| `MEMORY_SERVICE_ATTACHMENTS_MAX_EXPIRES_IN`                        | duration    | `PT24H` | Maximum allowed TTL clients can request                                                                                                |
+| `MEMORY_SERVICE_ATTACHMENTS_CLEANUP_INTERVAL`                      | duration    | `PT5M`  | How often the cleanup job runs                                                                                                         |
+| `MEMORY_SERVICE_ATTACHMENTS_DOWNLOAD_URL_EXPIRES_IN`               | duration    | `PT5M`  | Signed download URL expiry                                                                                                             |
+| —                                                                  | —           | —       | Signed download URLs are enabled automatically when `--encryption-dek-key` is set; the signing key is derived from it via HKDF-SHA256. |
 
 ### Attachment Storage: DB Configuration
 
 The default `db` backend stores attachments directly in the primary database (PostgreSQL or MongoDB). No additional configuration is required.
 
-<ConfigBlock property={`# Use database storage (default)
+<ConfigBlock
+  property={`# Use database storage (default)
 --attachments-kind=db`}
   env={`# Use database storage (default)
 MEMORY_SERVICE_ATTACHMENTS_KIND=db`}
@@ -186,23 +194,25 @@ MEMORY_SERVICE_ATTACHMENTS_KIND=db`}
 
 S3 storage offloads attachments to any S3-compatible object store. Use this for large files or high-throughput workloads.
 
-| Flag / Env Var | Values | Default | Description |
-|----------------|--------|---------|-------------|
-| <Cfg p="--attachments-s3-bucket" e="MEMORY_SERVICE_ATTACHMENTS_S3_BUCKET" /> | string | `memory-service-attachments` | S3 bucket name |
-| <Cfg p="--attachments-s3-use-path-style" e="MEMORY_SERVICE_ATTACHMENTS_S3_USE_PATH_STYLE" /> | `true`, `false` | `false` | Use path-style S3 addressing (required for LocalStack/MinIO) |
-| `MEMORY_SERVICE_ATTACHMENTS_S3_PREFIX` | string | _(empty)_ | Optional key prefix for all objects |
-| `MEMORY_SERVICE_ATTACHMENTS_S3_DIRECT_DOWNLOAD` | `true`, `false` | `true` | Redirect clients directly to S3 via presigned URLs |
-| `MEMORY_SERVICE_ATTACHMENTS_S3_EXTERNAL_ENDPOINT` | URL | _(none)_ | Override endpoint in presigned URLs |
+| Flag / Env Var                                                                               | Values          | Default                      | Description                                                  |
+| -------------------------------------------------------------------------------------------- | --------------- | ---------------------------- | ------------------------------------------------------------ |
+| <Cfg p="--attachments-s3-bucket" e="MEMORY_SERVICE_ATTACHMENTS_S3_BUCKET" />                 | string          | `memory-service-attachments` | S3 bucket name                                               |
+| <Cfg p="--attachments-s3-use-path-style" e="MEMORY_SERVICE_ATTACHMENTS_S3_USE_PATH_STYLE" /> | `true`, `false` | `false`                      | Use path-style S3 addressing (required for LocalStack/MinIO) |
+| `MEMORY_SERVICE_ATTACHMENTS_S3_PREFIX`                                                       | string          | _(empty)_                    | Optional key prefix for all objects                          |
+| `MEMORY_SERVICE_ATTACHMENTS_S3_DIRECT_DOWNLOAD`                                              | `true`, `false` | `true`                       | Redirect clients directly to S3 via presigned URLs           |
+| `MEMORY_SERVICE_ATTACHMENTS_S3_EXTERNAL_ENDPOINT`                                            | URL             | _(none)_                     | Override endpoint in presigned URLs                          |
 
 <ConfigBlock property={`# Select S3 storage
 --attachments-kind=s3
 
 # S3 bucket configuration
+
 --attachments-s3-bucket=memory-service-attachments`}
   env={`# Select S3 storage
 MEMORY_SERVICE_ATTACHMENTS_KIND=s3
 
 # S3 bucket configuration
+
 MEMORY_SERVICE_ATTACHMENTS_S3_BUCKET=memory-service-attachments`}
 />
 
@@ -221,18 +231,18 @@ See [Attachments](/docs/concepts/attachments/) for details on how attachments wo
 
 Memory Service supports transparent encryption of stored data using AES-256-GCM. Configure encryption by selecting one or more providers via `--encryption-kind`. The first provider is primary — used for all new encryptions. Additional providers are decryption-only fallbacks, enabling zero-downtime key rotation.
 
-| Flag / Env Var | Values | Default | Description |
-|----------------|--------|---------|-------------|
-| <Cfg p="--encryption-kind" e="MEMORY_SERVICE_ENCRYPTION_KIND" /> | comma-separated IDs | `plain` | Ordered list of providers (`plain`, `dek`, `vault`, `kms`); first provider encrypts new data |
-| <Cfg p="--encryption-db-disabled" e="MEMORY_SERVICE_ENCRYPTION_DB_DISABLED" /> | `true`, `false` | `false` | Disable at-rest encryption for the database even when an encryption provider is active |
-| <Cfg p="--encryption-attachments-disabled" e="MEMORY_SERVICE_ENCRYPTION_ATTACHMENTS_DISABLED" /> | `true`, `false` | `false` | Disable at-rest encryption for the attachment store even when an encryption provider is active |
+| Flag / Env Var                                                                                   | Values              | Default | Description                                                                                    |
+| ------------------------------------------------------------------------------------------------ | ------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| <Cfg p="--encryption-kind" e="MEMORY_SERVICE_ENCRYPTION_KIND" />                                 | comma-separated IDs | `plain` | Ordered list of providers (`plain`, `dek`, `vault`, `kms`); first provider encrypts new data   |
+| <Cfg p="--encryption-db-disabled" e="MEMORY_SERVICE_ENCRYPTION_DB_DISABLED" />                   | `true`, `false`     | `false` | Disable at-rest encryption for the database even when an encryption provider is active         |
+| <Cfg p="--encryption-attachments-disabled" e="MEMORY_SERVICE_ENCRYPTION_ATTACHMENTS_DISABLED" /> | `true`, `false`     | `false` | Disable at-rest encryption for the attachment store even when an encryption provider is active |
 
 ### Encryption: DEK (AES-256-GCM)
 
 The `dek` provider encrypts data locally using AES-256-GCM with a key you supply. No external service is required — all encryption happens in-process. Signed attachment download URLs are automatically derived from this key via HKDF-SHA256.
 
-| Flag / Env Var | Values | Default | Description |
-|----------------|--------|---------|-------------|
+| Flag / Env Var                                                         | Values               | Default  | Description                                                                                                                                |
+| ---------------------------------------------------------------------- | -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | <Cfg p="--encryption-dek-key" e="MEMORY_SERVICE_ENCRYPTION_DEK_KEY" /> | hex or base64 string | _(none)_ | Comma-separated AES-256 keys (16/24/32 bytes). First key encrypts new data; additional keys are legacy decryption-only (for key rotation). |
 
 <ConfigBlock
@@ -260,16 +270,16 @@ MEMORY_SERVICE_ENCRYPTION_DEK_KEY=new-primary-key,old-legacy-key
 
 The `vault` provider uses HashiCorp Vault Transit to wrap data-encryption keys (DEKs). DEKs are loaded from the `encryption_deks` database table at startup — Vault is called only once at load time (never per request). A random DEK is generated on first start, wrapped via Vault Transit, and stored in the table. Loss of Vault access prevents startup but does not affect already-running instances.
 
-| Flag / Env Var | Values | Default | Description |
-|----------------|--------|---------|-------------|
+| Flag / Env Var                                                                             | Values | Default      | Description            |
+| ------------------------------------------------------------------------------------------ | ------ | ------------ | ---------------------- |
 | <Cfg p="--encryption-vault-transit-key" e="MEMORY_SERVICE_ENCRYPTION_VAULT_TRANSIT_KEY" /> | string | _(required)_ | Vault Transit key name |
 
 Standard HashiCorp Vault environment variables are used for authentication:
 
-| Env Var | Description |
-|---------|-------------|
-| `VAULT_ADDR` | Vault server URL (e.g. `https://vault.example.com`) |
-| `VAULT_TOKEN` | Vault token (or use any other Vault auth method) |
+| Env Var       | Description                                         |
+| ------------- | --------------------------------------------------- |
+| `VAULT_ADDR`  | Vault server URL (e.g. `https://vault.example.com`) |
+| `VAULT_TOKEN` | Vault token (or use any other Vault auth method)    |
 
 <ConfigBlock
   property={`# Enable Vault encryption
@@ -280,6 +290,7 @@ MEMORY_SERVICE_ENCRYPTION_KIND=vault
 MEMORY_SERVICE_ENCRYPTION_VAULT_TRANSIT_KEY=memory-service
 
 # HashiCorp Vault connection (standard env vars)
+
 VAULT_ADDR=https://vault.example.com
 VAULT_TOKEN=<token>`}
 />
@@ -288,17 +299,17 @@ VAULT_TOKEN=<token>`}
 
 The `kms` provider uses AWS KMS to wrap data-encryption keys (DEKs). DEKs are loaded from the `encryption_deks` database table at startup — KMS is called only once at load time (never per request). A random DEK is generated on first start, wrapped via `kms:Encrypt`, and stored in the table. Loss of KMS access prevents startup but does not affect already-running instances.
 
-| Flag / Env Var | Values | Default | Description |
-|----------------|--------|---------|-------------|
+| Flag / Env Var                                                               | Values | Default      | Description           |
+| ---------------------------------------------------------------------------- | ------ | ------------ | --------------------- |
 | <Cfg p="--encryption-kms-key-id" e="MEMORY_SERVICE_ENCRYPTION_KMS_KEY_ID" /> | string | _(required)_ | AWS KMS key ID or ARN |
 
 Standard AWS SDK environment variables are used for authentication:
 
-| Env Var | Description |
-|---------|-------------|
-| `AWS_REGION` | AWS region (e.g. `us-east-1`) |
-| `AWS_ACCESS_KEY_ID` | AWS access key ID |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret access key |
+| Env Var                 | Description                   |
+| ----------------------- | ----------------------------- |
+| `AWS_REGION`            | AWS region (e.g. `us-east-1`) |
+| `AWS_ACCESS_KEY_ID`     | AWS access key ID             |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key         |
 
 Any other credential source supported by the AWS SDK (IAM roles, `AWS_PROFILE`, instance metadata, etc.) is also honoured.
 
@@ -311,6 +322,7 @@ MEMORY_SERVICE_ENCRYPTION_KIND=kms
 MEMORY_SERVICE_ENCRYPTION_KMS_KEY_ID=arn:aws:kms:us-east-1:123456789012:key/mrk-...
 
 # AWS authentication (standard env vars)
+
 AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=AKIA...
 AWS_SECRET_ACCESS_KEY=...`}
@@ -340,18 +352,19 @@ For semantic search capabilities, configure a vector store backend. The vector s
 
 > **Note:** A vector store requires an embedding provider. When a vector store is enabled, configure <Cfg p="--embedding-kind" e="MEMORY_SERVICE_EMBEDDING_KIND" /> to a value other than `none`. See [Embedding Configuration](#embedding-configuration).
 
-| Flag / Env Var | Values | Default | Description |
-|----------------|--------|---------|-------------|
-| <Cfg p="--vector-kind" e="MEMORY_SERVICE_VECTOR_KIND" /> | `none`, `pgvector`, `qdrant` | `none` | Vector store backend |
-| `MEMORY_SERVICE_VECTOR_MIGRATE_AT_START` | `true`, `false` | `true` | Run vector store migrations at startup |
-| `MEMORY_SERVICE_SEARCH_SEMANTIC_ENABLED` | `true`, `false` | `true` | Enable semantic (vector) search |
-| `MEMORY_SERVICE_SEARCH_FULLTEXT_ENABLED` | `true`, `false` | `true` | Enable full-text search |
+| Flag / Env Var                                           | Values                       | Default | Description                            |
+| -------------------------------------------------------- | ---------------------------- | ------- | -------------------------------------- |
+| <Cfg p="--vector-kind" e="MEMORY_SERVICE_VECTOR_KIND" /> | `none`, `pgvector`, `qdrant` | `none`  | Vector store backend                   |
+| `MEMORY_SERVICE_VECTOR_MIGRATE_AT_START`                 | `true`, `false`              | `true`  | Run vector store migrations at startup |
+| `MEMORY_SERVICE_SEARCH_SEMANTIC_ENABLED`                 | `true`, `false`              | `true`  | Enable semantic (vector) search        |
+| `MEMORY_SERVICE_SEARCH_FULLTEXT_ENABLED`                 | `true`, `false`              | `true`  | Enable full-text search                |
 
 ### Vector Store: pgvector Configuration
 
 pgvector integrates directly with PostgreSQL to add vector search capabilities alongside your existing data. It is the natural choice when the datastore is already PostgreSQL.
 
-<ConfigBlock property={`# pgvector (auto-selected when datastore is postgres)
+<ConfigBlock
+  property={`# pgvector (auto-selected when datastore is postgres)
 --vector-kind=pgvector`}
   env={`# pgvector (auto-selected when datastore is postgres)
 MEMORY_SERVICE_VECTOR_KIND=pgvector`}
@@ -361,17 +374,18 @@ MEMORY_SERVICE_VECTOR_KIND=pgvector`}
 
 Qdrant is a dedicated vector database for semantic search. When using Qdrant, the primary datastore (PostgreSQL or MongoDB) still stores all conversation data — Qdrant only stores embeddings and metadata.
 
-| Flag / Env Var | Default | Description |
-|----------------|---------|-------------|
-| <Cfg p="--vector-qdrant-host" e="MEMORY_SERVICE_VECTOR_QDRANT_HOST" /> | `localhost` | Qdrant server hostname or host:port |
-| `MEMORY_SERVICE_VECTOR_QDRANT_PORT` | `6334` | Qdrant gRPC port |
-| `MEMORY_SERVICE_VECTOR_QDRANT_COLLECTION_PREFIX` | `memory-service` | Prefix for derived collection name |
-| `MEMORY_SERVICE_VECTOR_QDRANT_COLLECTION_NAME` | _(none)_ | Optional explicit collection name override |
-| `MEMORY_SERVICE_VECTOR_QDRANT_API_KEY` | _(none)_ | API key for authentication |
-| `MEMORY_SERVICE_VECTOR_QDRANT_USE_TLS` | `false` | Enable TLS for gRPC connection |
-| `MEMORY_SERVICE_VECTOR_QDRANT_STARTUP_TIMEOUT` | `PT30S` | Startup migration timeout |
+| Flag / Env Var                                                         | Default          | Description                                |
+| ---------------------------------------------------------------------- | ---------------- | ------------------------------------------ |
+| <Cfg p="--vector-qdrant-host" e="MEMORY_SERVICE_VECTOR_QDRANT_HOST" /> | `localhost`      | Qdrant server hostname or host:port        |
+| `MEMORY_SERVICE_VECTOR_QDRANT_PORT`                                    | `6334`           | Qdrant gRPC port                           |
+| `MEMORY_SERVICE_VECTOR_QDRANT_COLLECTION_PREFIX`                       | `memory-service` | Prefix for derived collection name         |
+| `MEMORY_SERVICE_VECTOR_QDRANT_COLLECTION_NAME`                         | _(none)_         | Optional explicit collection name override |
+| `MEMORY_SERVICE_VECTOR_QDRANT_API_KEY`                                 | _(none)_         | API key for authentication                 |
+| `MEMORY_SERVICE_VECTOR_QDRANT_USE_TLS`                                 | `false`          | Enable TLS for gRPC connection             |
+| `MEMORY_SERVICE_VECTOR_QDRANT_STARTUP_TIMEOUT`                         | `PT30S`          | Startup migration timeout                  |
 
-<ConfigBlock property={`# Qdrant vector store
+<ConfigBlock
+  property={`# Qdrant vector store
 --vector-kind=qdrant
 --vector-qdrant-host=localhost:6334`}
   env={`# Qdrant vector store
@@ -385,15 +399,16 @@ By default, memory-service derives the collection name as `memory-service_<model
 
 The embedding provider controls how text is converted to vectors for semantic search. Embedding requires a vector store to be configured.
 
-| Flag / Env Var | Values | Default | Description |
-|----------------|--------|---------|-------------|
+| Flag / Env Var                                                 | Values                    | Default | Description                  |
+| -------------------------------------------------------------- | ------------------------- | ------- | ---------------------------- |
 | <Cfg p="--embedding-kind" e="MEMORY_SERVICE_EMBEDDING_KIND" /> | `none`, `local`, `openai` | `local` | Embedding provider selection |
 
 ### Embedding: Local Configuration
 
 The default `local` provider uses an in-process all-MiniLM-L6-v2 ONNX model (384 dimensions). No external API calls are required.
 
-<ConfigBlock property={`# Use local embedding model (default)
+<ConfigBlock
+  property={`# Use local embedding model (default)
 --embedding-kind=local`}
   env={`# Use local embedding model (default)
 MEMORY_SERVICE_EMBEDDING_KIND=local`}
@@ -403,14 +418,15 @@ MEMORY_SERVICE_EMBEDDING_KIND=local`}
 
 The `openai` provider uses the OpenAI Embeddings API for higher-quality embeddings.
 
-| Flag / Env Var | Default | Description |
-|----------------|---------|-------------|
-| <Cfg p="--embedding-openai-api-key" e="MEMORY_SERVICE_EMBEDDING_OPENAI_API_KEY" /> | _(required)_ | OpenAI API key |
-| `MEMORY_SERVICE_EMBEDDING_OPENAI_MODEL_NAME` | `text-embedding-3-small` | OpenAI model name |
-| `MEMORY_SERVICE_EMBEDDING_OPENAI_BASE_URL` | `https://api.openai.com/v1` | API base URL (for Azure OpenAI or proxies) |
-| `MEMORY_SERVICE_EMBEDDING_OPENAI_DIMENSIONS` | _(model default)_ | Optional dimension override |
+| Flag / Env Var                                                                     | Default                     | Description                                |
+| ---------------------------------------------------------------------------------- | --------------------------- | ------------------------------------------ |
+| <Cfg p="--embedding-openai-api-key" e="MEMORY_SERVICE_EMBEDDING_OPENAI_API_KEY" /> | _(required)_                | OpenAI API key                             |
+| `MEMORY_SERVICE_EMBEDDING_OPENAI_MODEL_NAME`                                       | `text-embedding-3-small`    | OpenAI model name                          |
+| `MEMORY_SERVICE_EMBEDDING_OPENAI_BASE_URL`                                         | `https://api.openai.com/v1` | API base URL (for Azure OpenAI or proxies) |
+| `MEMORY_SERVICE_EMBEDDING_OPENAI_DIMENSIONS`                                       | _(model default)_           | Optional dimension override                |
 
-<ConfigBlock property={`# Use OpenAI embeddings
+<ConfigBlock
+  property={`# Use OpenAI embeddings
 --embedding-kind=openai
 --embedding-openai-api-key=sk-...`}
   env={`# Use OpenAI embeddings
@@ -422,9 +438,9 @@ MEMORY_SERVICE_EMBEDDING_OPENAI_API_KEY=sk-...`}
 
 Configure namespaced Memories policy loading.
 
-| Flag | Values | Default | Description |
-|------|--------|---------|-------------|
-| <Cfg p="--policy-dir" e="MEMORY_SERVICE_POLICY_DIR" /> | path | built-in policies | Directory containing memory OPA/Rego policy files: `authz.rego` (`data.memories.authz.decision`), `attributes.rego` (`data.memories.attributes.attributes`), `filter.rego` (`data.memories.filter`) |
+| Flag                                                   | Values | Default           | Description                                                                                                                                                                                         |
+| ------------------------------------------------------ | ------ | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <Cfg p="--policy-dir" e="MEMORY_SERVICE_POLICY_DIR" /> | path   | built-in policies | Directory containing memory OPA/Rego policy files: `authz.rego` (`data.memories.authz.decision`), `attributes.rego` (`data.memories.attributes.attributes`), `filter.rego` (`data.memories.filter`) |
 
 ## API Key Authentication
 
@@ -445,7 +461,8 @@ Clients include the API key in requests via the `X-API-Key` header.
 
 Memory Service supports OIDC authentication via Keycloak or any compliant provider.
 
-<ConfigBlock property={`# OIDC configuration
+<ConfigBlock
+  property={`# OIDC configuration
 --oidc-issuer=http://localhost:8180/realms/memory-service`}
   env={`# OIDC configuration
 MEMORY_SERVICE_OIDC_ISSUER=http://localhost:8180/realms/memory-service`}
@@ -460,11 +477,11 @@ grants a role, the caller has that role.
 
 ### Roles
 
-| Role | Access | Description |
-|------|--------|-------------|
-| `admin` | Read + Write | Full administrative access across all users. Implies `auditor` and `indexer`. |
-| `auditor` | Read-only | View any user's conversations and search system-wide. Cannot modify data. |
-| `indexer` | Index only | Index any conversation's transcript for search. Cannot view or modify other data. |
+| Role      | Access       | Description                                                                       |
+| --------- | ------------ | --------------------------------------------------------------------------------- |
+| `admin`   | Read + Write | Full administrative access across all users. Implies `auditor` and `indexer`.     |
+| `auditor` | Read-only    | View any user's conversations and search system-wide. Cannot modify data.         |
+| `indexer` | Index only   | Index any conversation's transcript for search. Cannot view or modify other data. |
 
 ### Role Assignment
 
@@ -474,9 +491,9 @@ Roles can be assigned through three complementary mechanisms:
 
 Map OIDC token roles to internal Memory Service roles.
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| <Cfg p="--roles-admin-oidc-role" e="MEMORY_SERVICE_ROLES_ADMIN_OIDC_ROLE" /> | _(none)_ | OIDC role name that maps to `admin` |
+| Flag                                                                             | Default  | Description                           |
+| -------------------------------------------------------------------------------- | -------- | ------------------------------------- |
+| <Cfg p="--roles-admin-oidc-role" e="MEMORY_SERVICE_ROLES_ADMIN_OIDC_ROLE" />     | _(none)_ | OIDC role name that maps to `admin`   |
 | <Cfg p="--roles-auditor-oidc-role" e="MEMORY_SERVICE_ROLES_AUDITOR_OIDC_ROLE" /> | _(none)_ | OIDC role name that maps to `auditor` |
 | <Cfg p="--roles-indexer-oidc-role" e="MEMORY_SERVICE_ROLES_INDEXER_OIDC_ROLE" /> | _(none)_ | OIDC role name that maps to `indexer` |
 
@@ -484,55 +501,62 @@ Map OIDC token roles to internal Memory Service roles.
 --roles-admin-oidc-role=administrator
 
 # Map OIDC "manager" role to internal "auditor" role
+
 --roles-auditor-oidc-role=manager
 
 # Map OIDC "transcript-indexer" role to internal "indexer" role
+
 --roles-indexer-oidc-role=transcript-indexer`} />
 
 #### User-Based Assignment
 
 Assign roles directly to user IDs (matched against the OIDC token principal name):
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| <Cfg p="--roles-admin-users" e="MEMORY_SERVICE_ROLES_ADMIN_USERS" /> | _(empty)_ | Comma-separated user IDs with admin access |
+| Flag                                                                     | Default   | Description                                  |
+| ------------------------------------------------------------------------ | --------- | -------------------------------------------- |
+| <Cfg p="--roles-admin-users" e="MEMORY_SERVICE_ROLES_ADMIN_USERS" />     | _(empty)_ | Comma-separated user IDs with admin access   |
 | <Cfg p="--roles-auditor-users" e="MEMORY_SERVICE_ROLES_AUDITOR_USERS" /> | _(empty)_ | Comma-separated user IDs with auditor access |
 | <Cfg p="--roles-indexer-users" e="MEMORY_SERVICE_ROLES_INDEXER_USERS" /> | _(empty)_ | Comma-separated user IDs with indexer access |
 
-<ConfigBlock property={`--roles-admin-users=alice,bob
+<ConfigBlock
+  property={`--roles-admin-users=alice,bob
 --roles-auditor-users=charlie,dave
---roles-indexer-users=indexer-user`} />
+--roles-indexer-users=indexer-user`}
+/>
 
 #### Client-Based Assignment (API Key)
 
 Assign roles to API key client IDs, allowing agents or services to call admin APIs.
 
-| Flag | Default | Description |
-|------|---------|-------------|
-| <Cfg p="--roles-admin-clients" e="MEMORY_SERVICE_ROLES_ADMIN_CLIENTS" /> | _(empty)_ | Comma-separated API client IDs with admin access |
+| Flag                                                                         | Default   | Description                                        |
+| ---------------------------------------------------------------------------- | --------- | -------------------------------------------------- |
+| <Cfg p="--roles-admin-clients" e="MEMORY_SERVICE_ROLES_ADMIN_CLIENTS" />     | _(empty)_ | Comma-separated API client IDs with admin access   |
 | <Cfg p="--roles-auditor-clients" e="MEMORY_SERVICE_ROLES_AUDITOR_CLIENTS" /> | _(empty)_ | Comma-separated API client IDs with auditor access |
 | <Cfg p="--roles-indexer-clients" e="MEMORY_SERVICE_ROLES_INDEXER_CLIENTS" /> | _(empty)_ | Comma-separated API client IDs with indexer access |
 
-<ConfigBlock property={`--roles-admin-clients=admin-agent
+<ConfigBlock
+  property={`--roles-admin-clients=admin-agent
 --roles-auditor-clients=monitoring-agent,audit-agent
---roles-indexer-clients=indexer-service,summarizer-agent`} />
+--roles-indexer-clients=indexer-service,summarizer-agent`}
+/>
 
 ### Audit Logging
 
 All admin API calls are logged. Each request can include a `justification` field explaining why the admin action was taken.
 
-| Flag | Values | Default | Description |
-|------|--------|---------|-------------|
+| Flag                                                                                     | Values          | Default | Description                                   |
+| ---------------------------------------------------------------------------------------- | --------------- | ------- | --------------------------------------------- |
 | <Cfg p="--admin-require-justification" e="MEMORY_SERVICE_ADMIN_REQUIRE_JUSTIFICATION" /> | `true`, `false` | `false` | Require justification for all admin API calls |
 
 ### CORS Configuration
 
-| Env Var | Values | Default | Description |
-|---------|--------|---------|-------------|
-| `MEMORY_SERVICE_CORS_ENABLED` | `true`, `false` | `false` | Enable CORS |
+| Env Var                       | Values                  | Default  | Description          |
+| ----------------------------- | ----------------------- | -------- | -------------------- |
+| `MEMORY_SERVICE_CORS_ENABLED` | `true`, `false`         | `false`  | Enable CORS          |
 | `MEMORY_SERVICE_CORS_ORIGINS` | comma-separated origins | _(none)_ | Allowed CORS origins |
 
-<ConfigBlock property={`# Enable CORS
+<ConfigBlock
+  property={`# Enable CORS
 MEMORY_SERVICE_CORS_ENABLED=true
 MEMORY_SERVICE_CORS_ORIGINS=http://localhost:3000`}
   env={`# Enable CORS
@@ -546,33 +570,33 @@ Memory Service exposes Prometheus metrics and provides admin stats endpoints tha
 
 ### Management Endpoints
 
-| Endpoint | Description |
-|----------|-------------|
-| `GET /health` | Liveness — returns `200 {"status":"ok"}` as soon as the process is up |
-| `GET /ready` | Readiness — returns `200 {"status":"ready"}` once all initialization (migrations, store connections, network listeners) has completed; returns `503 {"status":"starting"}` before that |
-| `GET /metrics` | Prometheus metrics |
+| Endpoint       | Description                                                                                                                                                                            |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /health`  | Liveness — returns `200 {"status":"ok"}` as soon as the process is up                                                                                                                  |
+| `GET /ready`   | Readiness — returns `200 {"status":"ready"}` once all initialization (migrations, store connections, network listeners) has completed; returns `503 {"status":"starting"}` before that |
+| `GET /metrics` | Prometheus metrics                                                                                                                                                                     |
 
 Use `/ready` for Kubernetes readiness probes and Docker Compose `healthcheck` (so dependent services wait for full startup). Use `/health` for liveness probes.
 
 ### Prometheus Configuration
 
-| Flag | Values | Default | Description |
-|------|--------|---------|-------------|
-| <Cfg p="--prometheus-url" e="MEMORY_SERVICE_PROMETHEUS_URL" /> | URL | _(none)_ | Prometheus server URL for admin stats queries |
+| Flag                                                           | Values | Default  | Description                                   |
+| -------------------------------------------------------------- | ------ | -------- | --------------------------------------------- |
+| <Cfg p="--prometheus-url" e="MEMORY_SERVICE_PROMETHEUS_URL" /> | URL    | _(none)_ | Prometheus server URL for admin stats queries |
 
 When `--prometheus-url` is not configured, admin stats endpoints return **501 Not Implemented**. All other Memory Service functionality works normally.
 
 #### Available Stats Endpoints
 
-| Endpoint | Description |
-|----------|-------------|
-| `/v1/admin/stats/request-rate` | HTTP request rate (requests/sec) |
-| `/v1/admin/stats/error-rate` | 5xx error rate (percent) |
-| `/v1/admin/stats/latency-p95` | P95 response latency (seconds) |
-| `/v1/admin/stats/cache-hit-rate` | Cache hit rate (percent) |
-| `/v1/admin/stats/db-pool-utilization` | DB connection pool usage (percent) |
-| `/v1/admin/stats/store-latency-p95` | Store operation P95 latency by type |
-| `/v1/admin/stats/store-throughput` | Store operations/sec by type |
+| Endpoint                              | Description                         |
+| ------------------------------------- | ----------------------------------- |
+| `/v1/admin/stats/request-rate`        | HTTP request rate (requests/sec)    |
+| `/v1/admin/stats/error-rate`          | 5xx error rate (percent)            |
+| `/v1/admin/stats/latency-p95`         | P95 response latency (seconds)      |
+| `/v1/admin/stats/cache-hit-rate`      | Cache hit rate (percent)            |
+| `/v1/admin/stats/db-pool-utilization` | DB connection pool usage (percent)  |
+| `/v1/admin/stats/store-latency-p95`   | Store operation P95 latency by type |
+| `/v1/admin/stats/store-throughput`    | Store operations/sec by type        |
 
 ### Prometheus Scrape Configuration
 
@@ -586,11 +610,11 @@ For production, use a dedicated management port so Prometheus scrapes only the m
 ```yaml
 # prometheus.yml — scrape the management port
 scrape_configs:
-  - job_name: 'memory-service'
+  - job_name: "memory-service"
     scrape_interval: 15s
     metrics_path: /metrics
     static_configs:
-      - targets: ['memory-service:8085']
+      - targets: ["memory-service:8085"]
 ```
 
 Without a management port, scrape the main port instead:
@@ -598,11 +622,11 @@ Without a management port, scrape the main port instead:
 ```yaml
 # prometheus.yml — no dedicated management port
 scrape_configs:
-  - job_name: 'memory-service'
+  - job_name: "memory-service"
     scrape_interval: 15s
     metrics_path: /metrics
     static_configs:
-      - targets: ['memory-service:8080']
+      - targets: ["memory-service:8080"]
 ```
 
 ## Example: Docker Compose

--- a/site/src/pages/docs/deployment/docker.mdx
+++ b/site/src/pages/docs/deployment/docker.mdx
@@ -3,8 +3,9 @@ layout: ../../../layouts/DocsLayout.astro
 title: Docker Deployment
 description: Deploy Memory Service using Docker.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
 
 export const productionConfig = `services:
   memory-service:
@@ -38,14 +39,14 @@ docker run -d \
 For a complete local setup with all dependencies:
 
 ```yaml
-version: '3.8'
+version: "3.8"
 
 services:
   memory-service:
     image: ghcr.io/chirino/memory-service:latest
     ports:
-      - "8080:8080"   # REST API
-      - "9000:9000"   # gRPC API
+      - "8080:8080" # REST API
+      - "9000:9000" # gRPC API
     environment:
       - MEMORY_SERVICE_DB_URL=postgres://postgres:postgres@postgres:5432/memoryservice?sslmode=disable
       - MEMORY_SERVICE_DB_MIGRATE_AT_START=true
@@ -81,28 +82,28 @@ docker compose up -d
 
 ### Database Configuration
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `MEMORY_SERVICE_DB_KIND` | Database type (`postgres` or `mongo`) | `postgres` |
-| `MEMORY_SERVICE_DB_URL` | Database connection URL | - |
-| `MEMORY_SERVICE_DB_MIGRATE_AT_START` | Run schema migrations on startup | `true` |
-| `MEMORY_SERVICE_DB_MAX_OPEN_CONNS` | Maximum open database connections | `25` |
-| `MEMORY_SERVICE_DB_MAX_IDLE_CONNS` | Idle/minimum connections in pool | `5` |
+| Variable                             | Description                           | Default    |
+| ------------------------------------ | ------------------------------------- | ---------- |
+| `MEMORY_SERVICE_DB_KIND`             | Database type (`postgres` or `mongo`) | `postgres` |
+| `MEMORY_SERVICE_DB_URL`              | Database connection URL               | -          |
+| `MEMORY_SERVICE_DB_MIGRATE_AT_START` | Run schema migrations on startup      | `true`     |
+| `MEMORY_SERVICE_DB_MAX_OPEN_CONNS`   | Maximum open database connections     | `25`       |
+| `MEMORY_SERVICE_DB_MAX_IDLE_CONNS`   | Idle/minimum connections in pool      | `5`        |
 
 ### Vector Store Configuration
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `MEMORY_SERVICE_VECTOR_KIND` | Vector store type (`none`, `pgvector`, `qdrant`) | `none` |
-| `MEMORY_SERVICE_EMBEDDING_KIND` | Embedding provider (`none`, `local`, `openai`) | `local` |
-| `MEMORY_SERVICE_EMBEDDING_OPENAI_API_KEY` | OpenAI API key for embeddings | - |
+| Variable                                  | Description                                      | Default |
+| ----------------------------------------- | ------------------------------------------------ | ------- |
+| `MEMORY_SERVICE_VECTOR_KIND`              | Vector store type (`none`, `pgvector`, `qdrant`) | `none`  |
+| `MEMORY_SERVICE_EMBEDDING_KIND`           | Embedding provider (`none`, `local`, `openai`)   | `local` |
+| `MEMORY_SERVICE_EMBEDDING_OPENAI_API_KEY` | OpenAI API key for embeddings                    | -       |
 
 ### Authentication
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `MEMORY_SERVICE_OIDC_ISSUER` | OIDC issuer URL | - |
-| `MEMORY_SERVICE_API_KEYS_<CLIENT>` | API key(s) for a client ID | - |
+| Variable                           | Description                | Default |
+| ---------------------------------- | -------------------------- | ------- |
+| `MEMORY_SERVICE_OIDC_ISSUER`       | OIDC issuer URL            | -       |
+| `MEMORY_SERVICE_API_KEYS_<CLIENT>` | API key(s) for a client ID | -       |
 
 ## Health Checks
 
@@ -137,10 +138,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '2'
+          cpus: "2"
           memory: 1G
         reservations:
-          cpus: '0.5'
+          cpus: "0.5"
           memory: 512M
 ```
 

--- a/site/src/pages/docs/deployment/kubernetes.mdx
+++ b/site/src/pages/docs/deployment/kubernetes.mdx
@@ -3,8 +3,9 @@ layout: ../../../layouts/DocsLayout.astro
 title: Kubernetes Deployment
 description: Deploy Memory Service on Kubernetes.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
 
 export const k8sDeployment = `apiVersion: apps/v1
 kind: Deployment

--- a/site/src/pages/docs/faq.mdx
+++ b/site/src/pages/docs/faq.mdx
@@ -3,8 +3,9 @@ layout: ../../layouts/DocsLayout.astro
 title: FAQ
 description: Frequently asked questions about Memory Service.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../config';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../config";
 
 export const mavenDep = `<dependency>
   <groupId>io.github.chirino.memory-service</groupId>
@@ -22,24 +23,27 @@ Memory Service is a backend service that provides persistent memory for AI agent
 
 ### Is Memory Service production-ready?
 
-Not yet. Memory Service is in active development and has not reached its first stable release. APIs may change without notice, so production 
+Not yet. Memory Service is in active development and has not reached its first stable release. APIs may change without notice, so production
 use is not recommended at this time.
 
 ### What databases are supported?
 
 Memory Service supports:
+
 - **PostgreSQL** (recommended) - with pgvector for semantic search
 - **MongoDB** - with full-text search support
 
 ### What vector stores are supported?
 
 For semantic search capabilities:
+
 - **pgvector** - PostgreSQL extension for in-database vector search
 - **Qdrant** - Dedicated vector database via LangChain4j integration
 
 ### What caches are supported?
 
 Memory Service supports:
+
 - **Redis**
 - **Infinispan**
 
@@ -51,7 +55,7 @@ See the [Getting Started](/docs/getting-started/) guide for detailed instruction
 
 ### Do I need to run a separate service?
 
-In development mode, the Quarkus Dev Services automatically start Memory Service in a Docker container. For production environments, 
+In development mode, the Quarkus Dev Services automatically start Memory Service in a Docker container. For production environments,
 you'll deploy Memory Service as a separate service.
 
 ## Features
@@ -59,6 +63,7 @@ you'll deploy Memory Service as a separate service.
 ### What is conversation forking?
 
 Conversation forking allows you to create a new conversation branch from any point in an existing conversation. This is useful for:
+
 - If you think that correcting or adding more context to a previous message would improve the response, you can fork the conversation at that message and add the new context to continue from that point instead of starting a fresh conversation.
 - Exploring alternative conversation paths
 
@@ -78,11 +83,9 @@ No hard depth limit is enforced today. Fork ancestry is built iteratively (not r
 
 Yes. Entries include `conversationId`, and you can call `/v1/conversations/{conversationId}/forks` to get fork metadata (`forkedAtConversationId`, `forkedAtEntryId`) and reconstruct/visualize the tree.
 
-{/* 
 ### How does semantic search work?
 
-Memory Service uses vector embeddings to enable semantic search across all stored conversations. When you store a message, it's automatically embedded using your configured embedding model. You can then search for semantically similar content across all conversations. 
-*/}
+Memory Service uses vector embeddings to enable semantic search across all stored conversations. When you store a message, it's automatically embedded using your configured embedding model. You can then search for semantically similar content across all conversations.
 
 ### Can multiple agents share conversations?
 
@@ -97,6 +100,7 @@ Memory channel writes are agent-isolated by client identity. Also, conversation 
 ### How big can a single entry be?
 
 There is no strict service-level byte-size limit on `content` today, but practical datastore/request limits still apply (for example, MongoDB document limits). API-level limits currently include:
+
 - `content` max items: `1000`
 - `indexedContent` max length: `100000`
 
@@ -145,6 +149,7 @@ No. Rich event support depends on the agent framework producing those events (fo
 ### How can I contribute?
 
 We welcome contributions! Check out the [GitHub repository](https://github.com/chirino/memory-service) for:
+
 - Open issues
 - Pull requests
 

--- a/site/src/pages/docs/index.mdx
+++ b/site/src/pages/docs/index.mdx
@@ -4,7 +4,7 @@ title: Documentation
 description: Memory Service documentation - learn how to integrate persistent memory into your AI agents.
 ---
 
-import { Code } from 'astro:components';
+import { Code } from "astro:components";
 
 Welcome to the Memory Service documentation. This guide will help you integrate persistent memory into your AI agents.
 
@@ -28,7 +28,7 @@ Memory Service is a backend service designed to solve the persistent memory prob
 
 ![Memory Service Architecture](memory-service-architecture.png)
 
-Memory Service is packaged as container image and provides both REST and gRPC APIs.  It also provides 
+Memory Service is packaged as container image and provides both REST and gRPC APIs. It also provides
 several client side components to simplify integration with Quarkus LangChain4j and Spring AI applications.
 All the blue components in the diagram above are part of this project.
 
@@ -49,11 +49,15 @@ All the blue components in the diagram above are part of this project.
   </a>
   <a href="spring/getting-started/" class="card p-4 hover:border-primary-500 transition-colors">
     <h3 class="font-semibold text-gray-900 dark:text-white">Spring Boot Integration</h3>
-    <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">Build persistent AI agents with Spring Boot and Spring AI</p>
+    <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+      Build persistent AI agents with Spring Boot and Spring AI
+    </p>
   </a>
   <a href="python/getting-started/" class="card p-4 hover:border-primary-500 transition-colors">
     <h3 class="font-semibold text-gray-900 dark:text-white">Python Integration</h3>
-    <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">Build persistent AI agents with Python, FastAPI, and LangGraph patterns</p>
+    <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">
+      Build persistent AI agents with Python, FastAPI, and LangGraph patterns
+    </p>
   </a>
   <a href="configuration/" class="card p-4 hover:border-primary-500 transition-colors">
     <h3 class="font-semibold text-gray-900 dark:text-white">Configuration</h3>
@@ -68,4 +72,4 @@ Memory Service is currently a proof of concept under active development. APIs ma
 ## Getting Help
 
 - **GitHub Issues** - Report bugs or request features on [GitHub](https://github.com/chirino/memory-service/issues)
-{/* - **Discussions** - Ask questions in [GitHub Discussions](https://github.com/chirino/memory-service/discussions) */}
+  {/* - **Discussions** - Ask questions in [GitHub Discussions](https://github.com/chirino/memory-service/discussions) */}

--- a/site/src/pages/docs/python-langchain/conversation-forking.mdx
+++ b/site/src/pages/docs/python-langchain/conversation-forking.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Python Conversation Forking
 description: Branch conversations to explore alternative paths.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide covers conversation forking, letting users branch from any point in a conversation to explore alternative paths.
 
@@ -17,6 +18,7 @@ This guide covers conversation forking, letting users branch from any point in a
 **Starting checkpoint**: This guide starts from [python/examples/langchain/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/python/examples/langchain/doc-checkpoints/03-with-history)
 
 Make sure you've completed the previous guides:
+
 - [Python Getting Started](/docs/python-langchain/getting-started/) - Minimal agent + memory-service checkpointer
 - [Python Conversation History](/docs/python-langchain/conversation-history/) - History recording and conversation APIs
 

--- a/site/src/pages/docs/python-langchain/conversation-history.mdx
+++ b/site/src/pages/docs/python-langchain/conversation-history.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Python Conversation History
 description: Record conversation history and expose APIs for frontend applications.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide continues from [Python Getting Started](/docs/python-langchain/getting-started/) and shows how to record conversation history and expose APIs for frontend applications.
 
@@ -14,6 +15,7 @@ This guide continues from [Python Getting Started](/docs/python-langchain/gettin
 **Starting checkpoint**: View the code from the previous section at [python/examples/langchain/doc-checkpoints/02-with-memory](https://github.com/chirino/memory-service/tree/main/python/examples/langchain/doc-checkpoints/02-with-memory)
 
 Make sure you've completed the [Python Getting Started](/docs/python-langchain/getting-started/) guide first. You should have:
+
 - A working LangChain agent with Memory Service checkpointing
 - Memory Service running via Docker Compose
 - OIDC authentication configured
@@ -26,11 +28,7 @@ In the previous guide, you added conversation memory, but frontend conversation 
 
 To enable that, wire `MemoryServiceHistoryMiddleware` into the agent and bind request context:
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/03-with-history/app.py"
-  lang="python"
-  lines="52-64"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/03-with-history/app.py" lang="python" lines="52-64" />
 
 **What changed**: `MemoryServiceHistoryMiddleware()` is constructed and passed into `create_agent(middleware=[history_middleware])`. The `chat` endpoint wraps the `agent.invoke(...)` call in `with memory_service_scope(conversation_id):` instead of only setting `thread_id` in `configurable`.
 
@@ -74,16 +72,13 @@ curl -NsSfX POST http://localhost:9090/chat/0ef33d7b-11b1-4992-9785-681e222dbcd2
 ## Expose Conversation Entries API
 
 Checkpoint `03` exposes the same conversation endpoints as the Quarkus checkpoint:
+
 - `GET /v1/conversations/{conversation_id}`
 - `GET /v1/conversations/{conversation_id}/entries`
 
 The entries endpoint forces `channel=history` so frontend clients always receive recorded conversation turns.
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/03-with-history/app.py"
-  lang="python"
-  lines="90-105"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/03-with-history/app.py" lang="python" lines="90-105" />
 
 **What changed**: `proxy.list_conversation_entries(...)` is called with the hardcoded `channel="history"` parameter. The `get_conversation` endpoint delegates entirely to the proxy without modification.
 
@@ -152,11 +147,7 @@ curl -sSfX GET http://localhost:9090/v1/conversations/0ef33d7b-11b1-4992-9785-68
 
 To let users see all conversations they can access, expose `GET /v1/conversations`:
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/03-with-history/app.py"
-  lang="python"
-  lines="107-115"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/03-with-history/app.py" lang="python" lines="107-115" />
 
 **What changed**: A new `GET /v1/conversations` endpoint is added that calls `proxy.list_conversations(...)`.
 
@@ -190,6 +181,7 @@ curl -sSfX GET http://localhost:9090/v1/conversations \
 ## Next Steps
 
 Continue to:
+
 - [Indexing and Search](/docs/python-langchain/indexing-and-search/) — Add search indexing and semantic search to your conversations
 - [Conversation Forking](/docs/python-langchain/conversation-forking/) — Branch conversations to explore alternative paths
 - [Response Recording and Resumption](/docs/python-langchain/response-resumption/) — Streaming responses with resume and cancel support

--- a/site/src/pages/docs/python-langchain/dev-setup.mdx
+++ b/site/src/pages/docs/python-langchain/dev-setup.mdx
@@ -3,7 +3,8 @@ layout: ../../../layouts/DocsLayout.astro
 title: Python Dev Setup
 description: Reproducible Python setup using uv and Dockerized dependencies.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
 
 Use [`uv`](https://docs.astral.sh/uv/getting-started/installation/) for deterministic Python environments and lockfile-driven installs. Use Docker for dependency services (memory-service, Keycloak, databases), not as your day-to-day Python package workflow.
 
@@ -21,16 +22,9 @@ This is temporary. After the package is released, you can remove `UV_FIND_LINKS`
 
 ## Baseline Runtime
 
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/02-with-memory/.python-version" lang="text" />
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/02-with-memory/.python-version"
-  lang="text"
-/>
-
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/02-with-memory/pyproject.toml"
-  lang="toml"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/02-with-memory/pyproject.toml" lang="toml" />
 
 This is the minimum dependency set users need to run Memory Service-backed Python examples.
 Until the package is released, `memory-service-langchain` is resolved from the local wheel built in Step 1 (`UV_FIND_LINKS`).

--- a/site/src/pages/docs/python-langchain/getting-started.mdx
+++ b/site/src/pages/docs/python-langchain/getting-started.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Python Getting Started
 description: Step-by-step guide to integrating Memory Service with a Python FastAPI + LangGraph-style agent.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide walks you through a minimal Python agent first using [LangChain](https://docs.langchain.com/oss/python/langchain/overview), then adds incremental memory-service integration. The goal is to keep code changes small while unlocking memory features one step at a time.
 
@@ -18,10 +19,7 @@ Also complete **Step 2** on that page (build local `memory-service-langchain` wh
 
 Create a minimal LangChain agent and expose it over HTTP with FastAPI (no memory-service imports yet):
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/01-basic-agent/app.py"
-  lang="python"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/01-basic-agent/app.py" lang="python" />
 
 `create_agent()` builds a LangChain agent graph with the given model. Passing an empty `tools=[]` list gives a pure chat agent with no tool calls. The `system_prompt` primes every conversation with the agent's role.
 
@@ -31,10 +29,7 @@ The `POST /chat` endpoint accepts a raw text body and returns raw text — no JS
 
 Add LangChain dependencies:
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/01-basic-agent/pyproject.toml"
-  lang="toml"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/01-basic-agent/pyproject.toml" lang="toml" />
 
 <TestScenario checkpoint="python/examples/langchain/doc-checkpoints/01-basic-agent">
 
@@ -71,11 +66,7 @@ Checkpoint `02` is built from checkpoint `01` with three additions.
 
 ### Add a checkpointer and wire it into the agent
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/02-with-memory/app.py"
-  lang="python"
-  lines="46-56"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/02-with-memory/app.py" lang="python" lines="46-56" />
 
 **What changed**: `MemoryServiceCheckpointSaver()` is created and passed to `create_agent()` as `checkpointer=`.
 
@@ -85,11 +76,7 @@ Checkpoint `02` is built from checkpoint `01` with three additions.
 
 ### Change the endpoint to accept a `conversation_id`
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/02-with-memory/app.py"
-  lang="python"
-  lines="59-68"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/02-with-memory/app.py" lang="python" lines="59-68" />
 
 **What changed**: The route changes from `POST /chat` to `POST /chat/{conversation_id}`, and the agent invocation passes `{"configurable": {"thread_id": conversation_id}}`.
 

--- a/site/src/pages/docs/python-langchain/index.mdx
+++ b/site/src/pages/docs/python-langchain/index.mdx
@@ -5,6 +5,7 @@ description: Integrate Memory Service with Python FastAPI + LangGraph-style agen
 ---
 
 These guides walk through an incremental Python integration path for LangChain/LangGraph developers:
+
 - Start from a minimal working chat app
 - Turn on memory-service features one by one
 - Keep code changes small and explicit using checkpoint-based diffs
@@ -19,24 +20,31 @@ Also complete **Step 2** on that page (build local `memory-service-langchain` wh
 ## Tutorial Path
 
 ### [Getting Started](/docs/python-langchain/getting-started/)
+
 Build a minimal Python agent, then enable memory-backed conversations.
 
 ### [Conversation History](/docs/python-langchain/conversation-history/)
+
 Record USER/AI turns in the history channel and expose read APIs.
 
 ### [Indexing and Search](/docs/python-langchain/indexing-and-search/)
+
 Add indexed history content and conversation search.
 
 ### [Conversation Forking](/docs/python-langchain/conversation-forking/)
+
 Pass fork metadata and list conversation forks.
 
 ### [Response Recording and Resumption](/docs/python-langchain/response-resumption/)
+
 Stream responses and support resume-check, resume, and cancel.
 
 ### [Sharing](/docs/python-langchain/sharing/)
+
 Add memberships and ownership transfer APIs.
 
 ## Reference
 
 ### [Dev Setup](/docs/python-langchain/dev-setup/)
+
 Reproducible `uv` workflow, Dockerized dependencies, and fast Python-only docs tests.

--- a/site/src/pages/docs/python-langchain/indexing-and-search.mdx
+++ b/site/src/pages/docs/python-langchain/indexing-and-search.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Python Indexing and Search
 description: Add search indexing and semantic search to your conversations.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide continues from [Conversation History](/docs/python-langchain/conversation-history/) and shows how to add search indexing to history entries and expose a search API for frontend applications.
 
@@ -31,11 +32,7 @@ This gives you a redaction point. You can remove sensitive data from `indexedCon
 
 The simplest provider is pass-through:
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/07-with-search/app.py"
-  lang="python"
-  lines="54-61"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/07-with-search/app.py" lang="python" lines="54-61" />
 
 **What changed**: `pass_through_indexed_content(text, role)` is defined and passed to `MemoryServiceHistoryMiddleware(indexed_content_provider=...)`. Without an `indexed_content_provider`, history entries are written with no `indexedContent` field and therefore cannot be searched.
 
@@ -56,11 +53,7 @@ def redacting_indexed_content(text: str, role: str) -> str:
 
 Expose `POST /v1/conversations/search` so frontend apps can query across conversations:
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/07-with-search/app.py"
-  lang="python"
-  lines="127-130"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/07-with-search/app.py" lang="python" lines="127-130" />
 
 **Why**: The search query, search type (`auto`, `semantic`, `fulltext`, or a concrete type array like `["semantic","fulltext"]`), and pagination options all live in the JSON request body, so the endpoint requires no query-parameter parsing — it just reads the body and passes it through. The Memory Service returns scored results with highlights, which the proxy relays back to the caller. Exposing the endpoint from the agent app rather than pointing the frontend directly at the Memory Service keeps all traffic behind a single origin and ensures the user's Bearer token is validated in one place.
 
@@ -121,5 +114,6 @@ curl -sSfX POST http://localhost:9090/v1/conversations/search \
 ## Next Steps
 
 Continue to:
+
 - [Conversation Forking](/docs/python-langchain/conversation-forking/) - Branch conversations to explore alternative paths
 - [Response Recording and Resumption](/docs/python-langchain/response-resumption/) - Streaming responses with resume and cancel support

--- a/site/src/pages/docs/python-langchain/response-resumption.mdx
+++ b/site/src/pages/docs/python-langchain/response-resumption.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Python Response Recording and Resumption
 description: Streaming responses with resume-check, resume, and cancel endpoints.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide covers streaming responses with recording, resumption, and cancellation so users can reconnect after a disconnect and continue where they left off.
 
@@ -16,6 +17,7 @@ For the protocol and behavior model, see [Response Recording and Resumption Conc
 **Starting checkpoint**: This guide starts from [python/examples/langchain/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/python/examples/langchain/doc-checkpoints/03-with-history)
 
 Make sure you've completed:
+
 - [Python Getting Started](/docs/python-langchain/getting-started/) - Minimal agent + memory checkpointer
 - [Python Conversation History](/docs/python-langchain/conversation-history/) - History recording and conversation APIs
 
@@ -161,5 +163,6 @@ curl -sSfX POST http://localhost:9090/v1/conversations/2946ccfc-cf26-43e1-87fc-f
 ## Next Steps
 
 Continue to:
+
 - [Sharing](/docs/python-langchain/sharing/) - Membership and ownership transfer APIs
 - [Indexing and Search](/docs/python-langchain/indexing-and-search/) - Indexed content and semantic/full-text search

--- a/site/src/pages/docs/python-langchain/sharing.mdx
+++ b/site/src/pages/docs/python-langchain/sharing.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Python Sharing
 description: Membership and ownership transfer APIs in the Python tutorial app.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide shows how to add conversation sharing and ownership transfer APIs to the Python tutorial app.
 
@@ -17,6 +18,7 @@ This guide shows how to add conversation sharing and ownership transfer APIs to 
 **Starting checkpoint**: This guide starts from [python/examples/langchain/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/python/examples/langchain/doc-checkpoints/03-with-history)
 
 Make sure you've completed:
+
 - [Python Conversation History](/docs/python-langchain/conversation-history/) - History recording and conversation APIs
 - Multiple users in Keycloak (`bob`, `alice`, `charlie`)
 
@@ -26,11 +28,7 @@ Also complete **Step 2** in [Python Dev Setup](/docs/python-langchain/dev-setup/
 
 Checkpoint `06` adds membership endpoint passthroughs to the tutorial app:
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/06-sharing/app.py"
-  lang="python"
-  lines="127-152"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/06-sharing/app.py" lang="python" lines="127-152" />
 
 **Why**: These endpoints are thin pass-throughs so the agent app does not need to duplicate any membership logic. The `MemoryServiceProxy` injects the agent API key header automatically, while the user's Bearer token (forwarded by `install_fastapi_authorization_middleware`) provides identity for access-level enforcement on the Memory Service side. `parse_optional_json` is used on write operations to gracefully handle requests with empty bodies.
 
@@ -38,11 +36,7 @@ Checkpoint `06` adds membership endpoint passthroughs to the tutorial app:
 
 Checkpoint `06` also exposes ownership transfer APIs:
 
-<CodeFromFile
-  file="python/examples/langchain/doc-checkpoints/06-sharing/app.py"
-  lang="python"
-  lines="155-180"
-/>
+<CodeFromFile file="python/examples/langchain/doc-checkpoints/06-sharing/app.py" lang="python" lines="155-180" />
 
 **Why**: Ownership transfer is a two-step handshake: the current owner creates a pending transfer, and the recipient accepts it, which atomically promotes the recipient to owner and demotes the previous owner to manager. Exposing list and delete allows both parties to view outstanding transfers and to cancel or decline them. The DELETE endpoint uses `parse_optional_json` because HTTP DELETE requests from some clients may omit a body entirely.
 

--- a/site/src/pages/docs/python-langgraph/conversation-forking.mdx
+++ b/site/src/pages/docs/python-langgraph/conversation-forking.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: LangGraph Conversation Forking
 description: Branch conversations to explore alternative paths.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide covers conversation forking, letting users branch from any point in a conversation to explore alternative paths.
 
@@ -17,6 +18,7 @@ This guide covers conversation forking, letting users branch from any point in a
 **Starting checkpoint**: This guide starts from [python/examples/langgraph/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/python/examples/langgraph/doc-checkpoints/03-with-history)
 
 Make sure you've completed the previous guides:
+
 - [LangGraph Getting Started](/docs/python-langgraph/getting-started/) - Minimal agent + memory-service checkpointer
 - [LangGraph Conversation History](/docs/python-langgraph/conversation-history/) - History recording and conversation APIs
 

--- a/site/src/pages/docs/python-langgraph/conversation-history.mdx
+++ b/site/src/pages/docs/python-langgraph/conversation-history.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: LangGraph Conversation History
 description: Record conversation history and expose APIs for frontend applications.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide continues from [LangGraph Getting Started](/docs/python-langgraph/getting-started/) and shows how to record conversation history and expose APIs for frontend applications.
 
@@ -14,6 +15,7 @@ This guide continues from [LangGraph Getting Started](/docs/python-langgraph/get
 **Starting checkpoint**: View the code from the previous section at [python/examples/langgraph/doc-checkpoints/02-with-checkpointing](https://github.com/chirino/memory-service/tree/main/python/examples/langgraph/doc-checkpoints/02-with-checkpointing)
 
 Make sure you've completed the [LangGraph Getting Started](/docs/python-langgraph/getting-started/) guide first. You should have:
+
 - A working LangGraph agent with Memory Service checkpointing
 - Memory Service running via Docker Compose
 - OIDC authentication configured
@@ -26,11 +28,7 @@ In the previous guide, you added conversation memory through LangGraph checkpoin
 
 To enable that, wire `MemoryServiceHistoryMiddleware` into the `call_model` node and bind request context:
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/03-with-history/app.py"
-  lang="python"
-  lines="27-47"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/03-with-history/app.py" lang="python" lines="27-47" />
 
 **What changed**: `MemoryServiceHistoryMiddleware` is imported and instantiated, `call_model` is updated to call `history_middleware.wrap_model_call(user_text, lambda: model.invoke(messages))`, and the endpoint wraps `graph.ainvoke()` in a `with memory_service_scope(conversation_id):` block.
 
@@ -75,11 +73,7 @@ curl -NsSfX POST http://localhost:9090/chat/53d23c96-6b29-4fbb-879d-db18bf4d94ff
 
 Checkpoint `03` exposes conversation endpoints for frontend apps:
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/03-with-history/app.py"
-  lang="python"
-  lines="76-96"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/03-with-history/app.py" lang="python" lines="76-96" />
 
 **What changed**: `GET /v1/conversations/{conversation_id}` and `GET /v1/conversations/{conversation_id}/entries` are added, both implemented by forwarding to `MemoryServiceProxy`. The entries endpoint hard-codes `channel="history"` so callers always receive recorded conversation turns.
 
@@ -148,11 +142,7 @@ curl -sSfX GET http://localhost:9090/v1/conversations/53d23c96-6b29-4fbb-879d-db
 
 To let users see all conversations they can access, expose `GET /v1/conversations`:
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/03-with-history/app.py"
-  lang="python"
-  lines="99-107"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/03-with-history/app.py" lang="python" lines="99-107" />
 
 **What changed**: `GET /v1/conversations` is added, forwarding `mode`, `afterCursor`, `limit`, and `query` parameters to `proxy.list_conversations()`.
 
@@ -186,6 +176,7 @@ curl -sSfX GET http://localhost:9090/v1/conversations \
 ## Next Steps
 
 Continue to:
+
 - [Indexing and Search](/docs/python-langgraph/indexing-and-search/) — Add search indexing and semantic search to your conversations
 - [Conversation Forking](/docs/python-langgraph/conversation-forking/) — Branch conversations to explore alternative paths
 - [Response Recording and Resumption](/docs/python-langgraph/response-resumption/) — Streaming responses with resume and cancel support

--- a/site/src/pages/docs/python-langgraph/dev-setup.mdx
+++ b/site/src/pages/docs/python-langgraph/dev-setup.mdx
@@ -3,7 +3,8 @@ layout: ../../../layouts/DocsLayout.astro
 title: LangGraph Dev Setup
 description: Reproducible Python setup using uv and Dockerized dependencies.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
 
 Use [`uv`](https://docs.astral.sh/uv/getting-started/installation/) for deterministic Python environments and lockfile-driven installs. Use Docker for dependency services (memory-service, Keycloak, databases), not as your day-to-day Python package workflow.
 
@@ -29,15 +30,9 @@ This is temporary. After the packages are released, you can remove `UV_FIND_LINK
 
 ## Baseline Runtime
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/02-with-checkpointing/.python-version"
-  lang="text"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/02-with-checkpointing/.python-version" lang="text" />
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/02-with-checkpointing/pyproject.toml"
-  lang="toml"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/02-with-checkpointing/pyproject.toml" lang="toml" />
 
 This is the minimum dependency set users need to run Memory Service-backed LangGraph examples.
 Until the package is released, `memory-service-langchain` is resolved from the local wheel built in Step 1 (`UV_FIND_LINKS`).

--- a/site/src/pages/docs/python-langgraph/getting-started.mdx
+++ b/site/src/pages/docs/python-langgraph/getting-started.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: LangGraph Getting Started
 description: Step-by-step guide to integrating Memory Service with a Python FastAPI + LangGraph agent.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide walks you through a minimal LangGraph chatbot first, then adds incremental memory-service integration. The goal is to keep code changes small while unlocking memory features one step at a time.
 
@@ -18,19 +19,13 @@ Also complete **Step 2** on that page (build local `memory-service-langchain` wh
 
 Create a minimal LangGraph chatbot using `StateGraph(MessagesState)` and expose it over HTTP with FastAPI (no memory-service imports yet):
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/01-basic-langgraph/app.py"
-  lang="python"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/01-basic-langgraph/app.py" lang="python" />
 
 **Why**: `StateGraph(MessagesState)` is LangGraph's way of describing the computation as a directed graph where each node transforms state. `MessagesState` gives the graph a built-in `messages` list so nodes can append to it naturally. Starting with a single node keeps the structure clear before adding memory features.
 
 Add LangGraph dependencies:
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/01-basic-langgraph/pyproject.toml"
-  lang="toml"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/01-basic-langgraph/pyproject.toml" lang="toml" />
 
 The checkpoint reads model configuration from environment variables (`OPENAI_MODEL`, `OPENAI_BASE_URL`, `OPENAI_API_KEY`) so local dev and `site-tests` can inject provider settings without code changes.
 

--- a/site/src/pages/docs/python-langgraph/index.mdx
+++ b/site/src/pages/docs/python-langgraph/index.mdx
@@ -5,6 +5,7 @@ description: Integrate Memory Service with Python FastAPI + LangGraph agents.
 ---
 
 These guides walk through an incremental Python integration path for [LangGraph](https://langchain-ai.github.io/langgraph/) developers:
+
 - Start from a minimal stateless LangGraph chatbot
 - Turn on memory-service features one by one
 - Keep code changes small and explicit using checkpoint-based diffs
@@ -19,27 +20,35 @@ Also complete **Step 2** on that page (build local `memory-service-langchain` wh
 ## Tutorial Path
 
 ### [Getting Started](/docs/python-langgraph/getting-started/)
+
 Build a minimal LangGraph chatbot, then enable memory-backed conversations with persistent checkpointing.
 
 ### [Conversation History](/docs/python-langgraph/conversation-history/)
+
 Record USER/AI turns in the history channel and expose read APIs.
 
 ### [Indexing and Search](/docs/python-langgraph/indexing-and-search/)
+
 Add indexed history content and conversation search.
 
 ### [Conversation Forking](/docs/python-langgraph/conversation-forking/)
+
 Pass fork metadata and list conversation forks.
 
 ### [Response Recording and Resumption](/docs/python-langgraph/response-resumption/)
+
 Stream responses and support resume-check, resume, and cancel.
 
 ### [Sharing](/docs/python-langgraph/sharing/)
+
 Add memberships and ownership transfer APIs.
 
 ### [Episodic Memories](/docs/python-langgraph/memories/)
+
 Use the LangGraph `BaseStore` backend to give your agent persistent per-user memories.
 
 ## Reference
 
 ### [Dev Setup](/docs/python-langgraph/dev-setup/)
+
 Reproducible `uv` workflow, Dockerized dependencies, and fast Python-only docs tests.

--- a/site/src/pages/docs/python-langgraph/indexing-and-search.mdx
+++ b/site/src/pages/docs/python-langgraph/indexing-and-search.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: LangGraph Indexing and Search
 description: Add search indexing and semantic search to your conversations.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide continues from [Conversation History](/docs/python-langgraph/conversation-history/) and shows how to add search indexing to history entries and expose a search API for frontend applications.
 
@@ -31,11 +32,7 @@ This gives you a redaction point. You can remove sensitive data from `indexedCon
 
 The simplest provider is pass-through:
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/07-with-search/app.py"
-  lang="python"
-  lines="30-40"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/07-with-search/app.py" lang="python" lines="30-40" />
 
 **What changed**: A `pass_through_indexed_content(text, role)` function is defined and passed to `MemoryServiceHistoryMiddleware(indexed_content_provider=pass_through_indexed_content)`.
 
@@ -56,11 +53,7 @@ def redacting_indexed_content(text: str, role: str) -> str:
 
 Expose `POST /v1/conversations/search` so frontend apps can query across conversations:
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/07-with-search/app.py"
-  lang="python"
-  lines="88-90"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/07-with-search/app.py" lang="python" lines="88-90" />
 
 **Why**: Frontend apps need a single endpoint to run full-text and semantic search across all conversations the user has access to. `searchType` can be `auto`, a concrete type (`semantic` or `fulltext`), or an array of concrete types such as `["semantic","fulltext"]`. Proxying through the agent app means the user's bearer token is forwarded to Memory Service so only conversations the user can read are returned in results.
 
@@ -121,6 +114,7 @@ curl -sSfX POST http://localhost:9090/v1/conversations/search \
 ## Next Steps
 
 Continue to:
+
 - [Conversation Forking](/docs/python-langgraph/conversation-forking/) - Branch conversations to explore alternative paths
 - [Response Recording and Resumption](/docs/python-langgraph/response-resumption/) - Streaming responses with resume and cancel support
 - [Episodic Memories](/docs/python-langgraph/memories/) - Persistent per-user memories using the LangGraph BaseStore

--- a/site/src/pages/docs/python-langgraph/memories.mdx
+++ b/site/src/pages/docs/python-langgraph/memories.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: LangGraph Episodic Memories
 description: Add persistent per-user memories to a LangGraph agent using the Memory Service episodic store.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide adds the Memory Service episodic store to your LangGraph agent. Unlike conversation checkpointing — which persists the message thread for a single conversation — episodic memories cross conversation boundaries, giving the agent a persistent long-term view of each user.
 
@@ -19,6 +20,7 @@ Memory values are stored encrypted at rest; metadata, derived attributes, and ca
 **Starting checkpoint**: This guide starts from [python/examples/langgraph/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/python/examples/langgraph/doc-checkpoints/03-with-history)
 
 Make sure you've completed:
+
 - [LangGraph Getting Started](/docs/python-langgraph/getting-started/) — checkpointing and conversation memory
 - [LangGraph Conversation History](/docs/python-langgraph/conversation-history/) — history recording
 
@@ -34,6 +36,7 @@ cd python/langgraph && uv build && export UV_FIND_LINKS="$UV_FIND_LINKS:$PWD/dis
 The Memory Service provides a LangGraph `BaseStore` implementation (`AsyncMemoryServiceStore`) that stores and retrieves arbitrary key-value memories, namespaced per user.
 
 Memories are:
+
 - **Isolated per user** via namespace: `("user", user_id, "memories")`
 - **Recalled before each response** with `store.asearch()`
 - **Saved after each turn** with `store.aput()`
@@ -52,11 +55,7 @@ Checkpoint `30` adds episodic memories on top of the existing checkpointing and 
 
 ### Imports
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/30-memories/app.py"
-  lang="python"
-  lines="1-20"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/30-memories/app.py" lang="python" lines="1-20" />
 
 **What changed**: `RunnableConfig` is imported from `langchain_core.runnables` and `AsyncMemoryServiceStore` is imported from `memory_service_langgraph`. `uuid` is also imported to generate unique memory keys.
 
@@ -64,19 +63,15 @@ Checkpoint `30` adds episodic memories on top of the existing checkpointing and 
 
 `AsyncMemoryServiceStore` reads the Memory Service base URL from the environment:
 
-| Variable | Default | Purpose |
-|---|---|---|
+| Variable             | Default                 | Purpose                 |
+| -------------------- | ----------------------- | ----------------------- |
 | `MEMORY_SERVICE_URL` | `http://localhost:8083` | Memory Service base URL |
 
 The bearer token is forwarded from each incoming `Authorization` header — no static token configuration required.
 
 ### The `call_model` Node
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/30-memories/app.py"
-  lang="python"
-  lines="36-68"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/30-memories/app.py" lang="python" lines="36-68" />
 
 **What changed**: `call_model` becomes `async` and accepts a second `config: RunnableConfig` argument. It extracts `user_id` and `token` from `config["configurable"]`, builds a namespace `("user", user_id, "memories")`, then uses `AsyncMemoryServiceStore(token=token)` as an async context manager to recall memories before the model call and save the user's message as a new memory afterward.
 
@@ -90,11 +85,7 @@ The `history_middleware.wrap_model_call(...)` line records the user/AI turn to t
 
 ### Graph, App, and Endpoint
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/30-memories/app.py"
-  lang="python"
-  lines="71-101"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/30-memories/app.py" lang="python" lines="71-101" />
 
 **What changed**: The graph is compiled and the app is set up as before, but the endpoint changes from `POST /chat/{conversation_id}` to `POST /chat/{user_id}/{conversation_id}`. The endpoint extracts the bearer token from the `Authorization` header and passes `user_id`, `conversation_id` (as `thread_id`), and `token` through `config["configurable"]` into the graph.
 

--- a/site/src/pages/docs/python-langgraph/response-resumption.mdx
+++ b/site/src/pages/docs/python-langgraph/response-resumption.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: LangGraph Response Recording and Resumption
 description: Streaming responses with resume-check, resume, and cancel endpoints.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide covers streaming responses with recording, resumption, and cancellation so users can reconnect after a disconnect and continue where they left off.
 
@@ -16,6 +17,7 @@ For the protocol and behavior model, see [Response Recording and Resumption Conc
 **Starting checkpoint**: This guide starts from [python/examples/langgraph/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/python/examples/langgraph/doc-checkpoints/03-with-history)
 
 Make sure you've completed:
+
 - [LangGraph Getting Started](/docs/python-langgraph/getting-started/) - Minimal agent + memory checkpointer
 - [LangGraph Conversation History](/docs/python-langgraph/conversation-history/) - History recording and conversation APIs
 
@@ -141,5 +143,6 @@ curl -sSfX POST http://localhost:9090/v1/conversations/12b08143-3edb-4a86-a34e-e
 ## Next Steps
 
 Continue to:
+
 - [Sharing](/docs/python-langgraph/sharing/) - Membership and ownership transfer APIs
 - [Indexing and Search](/docs/python-langgraph/indexing-and-search/) - Indexed content and semantic/full-text search

--- a/site/src/pages/docs/python-langgraph/sharing.mdx
+++ b/site/src/pages/docs/python-langgraph/sharing.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: LangGraph Sharing
 description: Membership and ownership transfer APIs in the LangGraph tutorial app.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide shows how to add conversation sharing and ownership transfer APIs to the LangGraph tutorial app.
 
@@ -17,6 +18,7 @@ This guide shows how to add conversation sharing and ownership transfer APIs to 
 **Starting checkpoint**: This guide starts from [python/examples/langgraph/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/python/examples/langgraph/doc-checkpoints/03-with-history)
 
 Make sure you've completed:
+
 - [LangGraph Conversation History](/docs/python-langgraph/conversation-history/) - History recording and conversation APIs
 - Multiple users in Keycloak (`bob`, `alice`, `charlie`)
 
@@ -26,11 +28,7 @@ Also complete **Step 2** in [LangGraph Dev Setup](/docs/python-langgraph/dev-set
 
 Checkpoint `06` adds membership endpoint passthroughs to the tutorial app:
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/06-sharing/app.py"
-  lang="python"
-  lines="86-109"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/06-sharing/app.py" lang="python" lines="86-109" />
 
 **What changed**: `GET /v1/conversations/{conversation_id}/memberships`, `POST /v1/conversations/{conversation_id}/memberships`, `PATCH /v1/conversations/{conversation_id}/memberships/{user_id}`, and `DELETE /v1/conversations/{conversation_id}/memberships/{user_id}` are added. Each delegates to the corresponding `proxy.*_membership` method.
 
@@ -40,11 +38,7 @@ Checkpoint `06` adds membership endpoint passthroughs to the tutorial app:
 
 Checkpoint `06` also exposes ownership transfer APIs:
 
-<CodeFromFile
-  file="python/examples/langgraph/doc-checkpoints/06-sharing/app.py"
-  lang="python"
-  lines="112-135"
-/>
+<CodeFromFile file="python/examples/langgraph/doc-checkpoints/06-sharing/app.py" lang="python" lines="112-135" />
 
 **What changed**: `GET /v1/ownership-transfers`, `POST /v1/ownership-transfers`, `POST /v1/ownership-transfers/{transfer_id}/accept`, and `DELETE /v1/ownership-transfers/{transfer_id}` are added, all forwarded through `proxy.*_ownership_transfer` methods.
 

--- a/site/src/pages/docs/quarkus/attachments.mdx
+++ b/site/src/pages/docs/quarkus/attachments.mdx
@@ -3,11 +3,12 @@ layout: ../../../layouts/DocsLayout.astro
 title: Attachments
 description: Proxy attachment upload, download, and management APIs from your agent app.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide covers proxying attachment operations — upload, download, signed URLs, and deletion — from your agent app to the Memory Service.
 
@@ -19,6 +20,7 @@ This guide covers proxying attachment operations — upload, download, signed UR
 **Starting checkpoint**: This guide starts from [java/quarkus/examples/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/java/quarkus/examples/doc-checkpoints/03-with-history)
 
 Make sure you've completed the previous guides:
+
 - [Getting Started](/docs/quarkus/getting-started/) - Basic memory service integration
 - [Conversation History](/docs/quarkus/conversation-history/) - History recording and APIs
 
@@ -69,7 +71,7 @@ Update `application.properties` to allow unauthenticated access to the signed do
   lang="properties"
   before={1}
   after={1}
-match="quarkus.http.auth.permission.attachment-download.paths"
+  match="quarkus.http.auth.permission.attachment-download.paths"
 />
 
 The `attachment-download` permission must allow unauthenticated access to `/v1/attachments/download/*` since signed URLs are meant to be used without an Authorization header. The `api` permission requires authentication on all other `/v1/*` endpoints. Quarkus matches the most specific path first, so the order in the properties file doesn't matter.

--- a/site/src/pages/docs/quarkus/conversation-forking.mdx
+++ b/site/src/pages/docs/quarkus/conversation-forking.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Conversation Forking
 description: Branch conversations to explore alternative paths.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide covers conversation forking — letting users branch off from any point in a conversation to explore alternative paths.
 
@@ -17,6 +18,7 @@ This guide covers conversation forking — letting users branch off from any poi
 **Starting checkpoint**: This guide starts from [java/quarkus/examples/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/java/quarkus/examples/doc-checkpoints/03-with-history)
 
 Make sure you've completed the previous guides:
+
 - [Getting Started](/docs/quarkus/getting-started/) - Basic memory service integration
 - [Conversation History](/docs/quarkus/conversation-history/) - History recording and APIs
 
@@ -42,7 +44,7 @@ Add this method to `ConversationsResource.java` to list forks for a conversation
   lang="java"
   before={2}
   after={1}
-match="public Response listConversationForks"
+  match="public Response listConversationForks"
 />
 
 **What changed**: Added a `listConversationForks` endpoint at `GET /{conversationId}/forks` that calls `proxy.listConversationForks`. **Why**: Frontends need to discover all branches stemming from a conversation so users can navigate between them. The endpoint returns the root conversation and all its forks in a flat list, each annotated with its `forkedAtConversationId` so the UI can reconstruct the branch tree.

--- a/site/src/pages/docs/quarkus/conversation-history.mdx
+++ b/site/src/pages/docs/quarkus/conversation-history.mdx
@@ -3,11 +3,12 @@ layout: ../../../layouts/DocsLayout.astro
 title: Conversation History
 description: Record conversation history and expose APIs for frontend applications.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide continues from [Getting Started](/docs/quarkus/getting-started/) and shows how to record conversation history and expose APIs for frontend applications.
 
@@ -16,13 +17,14 @@ This guide continues from [Getting Started](/docs/quarkus/getting-started/) and 
 **Starting checkpoint**: View the code from the previous section at [java/quarkus/examples/doc-checkpoints/02-with-memory](https://github.com/chirino/memory-service/tree/main/java/quarkus/examples/doc-checkpoints/02-with-memory)
 
 Make sure you've completed the [Getting Started](/docs/quarkus/getting-started/) guide first. You should have:
+
 - A working Quarkus agent with the Memory Service extension
 - Memory Service running via Docker Compose
 - OIDC authentication configured
 
 ## Enable Conversation History Recording
 
-In the [previous guide](/docs/quarkus/getting-started/), you added conversation memory, but messages don't appear in the UI yet. That's because we're only storing *agent memory*, not the *conversation history* that users see.
+In the [previous guide](/docs/quarkus/getting-started/), you added conversation memory, but messages don't appear in the UI yet. That's because we're only storing _agent memory_, not the _conversation history_ that users see.
 
 To display conversation history in a frontend UI, wrap your agent with the `@RecordConversation` interceptor. This records both user messages and agent responses to the `history` channel (separate from the `memory` channel used by agents).
 
@@ -41,7 +43,7 @@ Update `ChatResource.java` to inject `HistoryRecordingAgent` instead of `Agent`:
   file="java/quarkus/examples/doc-checkpoints/03-with-history/src/main/java/org/acme/ChatResource.java"
   lang="java"
   before={2}
-match="@Inject HistoryRecordingAgent agent"
+  match="@Inject HistoryRecordingAgent agent"
 />
 
 **What changed**: The injected field was changed from `Agent` to `HistoryRecordingAgent`. **Why**: Routing calls through `HistoryRecordingAgent` instead of `Agent` directly activates the `@RecordConversation` interceptor, so every exchange is automatically persisted to the history channel without any additional code in the resource class.
@@ -95,7 +97,7 @@ add a jackson dependency to enable JSON serialization/deserialization to the `po
   lang="xml"
   before={2}
   after={1}
-match="quarkus-rest-jackson"
+  match="quarkus-rest-jackson"
 />
 
 **What changed**: Added the `quarkus-rest-jackson` dependency. **Why**: This enables automatic JSON serialization and deserialization for JAX-RS responses, which is needed for the conversation and entry list endpoints that return JSON from the Memory Service.
@@ -104,7 +106,8 @@ Then create a REST resource that proxies requests to Memory Service:
 
 <CodeFromFile
   file="java/quarkus/examples/doc-checkpoints/03-with-history/src/main/java/org/acme/ConversationsResource.java"
-  lang="java"/>
+  lang="java"
+/>
 
 **What changed**: Created `ConversationsResource` with `getConversation` and `listConversationEntries` endpoints that delegate to an injected `MemoryServiceProxy`. **Why**: Agent apps should expose a subset of the Memory Service API to their frontends rather than giving clients direct access. The `MemoryServiceProxy` adds the service account API key for Memory Service authentication and passes through the caller's Bearer token so the Memory Service can enforce per-user access control.
 
@@ -185,7 +188,7 @@ To let users browse all their conversations, add a listing method to `Conversati
   lang="java"
   before={2}
   after={6}
-match="public Response listConversations"
+  match="public Response listConversations"
 />
 
 **What changed**: Added a `listConversations` endpoint that accepts `mode`, `afterCursor`, `limit`, and `query` query parameters and forwards them to `MemoryServiceProxy`. **Why**: This gives frontends a paginated, filterable view of a user's conversations. The `mode` parameter can restrict results to conversations owned by the user or ones shared with them, while `query` enables keyword filtering without requiring a separate search index.
@@ -229,6 +232,7 @@ curl -sSfX GET http://localhost:9090/v1/conversations \
 ## Next Steps
 
 Continue to:
+
 - [Indexing and Search](/docs/quarkus/indexing-and-search/) — Add search indexing and semantic search to your conversations
 - [Conversation Forking](/docs/quarkus/conversation-forking/) — Branch conversations to explore alternative paths
 - [Response Recording and Resumption](/docs/quarkus/response-resumption/) — Streaming responses with resume and cancel support

--- a/site/src/pages/docs/quarkus/dev-services.mdx
+++ b/site/src/pages/docs/quarkus/dev-services.mdx
@@ -3,8 +3,9 @@ layout: ../../../layouts/DocsLayout.astro
 title: Dev Services
 description: Automatic memory-service container startup for development and testing.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
 
 The Memory Service extension provides **Dev Services** that automatically start a memory-service container in development mode. This eliminates the need to manually configure and run the memory-service separately, making local development much easier.
 
@@ -32,6 +33,7 @@ When you run your Quarkus application in dev mode (`mvn quarkus:dev`), the exten
    - `memory-service.client.api-key` - The API key (generated or from your config)
 
 The memory-service container automatically connects to:
+
 - **PostgreSQL** dev service (if available) - for the main datastore
 - **Keycloak** dev service (if available) - for OIDC authentication
 - **Redis** dev service (if available and `memory-service.cache.type=redis`) - for caching
@@ -98,26 +100,35 @@ The memory-service container requires either PostgreSQL or MongoDB. Add one of t
 
 **PostgreSQL (Recommended):**
 
-<Code lang="xml" code={`<dependency>
+<Code
+  lang="xml"
+  code={`<dependency>
   <groupId>io.quarkus</groupId>
   <artifactId>quarkus-jdbc-postgresql</artifactId>
-</dependency>`} />
+</dependency>`}
+/>
 
 **MongoDB:**
 
-<Code lang="xml" code={`<dependency>
+<Code
+  lang="xml"
+  code={`<dependency>
   <groupId>io.quarkus</groupId>
   <artifactId>quarkus-mongodb-client</artifactId>
-</dependency>`} />
+</dependency>`}
+/>
 
 ### Required: OIDC Dev Service
 
 The memory-service container requires Keycloak for authentication. Add this dependency:
 
-<Code lang="xml" code={`<dependency>
+<Code
+  lang="xml"
+  code={`<dependency>
   <groupId>io.quarkus</groupId>
   <artifactId>quarkus-oidc</artifactId>
-</dependency>`} />
+</dependency>`}
+/>
 
 ### Optional: Cache Dev Services
 
@@ -125,17 +136,23 @@ If you're using response recording and resumption with Redis or Infinispan, add 
 
 **Redis (for `memory-service.cache.type=redis`):**
 
-<Code lang="xml" code={`<dependency>
+<Code
+  lang="xml"
+  code={`<dependency>
   <groupId>io.quarkus</groupId>
   <artifactId>quarkus-redis-client</artifactId>
-</dependency>`} />
+</dependency>`}
+/>
 
 **Infinispan (for `memory-service.cache.type=infinispan`):**
 
-<Code lang="xml" code={`<dependency>
+<Code
+  lang="xml"
+  code={`<dependency>
   <groupId>io.quarkus</groupId>
   <artifactId>quarkus-infinispan-client</artifactId>
-</dependency>`} />
+</dependency>`}
+/>
 
 ## Full `pom.xml` Example
 
@@ -150,18 +167,21 @@ Here's a complete `pom.xml` example showing all the dependencies needed for Dev 
   </dependency>
 
   <!-- PostgreSQL Dev Service (required) -->
-  <dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-jdbc-postgresql</artifactId>
-  </dependency>
+
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-jdbc-postgresql</artifactId>
+</dependency>
 
   <!-- OIDC Dev Service (required) -->
-  <dependency>
-    <groupId>io.quarkus</groupId>
-    <artifactId>quarkus-oidc</artifactId>
-  </dependency>
+
+<dependency>
+  <groupId>io.quarkus</groupId>
+  <artifactId>quarkus-oidc</artifactId>
+</dependency>
 
   <!-- Redis Dev Service (optional, for response recording and resumption) -->
+
   <dependency>
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-redis-client</artifactId>
@@ -174,13 +194,7 @@ And the corresponding `application.properties`:
 memory-service.cache.type=redis
 
 # OIDC configuration
+
 quarkus.oidc.client-id=memory-service-client
 quarkus.oidc.credentials.secret=change-me`} />
 
-{/* 
-## Next Steps
-
-- [Getting Started](/docs/quarkus/getting-started/) - Learn how to integrate Memory Service with your agent
-- [Response Recording and Resumption](/docs/quarkus/response-resumption/) - Streaming responses with resume and cancel support
-- [Configuration](/docs/configuration/) - All configuration options 
-*/}

--- a/site/src/pages/docs/quarkus/getting-started.mdx
+++ b/site/src/pages/docs/quarkus/getting-started.mdx
@@ -3,12 +3,12 @@ layout: ../../../layouts/DocsLayout.astro
 title: Quarkus Getting Started
 description: Step-by-step guide to integrating Memory Service with your Quarkus AI agent.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
 
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide walks you through integrating Memory Service with a Quarkus AI agent. You'll start with basic chat memory and can progressively add features in the follow-up guides.
 
@@ -18,7 +18,7 @@ Make sure you've completed the [prerequisites](/docs/quarkus/) before starting t
 
 **Starting checkpoint**: View the complete code at [java/quarkus/examples/doc-checkpoints/01-basic-agent](https://github.com/chirino/memory-service/tree/main/java/quarkus/examples/doc-checkpoints/01-basic-agent)
 
-First, let's create a new [Quarkus](https://quarkus.io/get-started/) application with: 
+First, let's create a new [Quarkus](https://quarkus.io/get-started/) application with:
 
 ```plain
 quarkus create example
@@ -32,7 +32,7 @@ Add the LangChain4j OpenAI dependency to your `pom.xml`:
   lang="xml"
   before={2}
   after={2}
-match="quarkus-langchain4j-openai"
+  match="quarkus-langchain4j-openai"
 />
 
 **Why**: This extension integrates LangChain4j with Quarkus and provides built-in support for calling OpenAI-compatible LLMs, along with CDI-managed AI service beans via `@RegisterAiService`.
@@ -71,6 +71,7 @@ Run your agent:
 ```bash
 export OPENAI_API_KEY=your-api-key
 ```
+
 ```bash
 mvn quarkus:dev
 ```
@@ -118,12 +119,15 @@ Let's add conversation memory.
 
 Add the Memory Service extension to your `pom.xml`:
 
-<Code lang="xml" code={`<dependency>
+<Code
+  lang="xml"
+  code={`<dependency>
     <groupId>io.github.chirino.memory-service</groupId>
     <artifactId>memory-service-extension</artifactId>
     <version>${PROJECT_VERSION}</version>
 </dependency>
-`} />
+`}
+/>
 
 Update the Agent interface to accept a conversation ID using the `@MemoryId` annotation:
 
@@ -151,7 +155,7 @@ Configure the agent to connect to the Memory Service and configure OIDC authenti
   file="java/quarkus/examples/doc-checkpoints/02-with-memory/src/main/resources/application.properties"
   lang="properties"
   after={11}
-match="# Memory Service Client"
+  match="# Memory Service Client"
 />
 
 **What changed**: Added Memory Service client URL and API key, OIDC server configuration, and a route policy that requires authentication on `/chat/*`. **Why**: The Memory Service uses a dual-authentication pattern — your Quarkus app authenticates to it using a service account API key, while the user's Bearer token is passed through to enforce ownership of conversations. Enabling OIDC on the Quarkus side allows it to validate and propagate the user's identity automatically.
@@ -179,7 +183,6 @@ function get-token() {
     | jq -r '.access_token'
 }
 ```
-
 
 Test it with curl—now with conversation memory:
 
@@ -219,16 +222,18 @@ curl -NsSfX POST http://localhost:9090/chat/6a6e7762-4569-4f63-b01c-c3666a27428b
 </TestScenario>
 
 If you browse to the demo agent app at [http://localhost:8080/](http://localhost:8080/), you will see that a conversation has been created with the ID `6a6e7762-4569-4f63-b01c-c3666a27428b`.
-But it won't show any messages.  That's because we are not yet storing what we call the history of the conversation.  The only thing being stored is the agent memory, and 
+But it won't show any messages. That's because we are not yet storing what we call the history of the conversation. The only thing being stored is the agent memory, and
 that's not typically what you want to display to a user in a UI.
 
 ## Next Steps
 
 Continue to [Conversation History](/docs/quarkus/conversation-history/) to learn how to:
+
 - Record conversation history for frontend display
 - Expose conversation APIs (messages, listing)
 - Build a complete chat UI experience
 
 Or jump ahead to:
+
 - [Conversation Forking](/docs/quarkus/conversation-forking/) - Branch conversations to explore alternative paths
 - [Response Recording and Resumption](/docs/quarkus/response-resumption/) - Streaming responses with resume and cancel support

--- a/site/src/pages/docs/quarkus/grpc-client.mdx
+++ b/site/src/pages/docs/quarkus/grpc-client.mdx
@@ -3,8 +3,9 @@ layout: ../../../layouts/DocsLayout.astro
 title: Quarkus gRPC Client
 description: Using the Memory Service gRPC client in Quarkus applications.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
 
 export const mavenDep = `<dependency>
   <groupId>io.github.chirino.memory-service</groupId>
@@ -38,15 +39,15 @@ quarkus.grpc.clients.search.port=9000
 
 The Memory Service gRPC API is split into multiple services:
 
-| Service | Description |
-|---------|-------------|
-| `ConversationsService` | CRUD operations for conversations |
-| `EntriesService` | List, append, and sync entries |
-| `ConversationMembershipsService` | Sharing and membership management |
-| `OwnershipTransfersService` | Ownership transfer operations |
-| `SearchService` | Semantic search and indexing |
-| `ResponseRecorderService` | Streaming response recording and resumption |
-| `SystemService` | Health checks |
+| Service                          | Description                                 |
+| -------------------------------- | ------------------------------------------- |
+| `ConversationsService`           | CRUD operations for conversations           |
+| `EntriesService`                 | List, append, and sync entries              |
+| `ConversationMembershipsService` | Sharing and membership management           |
+| `OwnershipTransfersService`      | Ownership transfer operations               |
+| `SearchService`                  | Semantic search and indexing                |
+| `ResponseRecorderService`        | Streaming response recording and resumption |
+| `SystemService`                  | Health checks                               |
 
 ## UUID Handling
 

--- a/site/src/pages/docs/quarkus/index.mdx
+++ b/site/src/pages/docs/quarkus/index.mdx
@@ -32,22 +32,29 @@ This installs all project artifacts to your local Maven repository.
 ## Guides
 
 ### [Getting Started](/docs/quarkus/getting-started/)
+
 Create a Quarkus AI agent and connect it to Memory Service for persistent conversation memory.
 
 ### [Conversation History](/docs/quarkus/conversation-history/)
+
 Record conversation history and expose APIs for frontend applications to display messages.
 
 ### [Indexing and Search](/docs/quarkus/indexing-and-search/)
+
 Add search indexing to your conversation history entries and expose a search API for frontend applications.
 
 ### [Conversation Forking](/docs/quarkus/conversation-forking/)
+
 Let users branch off from any point in a conversation to explore alternative paths.
 
 ### [Response Recording and Resumption](/docs/quarkus/response-resumption/)
+
 Implement streaming responses with resume and cancellation support, so users can reconnect after a disconnect.
 
 ### [Conversation Sharing](/docs/quarkus/sharing/)
+
 Implement conversation sharing and ownership transfer between users.
 
 ### [Dev Services](/docs/quarkus/dev-services/)
+
 Automatically start a Memory Service container in development mode, eliminating manual setup.

--- a/site/src/pages/docs/quarkus/indexing-and-search.mdx
+++ b/site/src/pages/docs/quarkus/indexing-and-search.mdx
@@ -3,11 +3,12 @@ layout: ../../../layouts/DocsLayout.astro
 title: Indexing and Search
 description: Add search indexing and semantic search to your conversations.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide continues from [Conversation History](/docs/quarkus/conversation-history/) and shows how to add search indexing to your conversation history entries and expose a search API for frontend applications.
 
@@ -19,6 +20,7 @@ This guide continues from [Conversation History](/docs/quarkus/conversation-hist
 **Starting checkpoint**: View the code from the previous section at [java/quarkus/examples/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/java/quarkus/examples/doc-checkpoints/03-with-history)
 
 Make sure you've completed the [Conversation History](/docs/quarkus/conversation-history/) guide first. You should have:
+
 - Conversation history recording with `@RecordConversation`
 - Conversation APIs exposed via `ConversationsResource`
 - Memory Service running via Docker Compose
@@ -46,6 +48,7 @@ To enable search indexing, create a bean that implements the `IndexedContentProv
 > `indexedContent` is not encrypted. Redact or minimize sensitive values before returning indexed text.
 
 The `IndexedContentProvider` interface has a single method:
+
 - **`getIndexedContent(String text, String role)`** — Transforms message text into content for the search index. The `role` parameter is either `"USER"` or `"AI"`. Return `null` to skip indexing for that message.
 
 ### Custom Redaction
@@ -58,7 +61,7 @@ For production applications, you'll likely want to redact sensitive information.
   lang="java"
   before={1}
   after={2}
-match="public String getIndexedContent(String text, String role)"
+  match="public String getIndexedContent(String text, String role)"
 />
 
 You can also return `null` to skip indexing entirely for certain messages — for example, you might choose not to index AI responses:
@@ -74,12 +77,13 @@ To let the frontend search across conversations, add a search endpoint to your `
   lang="java"
   before={4}
   after={2}
-match="public Response searchConversations"
+  match="public Response searchConversations"
 />
 
 **Why**: Exposing search through the Quarkus proxy rather than directly to clients ensures the Memory Service enforces that results are scoped to conversations the authenticated user has access to. The raw JSON forwarding keeps the endpoint simple while still letting callers control search type, grouping, and result limits via the request body.
 
 This endpoint accepts a JSON request body with the following fields:
+
 - **`query`** (required) — The search query text
 - **`searchType`** — Either a single type (`"auto"`, `"semantic"`, `"fulltext"`) or an array of concrete types (`["semantic","fulltext"]`)
 - **`limit`** — Maximum number of results per requested search type (default 20)
@@ -149,7 +153,7 @@ Example response:
         "userId": "bob",
         "channel": "history",
         "contentType": "history",
-        "content": [{"role": "USER", "text": "Give me a random number between 1 and 100."}],
+        "content": [{ "role": "USER", "text": "Give me a random number between 1 and 100." }],
         "createdAt": "2025-01-10T14:32:05Z"
       }
     }
@@ -159,6 +163,7 @@ Example response:
 ```
 
 Search results include:
+
 - **`conversationId`** and **`conversationTitle`** — For linking to the conversation
 - **`entryId`** — For deep-linking to a specific message
 - **`score`** — Relevance score
@@ -172,5 +177,6 @@ Search results include:
 ## Next Steps
 
 Continue to:
+
 - [Conversation Forking](/docs/quarkus/conversation-forking/) — Branch conversations to explore alternative paths
 - [Response Recording and Resumption](/docs/quarkus/response-resumption/) — Streaming responses with resume and cancel support

--- a/site/src/pages/docs/quarkus/response-resumption.mdx
+++ b/site/src/pages/docs/quarkus/response-resumption.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Response Recording and Resumption
 description: Streaming responses with recording, resumption, and cancellation.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide covers streaming responses with recording, resumption, and cancellation so users can reconnect after a disconnect and pick up where they left off. For a conceptual overview of how response recording and resumption works, including the gRPC service contract and multi-instance redirect behavior, see [Response Recording and Resumption Concepts](/docs/concepts/response-resumption/).
 
@@ -14,6 +15,7 @@ This guide covers streaming responses with recording, resumption, and cancellati
 **Starting checkpoint**: This guide starts from [java/quarkus/examples/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/java/quarkus/examples/doc-checkpoints/03-with-history)
 
 Make sure you've completed the previous guides:
+
 - [Getting Started](/docs/quarkus/getting-started/) - Basic memory service integration
 - [Conversation History](/docs/quarkus/conversation-history/) - History recording and APIs
 
@@ -78,7 +80,6 @@ You should see the response streaming to your command line.
 
 Now browse to the demo agent app at [http://localhost:8080/?conversationId=bafd53b0-ee0d-4d5f-83e3-406fbc3506cb](http://localhost:8080/?conversationId=bafd53b0-ee0d-4d5f-83e3-406fbc3506cb)
 and you should see the response streaming to the browser.
-
 
 ## Response Recording and Resumption
 

--- a/site/src/pages/docs/quarkus/rest-client.mdx
+++ b/site/src/pages/docs/quarkus/rest-client.mdx
@@ -3,8 +3,9 @@ layout: ../../../layouts/DocsLayout.astro
 title: Quarkus REST Client
 description: Using the Memory Service REST client in Quarkus applications.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
 
 export const mavenDep = `<dependency>
   <groupId>io.github.chirino.memory-service</groupId>
@@ -198,11 +199,11 @@ public class MyService {
 
 ### Available API Classes
 
-| API Class | Description |
-|-----------|-------------|
+| API Class          | Description                                   |
+| ------------------ | --------------------------------------------- |
 | `ConversationsApi` | CRUD operations for conversations and entries |
-| `SearchApi` | Semantic search and indexing |
-| `SharingApi` | Memberships and ownership transfers |
+| `SearchApi`        | Semantic search and indexing                  |
+| `SharingApi`       | Memberships and ownership transfers           |
 
 ## Error Handling
 

--- a/site/src/pages/docs/quarkus/sharing.mdx
+++ b/site/src/pages/docs/quarkus/sharing.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Conversation Sharing
 description: Learn how to share conversations with other users and manage access control in your Quarkus application
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 # Conversation Sharing
 
@@ -19,6 +20,7 @@ This guide shows you how to implement conversation sharing and ownership transfe
 **Starting checkpoint**: This guide starts from [java/quarkus/examples/doc-checkpoints/05-response-resumption](https://github.com/chirino/memory-service/tree/main/java/quarkus/examples/doc-checkpoints/05-response-resumption)
 
 Make sure you've completed the previous guides:
+
 - [Conversation Forking](/docs/quarkus/conversation-forking/) - Branching conversations
 - [Response Recording and Resumption](/docs/quarkus/response-resumption/) - Streaming with resume support
 - Multiple test users in Keycloak (bob, alice, charlie)
@@ -32,7 +34,7 @@ Add the membership endpoints to your `ConversationsResource`:
   lang="java"
   before={0}
   after={35}
-match="// Membership management endpoints"
+  match="// Membership management endpoints"
 />
 
 **Why**: These endpoints let your frontend implement a sharing UI without directly exposing the Memory Service. The proxy pattern ensures that all calls carry both the service account API key (for Memory Service authentication) and the caller's Bearer token (for authorization checks), so users can only manage memberships on conversations they own or manage.
@@ -338,5 +340,3 @@ Returns `204 No Content`. The transfer is deleted and ownership remains unchange
 ## Completed Checkpoint
 
 **Completed code**: View the full implementation at [java/quarkus/examples/doc-checkpoints/06-sharing](https://github.com/chirino/memory-service/tree/main/java/quarkus/examples/doc-checkpoints/06-sharing)
-
-

--- a/site/src/pages/docs/spring/attachments.mdx
+++ b/site/src/pages/docs/spring/attachments.mdx
@@ -3,11 +3,12 @@ layout: ../../../layouts/DocsLayout.astro
 title: Attachments
 description: Proxy attachment upload, download, and management APIs from your agent app.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide covers proxying attachment operations — upload, download, signed URLs, and deletion — from your agent app to the Memory Service.
 
@@ -19,6 +20,7 @@ This guide covers proxying attachment operations — upload, download, signed UR
 **Starting checkpoint**: This guide starts from [java/spring/examples/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/java/spring/examples/doc-checkpoints/03-with-history)
 
 Make sure you've completed the previous guides:
+
 - [Getting Started](/docs/spring/getting-started/) - Basic memory service integration
 - [Conversation History](/docs/spring/conversation-history/) - History recording and APIs
 

--- a/site/src/pages/docs/spring/conversation-forking.mdx
+++ b/site/src/pages/docs/spring/conversation-forking.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Conversation Forking
 description: Branch conversations to explore alternative paths.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide covers conversation forking — letting users branch off from any point in a conversation to explore alternative paths.
 
@@ -17,6 +18,7 @@ This guide covers conversation forking — letting users branch off from any poi
 **Starting checkpoint**: This guide starts from [java/spring/examples/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/java/spring/examples/doc-checkpoints/03-with-history)
 
 Make sure you've completed the previous guides:
+
 - [Getting Started](/docs/spring/getting-started/) - Basic memory service integration
 - [Conversation History](/docs/spring/conversation-history/) - History recording and APIs
 
@@ -43,7 +45,7 @@ Add this method to the `MemoryServiceProxyController` to list forks for a conver
   lang="java"
   before={2}
   after={1}
-match="listConversationForks(@PathVariable String conversationId)"
+  match="listConversationForks(@PathVariable String conversationId)"
 />
 
 **What changed**: A new `GET /{conversationId}/forks` endpoint is added to `MemoryServiceProxyController`, delegating to `proxy.listConversationForks()`.
@@ -129,7 +131,6 @@ curl -sSfX GET http://localhost:9090/v1/conversations/a8391789-592d-4273-90df-73
 </CurlTest>
 
 </TestScenario>
-
 
 ## Next Steps
 

--- a/site/src/pages/docs/spring/conversation-history.mdx
+++ b/site/src/pages/docs/spring/conversation-history.mdx
@@ -3,11 +3,12 @@ layout: ../../../layouts/DocsLayout.astro
 title: Conversation History
 description: Record conversation history and expose APIs for frontend applications.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide continues from [Getting Started](/docs/spring/getting-started/) and shows how to record conversation history and expose APIs for frontend applications.
 
@@ -16,6 +17,7 @@ This guide continues from [Getting Started](/docs/spring/getting-started/) and s
 **Starting checkpoint**: View the code from the previous section at [java/spring/examples/doc-checkpoints/02-with-memory](https://github.com/chirino/memory-service/tree/main/java/spring/examples/doc-checkpoints/02-with-memory)
 
 Make sure you've completed the [Getting Started](/docs/spring/getting-started/) guide first. You should have:
+
 - A working Spring Boot agent with the Memory Service starter
 - Memory Service running via Docker Compose
 - OAuth2 authentication configured
@@ -141,6 +143,7 @@ curl -sSfX GET http://localhost:9090/v1/conversations/564f4b5f-789c-473b-adbf-44
 ## Expose Conversation Listing API
 
 The `MemoryServiceProxyController` already includes the `listConversations` method (shown in the full code above). This endpoint supports:
+
 - **Pagination** via `after` (cursor) and `limit` parameters
 - **Search** via the `query` parameter for filtering conversations
 - **Mode** for different listing modes (e.g., `owned`, `shared`)
@@ -172,6 +175,7 @@ curl -sSfX GET http://localhost:9090/v1/conversations \
 ## Next Steps
 
 Continue to:
+
 - [Indexing and Search](/docs/spring/indexing-and-search/) — Add search indexing and semantic search to your conversations
 - [Conversation Forking](/docs/spring/conversation-forking/) — Branch conversations to explore alternative paths
 - [Response Recording and Resumption](/docs/spring/response-resumption/) — Streaming responses with resume and cancel support

--- a/site/src/pages/docs/spring/docker-compose.mdx
+++ b/site/src/pages/docs/spring/docker-compose.mdx
@@ -3,8 +3,9 @@ layout: ../../../layouts/DocsLayout.astro
 title: Docker Compose Integration
 description: Automatic memory-service container startup for development and testing.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
 
 Spring Boot 3.1+ includes built-in Docker Compose support that can automatically start and configure services defined in a `compose.yaml` file. This makes it easy to run Memory Service and its dependencies during development.
 
@@ -21,13 +22,15 @@ Spring Boot's Docker Compose integration provides:
 
 Add the Docker Compose dependency to your `pom.xml`:
 
-<Code lang="xml" code={`<dependency>
+<Code
+  lang="xml"
+  code={`<dependency>
     <groupId>io.github.chirino.memory-service</groupId>
     <artifactId>memory-service-spring-boot-docker-compose-starter</artifactId>
     <version>${PROJECT_VERSION}</version>
 </dependency>
-`} />
-
+`}
+/>
 
 Place a `compose.yaml` file in your project root (Spring Boot auto-detects it):
 
@@ -107,15 +110,16 @@ services:
       retries: 12
 ```
 
-Add a [`memory-service-realm.json`](https://raw.githubusercontent.com/chirino/memory-service/refs/heads/main/deploy/keycloak/memory-service-realm.json) file 
-to the root of your project.  This file contains an example Keycloak realm configuration for the Memory Service.
+Add a [`memory-service-realm.json`](https://raw.githubusercontent.com/chirino/memory-service/refs/heads/main/deploy/keycloak/memory-service-realm.json) file
+to the root of your project. This file contains an example Keycloak realm configuration for the Memory Service.
 
 ## Service Connection
 
-Spring Boot automatically detects the `memory-service` container and provides connection details via `MemoryServiceConnectionDetails`. The starter uses these connection 
+Spring Boot automatically detects the `memory-service` container and provides connection details via `MemoryServiceConnectionDetails`. The starter uses these connection
 details to configure the REST and gRPC clients.
 
 Make sure you comment out the memory-service.client properties in your application.properties file to pickup the connection details from the Docker Compose file.
+
 ```properties
 # These will override Docker Compose connection details if set
 #memory-service.client.base-url=http://localhost:8082
@@ -131,6 +135,7 @@ mvn spring-boot:run
 ```
 
 Spring Boot will:
+
 1. Detect the `compose.yaml` file
 2. Start all services defined in the file
 3. Wait for health checks to pass
@@ -158,11 +163,3 @@ If your `compose.yaml` is in a different location:
 ```properties
 spring.docker.compose.file=./docker/compose.yaml
 ```
-
-
-{/* 
-## Next Steps
-
-- [Getting Started](/docs/spring/getting-started/) - Build your first Spring AI agent with Memory Service
-- [Configuration](/docs/configuration/) - Learn about all configuration options 
-*/}

--- a/site/src/pages/docs/spring/getting-started.mdx
+++ b/site/src/pages/docs/spring/getting-started.mdx
@@ -3,11 +3,12 @@ layout: ../../../layouts/DocsLayout.astro
 title: Spring Getting Started
 description: Step-by-step guide to integrating Memory Service with your Spring Boot AI agent.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide walks you through integrating Memory Service with a Spring Boot AI agent. You'll start with basic chat memory and can progressively add features in the follow-up guides.
 
@@ -26,7 +27,6 @@ Once you download the starter project extract it and open it in your favorite ID
 unzip demo.zip
 cd demo
 ```
-
 
 Create a simple REST controller:
 
@@ -53,6 +53,7 @@ Run your agent:
 ```bash
 export OPENAI_API_KEY=your-api-key
 ```
+
 ```bash
 mvn spring-boot:run
 ```
@@ -100,7 +101,9 @@ Let's add conversation memory.
 
 Add the Memory Service Spring Boot starter and OAuth2 resource server dependencies to your `pom.xml`:
 
-<Code lang="xml" code={`<dependency>
+<Code
+  lang="xml"
+  code={`<dependency>
     <groupId>io.github.chirino.memory-service</groupId>
     <artifactId>memory-service-spring-boot-starter</artifactId>
     <version>${PROJECT_VERSION}</version>
@@ -109,7 +112,8 @@ Add the Memory Service Spring Boot starter and OAuth2 resource server dependenci
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
 </dependency>
-`} />
+`}
+/>
 
 Start the Memory Service in Docker Compose following the [Getting Started](/docs/getting-started/) guide.
 
@@ -218,16 +222,18 @@ curl -NsSfX POST http://localhost:9090/chat/2cdbd4b0-b48d-4f75-8f7a-9616301e5143
 </TestScenario>
 
 If you browse to the demo agent app at [http://localhost:8080/](http://localhost:8080/), you will see that a conversation has been created with the ID `2cdbd4b0-b48d-4f75-8f7a-9616301e5143`.
-But it won't show any messages.  That's because we are not yet storing what we call the history of the conversation.  The only thing being stored is the agent memory, and
+But it won't show any messages. That's because we are not yet storing what we call the history of the conversation. The only thing being stored is the agent memory, and
 that's not typically what you want to display to a user in a UI.
 
 ## Next Steps
 
 Continue to [Conversation History](/docs/spring/conversation-history/) to learn how to:
+
 - Record conversation history for frontend display
 - Expose conversation APIs (messages, listing)
 - Build a complete chat UI experience
 
 Or jump ahead to:
+
 - [Conversation Forking](/docs/spring/conversation-forking/) - Branch conversations to explore alternative paths
 - [Response Recording and Resumption](/docs/spring/response-resumption/) - Streaming responses with resume and cancel support

--- a/site/src/pages/docs/spring/grpc-client.mdx
+++ b/site/src/pages/docs/spring/grpc-client.mdx
@@ -3,8 +3,9 @@ layout: ../../../layouts/DocsLayout.astro
 title: Spring gRPC Client
 description: Using the Memory Service gRPC client in Spring Boot applications.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
 
 export const mavenDep = `<dependency>
   <groupId>io.github.chirino.memory-service</groupId>
@@ -85,7 +86,7 @@ The `MemoryServiceStubs` provides access to all service stubs:
 import io.github.chirino.memory.grpc.v1.ConversationsServiceGrpc;
 import io.github.chirino.memory.grpc.v1.GetConversationRequest;
 
-ConversationsServiceGrpc.ConversationsServiceBlockingStub conversations = 
+ConversationsServiceGrpc.ConversationsServiceBlockingStub conversations =
     stubs.conversationsService();
 
 GetConversationRequest request = GetConversationRequest.newBuilder()
@@ -133,7 +134,7 @@ import io.github.chirino.memory.grpc.v1.MessagesServiceGrpc;
 import io.github.chirino.memory.grpc.v1.GetMessagesRequest;
 import io.grpc.stub.StreamObserver;
 
-MessagesServiceGrpc.MessagesServiceStub messages = 
+MessagesServiceGrpc.MessagesServiceStub messages =
     MessagesServiceGrpc.newStub(stubs.conversationsService().getChannel());
 
 GetMessagesRequest request = GetMessagesRequest.newBuilder()

--- a/site/src/pages/docs/spring/index.mdx
+++ b/site/src/pages/docs/spring/index.mdx
@@ -32,22 +32,29 @@ This installs all project artifacts to your local Maven repository.
 ## Guides
 
 ### [Getting Started](/docs/spring/getting-started/)
+
 Create a Spring Boot AI agent and connect it to Memory Service for persistent conversation memory.
 
 ### [Conversation History](/docs/spring/conversation-history/)
+
 Record conversation history and expose APIs for frontend applications to display messages.
 
 ### [Indexing and Search](/docs/spring/indexing-and-search/)
+
 Add search indexing to your conversation history entries and expose a search API for frontend applications.
 
 ### [Conversation Forking](/docs/spring/conversation-forking/)
+
 Let users branch off from any point in a conversation to explore alternative paths.
 
 ### [Response Recording and Resumption](/docs/spring/response-resumption/)
+
 Implement streaming responses with resume and cancellation support, so users can reconnect after a disconnect.
 
 ### [Conversation Sharing](/docs/spring/sharing/)
+
 Implement conversation sharing and ownership transfer between users.
 
 ### [Docker Compose](/docs/spring/docker-compose/)
+
 Use Spring Boot's built-in Docker Compose support to automatically start Memory Service during development.

--- a/site/src/pages/docs/spring/indexing-and-search.mdx
+++ b/site/src/pages/docs/spring/indexing-and-search.mdx
@@ -3,11 +3,12 @@ layout: ../../../layouts/DocsLayout.astro
 title: Indexing and Search
 description: Add search indexing and semantic search to your conversations.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide continues from [Conversation History](/docs/spring/conversation-history/) and shows how to add search indexing to your conversation history entries and expose a search API for frontend applications.
 
@@ -19,6 +20,7 @@ This guide continues from [Conversation History](/docs/spring/conversation-histo
 **Starting checkpoint**: View the code from the previous section at [java/spring/examples/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/java/spring/examples/doc-checkpoints/03-with-history)
 
 Make sure you've completed the [Conversation History](/docs/spring/conversation-history/) guide first. You should have:
+
 - Conversation history recording with `ConversationHistoryStreamAdvisor`
 - Conversation APIs exposed via `MemoryServiceProxyController`
 - Memory Service running via Docker Compose
@@ -48,6 +50,7 @@ To enable search indexing, create a bean that implements the `IndexedContentProv
 > `indexedContent` is not encrypted. Redact or minimize sensitive values before returning indexed text.
 
 The `IndexedContentProvider` interface has a single method:
+
 - **`getIndexedContent(String text, String role)`** — Transforms message text into content for the search index. The `role` parameter is either `"USER"` or `"AI"`. Return `null` to skip indexing for that message.
 
 ### Custom Redaction
@@ -60,7 +63,7 @@ For production applications, you'll likely want to redact sensitive information.
   lang="java"
   before={1}
   after={2}
-match="public String getIndexedContent(String text, String role)"
+  match="public String getIndexedContent(String text, String role)"
 />
 
 You can also return `null` to skip indexing entirely for certain messages — for example, you might choose not to index AI responses:
@@ -76,12 +79,13 @@ To let the frontend search across conversations, add a search endpoint to your `
   lang="java"
   before={1}
   after={2}
-match="searchConversations(@RequestBody"
+  match="searchConversations(@RequestBody"
 />
 
 **Why**: Exposing search through the proxy controller means the frontend can issue search queries with the user's Bearer token, and the Memory Service automatically scopes results to conversations the user has access to. Passing the body through as a raw string avoids the need to model every search parameter as a Java type — the JSON is serialized and forwarded as-is, so new search fields added to the Memory Service API become available immediately without controller changes.
 
 This endpoint accepts a JSON request body with the following fields:
+
 - **`query`** (required) — The search query text
 - **`searchType`** — Either a single type (`"auto"`, `"semantic"`, `"fulltext"`) or an array of concrete types (`["semantic","fulltext"]`)
 - **`limit`** — Maximum number of results per requested search type (default 20)
@@ -139,7 +143,7 @@ Example response:
         "userId": "bob",
         "channel": "history",
         "contentType": "history",
-        "content": [{"role": "USER", "text": "Give me a random number between 1 and 100."}],
+        "content": [{ "role": "USER", "text": "Give me a random number between 1 and 100." }],
         "createdAt": "2025-01-10T14:32:05Z"
       }
     }
@@ -149,6 +153,7 @@ Example response:
 ```
 
 Search results include:
+
 - **`conversationId`** and **`conversationTitle`** — For linking to the conversation
 - **`entryId`** — For deep-linking to a specific message
 - **`score`** — Relevance score
@@ -162,5 +167,6 @@ Search results include:
 ## Next Steps
 
 Continue to:
+
 - [Conversation Forking](/docs/spring/conversation-forking/) — Branch conversations to explore alternative paths
 - [Response Recording and Resumption](/docs/spring/response-resumption/) — Streaming responses with resume and cancel support

--- a/site/src/pages/docs/spring/overview.mdx
+++ b/site/src/pages/docs/spring/overview.mdx
@@ -3,8 +3,9 @@ layout: ../../../layouts/DocsLayout.astro
 title: Spring Integration
 description: Integrate Memory Service with Spring Boot applications.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
 
 export const mavenDep = `<dependency>
   <groupId>io.github.chirino.memory-service</groupId>

--- a/site/src/pages/docs/spring/response-resumption.mdx
+++ b/site/src/pages/docs/spring/response-resumption.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Response Recording and Resumption
 description: Streaming responses with recording, resumption, and cancellation.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide covers streaming responses with recording, resumption, and cancellation so users can reconnect after a disconnect and pick up where they left off. For a conceptual overview of how response recording and resumption works, including the gRPC service contract and multi-instance redirect behavior, see [Response Recording and Resumption Concepts](/docs/concepts/response-resumption/).
 
@@ -14,6 +15,7 @@ This guide covers streaming responses with recording, resumption, and cancellati
 **Starting checkpoint**: This guide starts from [java/spring/examples/doc-checkpoints/03-with-history](https://github.com/chirino/memory-service/tree/main/java/spring/examples/doc-checkpoints/03-with-history)
 
 Make sure you've completed the previous guides:
+
 - [Getting Started](/docs/spring/getting-started/) - Basic memory service integration
 - [Conversation History](/docs/spring/conversation-history/) - History recording and APIs
 

--- a/site/src/pages/docs/spring/rest-client.mdx
+++ b/site/src/pages/docs/spring/rest-client.mdx
@@ -3,8 +3,9 @@ layout: ../../../layouts/DocsLayout.astro
 title: Spring REST Client
 description: Using the Memory Service REST client in Spring Boot applications.
 ---
-import { Code } from 'astro:components';
-import { PROJECT_VERSION } from '../../../config';
+
+import { Code } from "astro:components";
+import { PROJECT_VERSION } from "../../../config";
 
 export const mavenDep = `<dependency>
   <groupId>io.github.chirino.memory-service</groupId>

--- a/site/src/pages/docs/spring/sharing.mdx
+++ b/site/src/pages/docs/spring/sharing.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: Conversation Sharing
 description: Learn how to share conversations with other users and manage access control in your Spring Boot application
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 # Conversation Sharing
 
@@ -19,6 +20,7 @@ This guide shows you how to implement conversation sharing and ownership transfe
 **Starting checkpoint**: This guide starts from [java/spring/examples/doc-checkpoints/05-response-resumption](https://github.com/chirino/memory-service/tree/main/java/spring/examples/doc-checkpoints/05-response-resumption)
 
 Make sure you've completed the previous guides:
+
 - [Conversation Forking](/docs/spring/conversation-forking/) - Branching conversations
 - [Response Recording and Resumption](/docs/spring/response-resumption/) - Streaming with resume support
 - Multiple test users in Keycloak (bob, alice, charlie)
@@ -32,7 +34,7 @@ Add the membership endpoints to your `MemoryServiceProxyController`:
   lang="java"
   before={1}
   after={23}
-match="// Membership management endpoints"
+  match="// Membership management endpoints"
 />
 
 **Why**: These endpoints give the agent app's frontend everything it needs to build a sharing UI — listing who has access, inviting new collaborators, promoting or demoting their access level, and revoking access. The `MemoryServiceProxy` handles authentication forwarding, so the Memory Service's access-level enforcement (owner, manager, writer, reader) is automatically applied based on the authenticated user's token.
@@ -338,4 +340,3 @@ Returns `204 No Content`. The transfer is deleted and ownership remains unchange
 ## Completed Checkpoint
 
 **Completed code**: View the full implementation at [java/spring/examples/doc-checkpoints/06-sharing](https://github.com/chirino/memory-service/tree/main/java/spring/examples/doc-checkpoints/06-sharing)
-

--- a/site/src/pages/docs/typescript-vecelai/conversation-forking.mdx
+++ b/site/src/pages/docs/typescript-vecelai/conversation-forking.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: TypeScript Conversation Forking
 description: Branch conversations by writing fork metadata on first append.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide adds conversation forking metadata to the chat path.
 

--- a/site/src/pages/docs/typescript-vecelai/conversation-history.mdx
+++ b/site/src/pages/docs/typescript-vecelai/conversation-history.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: TypeScript Conversation History
 description: Record conversation history entries alongside memory channel state.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide continues from [TypeScript Getting Started](/docs/typescript-vecelai/getting-started/) and adds `history` channel recording.
 
@@ -75,6 +76,7 @@ curl -NsSfX POST http://localhost:9090/chat/52b0f67a-6d8a-4d35-a2e5-8abf0e7f1c22
 ## Next Steps
 
 Continue to:
+
 - [Conversation Forking](/docs/typescript-vecelai/conversation-forking/) - Branch a conversation from a specific prior entry
 - [Response Recording and Resumption](/docs/typescript-vecelai/response-resumption/) - Stream responses and support resume/cancel
 - [Sharing](/docs/typescript-vecelai/sharing/) - Add conversation membership and ownership transfer APIs

--- a/site/src/pages/docs/typescript-vecelai/getting-started.mdx
+++ b/site/src/pages/docs/typescript-vecelai/getting-started.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: TypeScript Getting Started
 description: Step-by-step guide to integrating Memory Service with a TypeScript Express + Vercel AI SDK agent.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide walks you through a minimal TypeScript agent using [Vercel AI SDK](https://ai-sdk.dev/docs/getting-started/nodejs), then adds incremental memory-service integration. The goal is to keep code changes small while unlocking memory features one step at a time.
 
@@ -17,10 +18,7 @@ Make sure you have completed [TypeScript Dev Setup](/docs/typescript-vecelai/dev
 
 Create a minimal Vercel AI SDK agent and expose it over HTTP with Express (no memory-service imports yet):
 
-<CodeFromFile
-  file="typescript/examples/vecelai/doc-checkpoints/01-basic-chat/src/app.ts"
-  lang="typescript"
-/>
+<CodeFromFile file="typescript/examples/vecelai/doc-checkpoints/01-basic-chat/src/app.ts" lang="typescript" />
 
 **What this shows**: A baseline `POST /chat` handler that calls Vercel AI SDK directly and returns plain text.
 
@@ -28,10 +26,7 @@ Create a minimal Vercel AI SDK agent and expose it over HTTP with Express (no me
 
 Add Vercel AI SDK dependencies:
 
-<CodeFromFile
-  file="typescript/examples/vecelai/doc-checkpoints/01-basic-chat/package.json"
-  lang="json"
-/>
+<CodeFromFile file="typescript/examples/vecelai/doc-checkpoints/01-basic-chat/package.json" lang="json" />
 
 **What this shows**: The minimum dependencies for the baseline app.
 

--- a/site/src/pages/docs/typescript-vecelai/index.mdx
+++ b/site/src/pages/docs/typescript-vecelai/index.mdx
@@ -13,22 +13,29 @@ Before starting, complete [TypeScript Dev Setup](/docs/typescript-vecelai/dev-se
 ## Guides
 
 ### [Getting Started](/docs/typescript-vecelai/getting-started/)
+
 Build a minimal Express chat app and add conversation-backed memory.
 
 ### [Conversation History](/docs/typescript-vecelai/conversation-history/)
+
 Record user/AI turns in the history channel and expose conversation APIs.
 
 ### [Indexing and Search](/docs/typescript-vecelai/indexing-and-search/)
+
 Index history text and expose `POST /v1/conversations/search`.
 
 ### [Conversation Forking](/docs/typescript-vecelai/conversation-forking/)
+
 Create and list conversation forks.
 
 ### [Response Recording and Resumption](/docs/typescript-vecelai/response-resumption/)
+
 Stream responses and support resume-check/resume/cancel APIs.
 
 ### [Sharing](/docs/typescript-vecelai/sharing/)
+
 Manage memberships and ownership transfers.
 
 ### [Dev Setup](/docs/typescript-vecelai/dev-setup/)
+
 Local setup and pre-publish package workflow.

--- a/site/src/pages/docs/typescript-vecelai/indexing-and-search.mdx
+++ b/site/src/pages/docs/typescript-vecelai/indexing-and-search.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: TypeScript Indexing and Search
 description: Add indexed history content and conversation search endpoint.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide adds indexed history text and a proxied search endpoint.
 

--- a/site/src/pages/docs/typescript-vecelai/response-resumption.mdx
+++ b/site/src/pages/docs/typescript-vecelai/response-resumption.mdx
@@ -3,11 +3,13 @@ layout: ../../../layouts/DocsLayout.astro
 title: TypeScript Response Recording and Resumption
 description: First add streaming (05a), then add response recording/resumption (05b).
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide is split into two implementation phases:
+
 1. `05a-streaming`: switch chat to streaming only.
 2. `05b-response-resumption`: add resume-check/replay/cancel on top of streaming.
 
@@ -84,7 +86,7 @@ And the response should contain "text"
 
 data: {"text":"upon "}
 
-data: {"text":"a time..."}`}> 
+data: {"text":"a time..."}`}>
 
 ```bash
 curl -NsSfX POST http://localhost:9090/chat/a9f2d4c3-7b1e-4d5f-9c44-2e6a8b7c5333 \
@@ -192,7 +194,7 @@ And the response should contain "data:"
 And the response should contain "text"
 `} exampleOutputLang="text" exampleOutput={`data: {"text":"Once upon a time, there was a curious little cat named Whiskers."}
 
-data: {"text":" She explored the moonlit garden and found a hidden pond."}`}> 
+data: {"text":" She explored the moonlit garden and found a hidden pond."}`}>
 
 ```bash
 curl -NsSfX POST http://localhost:9090/chat/91b7f6be-1ab8-4a31-b86a-a4fd2c8b2d27 \

--- a/site/src/pages/docs/typescript-vecelai/sharing.mdx
+++ b/site/src/pages/docs/typescript-vecelai/sharing.mdx
@@ -3,9 +3,10 @@ layout: ../../../layouts/DocsLayout.astro
 title: TypeScript Sharing
 description: Add membership and ownership transfer APIs.
 ---
-import CodeFromFile from '../../../components/CodeFromFile.astro';
-import TestScenario from '../../../components/TestScenario.astro';
-import CurlTest from '../../../components/CurlTest.astro';
+
+import CodeFromFile from "../../../components/CodeFromFile.astro";
+import TestScenario from "../../../components/TestScenario.astro";
+import CurlTest from "../../../components/CurlTest.astro";
 
 This guide adds sharing features to the TypeScript tutorial app.
 


### PR DESCRIPTION
## Summary
- enable MDX files in the site Prettier script
- apply formatting updates across the site documentation pages
- include generated lockfile and Astro type updates from the formatting pass

## Testing
- not run (docs formatting only)