### PR TITLE
feat(admin): add client checkpoints

### DIFF
--- a/.skills/openapi-workflow/SKILL.md
+++ b/.skills/openapi-workflow/SKILL.md
@@ -5,19 +5,29 @@ description: Use when making changes to the OpenAPI contract. Workflow for updat
 
 # OpenAPI Change Workflow
 
-1. **Edit the spec**: `contracts/openapi/openapi.yml`
+1. **Edit the spec**: Agent API changes use `contracts/openapi/openapi.yml`; Admin API changes use `contracts/openapi/openapi-admin.yml`.
 
-2. **Regenerate Java client**:
+2. **Regenerate Go bindings**:
+   ```bash
+   # Agent API + client
+   go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config=internal/generated/api/cfg.yaml contracts/openapi/openapi.yml
+   go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config=internal/generated/apiclient/cfg.yaml contracts/openapi/openapi.yml
+
+   # Admin API
+   go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config=internal/generated/admin/cfg.yaml contracts/openapi/openapi-admin.yml
+   ```
+
+3. **Regenerate Java client**:
    ```bash
    ./java/mvnw -f java/pom.xml -pl quarkus/memory-service-rest-quarkus clean compile -am
    ```
 
-3. **Regenerate TypeScript client**:
+4. **Regenerate TypeScript client**:
    ```bash
    cd frontends/chat-frontend && npm run generate
    ```
 
-4. **Verify**:
+5. **Verify**:
    ```bash
    ./java/mvnw -f java/pom.xml compile
    cd frontends/chat-frontend && npm run lint && npm run build

--- a/contracts/openapi/openapi-admin.yml
+++ b/contracts/openapi/openapi-admin.yml
@@ -787,6 +787,74 @@ paths:
       security:
         - BearerAuth: []
 
+  /v1/admin/checkpoints/{clientId}:
+    get:
+      tags: [Admin]
+      summary: Get an admin client checkpoint
+      description: Returns the checkpoint for an admin client. When the caller has an authenticated client ID, it must match the path clientId.
+      operationId: adminGetCheckpoint
+      parameters:
+        - name: clientId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Client checkpoint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminCheckpoint'
+        '401':
+          description: Authentication required.
+        '403':
+          description: Admin role required.
+        '404':
+          description: Checkpoint not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security:
+        - BearerAuth: []
+    put:
+      tags: [Admin]
+      summary: Upsert an admin client checkpoint
+      description: Persists an encrypted JSON checkpoint for an admin client. When the caller has an authenticated client ID, it must match the path clientId.
+      operationId: adminPutCheckpoint
+      parameters:
+        - name: clientId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminCheckpointPutRequest'
+      responses:
+        '200':
+          description: Client checkpoint updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AdminCheckpoint'
+        '400':
+          description: Invalid request.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '401':
+          description: Authentication required.
+        '403':
+          description: Admin role required.
+      security:
+        - BearerAuth: []
+
   ############################################################
   # Admin Attachments
   ############################################################
@@ -1391,6 +1459,29 @@ components:
         details:
           type: object
           additionalProperties: true
+
+    AdminCheckpoint:
+      type: object
+      required: [clientId, contentType, value, updatedAt]
+      properties:
+        clientId:
+          type: string
+        contentType:
+          type: string
+        value:
+          description: Processor-defined JSON payload for this client checkpoint. Stored encrypted at rest.
+        updatedAt:
+          type: string
+          format: date-time
+
+    AdminCheckpointPutRequest:
+      type: object
+      required: [contentType, value]
+      properties:
+        contentType:
+          type: string
+        value:
+          description: Processor-defined JSON payload to persist for this client checkpoint. Stored encrypted at rest.
 
     MemoryPolicyBundle:
       type: object

--- a/docs/enhancements/implemented/097-admin-client-checkpoints.md
+++ b/docs/enhancements/implemented/097-admin-client-checkpoints.md
@@ -125,21 +125,21 @@ Feature: Admin checkpoint REST API
     When I call GET "/v1/admin/checkpoints/checkpoint-processor"
     Then the response status should be 403
 
-  Scenario: Admin client IDs scope checkpoint ownership
+  Scenario: Admin clients can only access checkpoints for their own client ID
     Given I am authenticated as admin user "alice"
-    And I am authenticated as agent with API key "test-agent-key"
-    And set "currentClientId" to the current client ID
-    When I call PUT "/v1/admin/checkpoints/${currentClientId}" with body:
+    And I am authenticated as admin client with API key "test-agent-key"
+    And set "ownerClientId" to the current client ID
+    When I call PUT "/v1/admin/checkpoints/${ownerClientId}" with body:
       """
       {
         "contentType": "application/example+json",
-        "value": { "cursor": "client-a" }
+        "value": { "cursor": "owner-client" }
       }
       """
     Then the response status should be 200
     Given I am authenticated as admin user "alice"
-    And I am authenticated as agent with API key "test-agent-key-b"
-    When I call GET "/v1/admin/checkpoints/${currentClientId}"
+    And I am authenticated as admin client with API key "test-agent-key-b"
+    When I call GET "/v1/admin/checkpoints/${ownerClientId}"
     Then the response status should be 404
 ```
 

--- a/docs/enhancements/implemented/097-admin-client-checkpoints.md
+++ b/docs/enhancements/implemented/097-admin-client-checkpoints.md
@@ -139,6 +139,17 @@ Feature: Admin checkpoint REST API
     Then the response status should be 200
     Given I am authenticated as admin user "alice"
     And I am authenticated as admin client with API key "test-agent-key-b"
+    And set "otherClientId" to the current client ID
+    When I call GET "/v1/admin/checkpoints/${ownerClientId}"
+    Then the response status should be 404
+    When I call PUT "/v1/admin/checkpoints/${otherClientId}" with body:
+      """
+      {
+        "contentType": "application/example+json",
+        "value": { "cursor": "other-client" }
+      }
+      """
+    Then the response status should be 200
     When I call GET "/v1/admin/checkpoints/${ownerClientId}"
     Then the response status should be 404
 ```

--- a/docs/enhancements/implemented/097-admin-client-checkpoints.md
+++ b/docs/enhancements/implemented/097-admin-client-checkpoints.md
@@ -1,0 +1,197 @@
+---
+status: implemented
+---
+
+# Enhancement 097: Admin Client Checkpoints
+
+> **Status**: Implemented.
+
+## Summary
+
+Add a small admin-only checkpoint API that lets external processors persist and retrieve encrypted, processor-defined JSON progress state by stable admin `clientId`. The API is intentionally generic so external processors, indexers, or future background clients can resume from the last acknowledged cursor without adding processor-specific database tables.
+
+## Motivation
+
+Remote processors often consume durable streams or batch work outside the main memory-service process. They need a reliable place to save restart state after successful processing so they do not lose progress or reprocess large event ranges after a crash.
+
+Keeping checkpoint persistence inside the admin API gives processor deployments a single authenticated control plane. Processors should use dedicated admin credentials and use that credential's `clientId` as the checkpoint key. The service validates ownership, checkpoint key, content type, and JSON shape, and encrypts the payload at rest, while the processor owns the payload contract.
+
+## Design
+
+### REST API
+
+The admin API exposes two endpoints:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/v1/admin/checkpoints/{clientId}` | Return the latest checkpoint for one admin client. |
+| `PUT` | `/v1/admin/checkpoints/{clientId}` | Create or replace the checkpoint for one admin client. |
+
+Both endpoints require the admin role. Auditors and regular users cannot read or write checkpoints. Callers should pass the processor credential's stable `clientId` as the path parameter. When the request has an authenticated client ID, it must match the path `clientId`. Admin calls without a client ID can manage any checkpoint.
+
+Example write:
+
+```http
+PUT /v1/admin/checkpoints/checkpoint-processor
+Content-Type: application/json
+
+{
+  "contentType": "application/vnd.memory-service.checkpoint+json;v=1",
+  "value": {
+    "cursor": "cursor-123",
+    "processed": 3,
+    "recentConversationIds": ["conv-a", "conv-b"]
+  }
+}
+```
+
+Example response:
+
+```json
+{
+  "clientId": "checkpoint-processor",
+  "contentType": "application/vnd.memory-service.checkpoint+json;v=1",
+  "value": {
+    "cursor": "cursor-123",
+    "processed": 3,
+    "recentConversationIds": ["conv-a", "conv-b"]
+  },
+  "updatedAt": "2026-04-29T12:00:00Z"
+}
+```
+
+### Data Model
+
+Each store implements `AdminCheckpointStore`:
+
+```go
+type ClientCheckpoint struct {
+    ClientID    string          `json:"clientId"`
+    ContentType string          `json:"contentType"`
+    Value       json.RawMessage `json:"value"`
+    UpdatedAt   time.Time       `json:"updatedAt"`
+}
+
+type AdminCheckpointStore interface {
+    AdminGetCheckpoint(ctx context.Context, clientID string) (*ClientCheckpoint, error)
+    AdminPutCheckpoint(ctx context.Context, checkpoint ClientCheckpoint) (*ClientCheckpoint, error)
+}
+```
+
+PostgreSQL and SQLite store checkpoints in `admin_checkpoints` with `client_id` as the primary key. MongoDB stores checkpoints in the `admin_checkpoints` collection with a unique `client_id` index.
+
+The `value` field is encrypted before it is written to the store and decrypted before it is returned by the API. When database encryption is disabled, the same code path stores the JSON bytes as opaque `BYTEA`/`BLOB`/binary data rather than as queryable JSON.
+
+### Validation
+
+The checkpoint `clientId` is trimmed and must be non-empty. `contentType` is trimmed and must be non-empty. `value` must be valid JSON, but the service does not validate processor-specific fields inside the payload. If the authenticated admin client ID does not match the path `clientId`, reads and writes return `404` so callers cannot distinguish it from an unknown checkpoint.
+
+## Testing
+
+BDD coverage should exercise:
+
+```gherkin
+Feature: Admin checkpoint REST API
+
+  Scenario: Admin can create a checkpoint with typed generic JSON data
+    When I call PUT "/v1/admin/checkpoints/checkpoint-processor" with body:
+      """
+      {
+        "contentType": "application/vnd.memory-service.checkpoint+json;v=1",
+        "value": {
+          "cursor": "cursor-123",
+          "processed": 3
+        }
+      }
+      """
+    Then the response status should be 200
+    And the response body field "clientId" should be "checkpoint-processor"
+    And the response body field "value.cursor" should be "cursor-123"
+
+  Scenario: Admin can read a previously stored checkpoint
+    Given I call PUT "/v1/admin/checkpoints/checkpoint-processor" with body:
+      """
+      {
+        "contentType": "application/example+json",
+        "value": { "cursor": "cursor-456" }
+      }
+      """
+    When I call GET "/v1/admin/checkpoints/checkpoint-processor"
+    Then the response status should be 200
+    And the response body field "value.cursor" should be "cursor-456"
+
+  Scenario: Non-admin callers cannot read or write checkpoints
+    Given I am authenticated as user "bob"
+    When I call GET "/v1/admin/checkpoints/checkpoint-processor"
+    Then the response status should be 403
+
+  Scenario: Admin client IDs scope checkpoint ownership
+    Given I am authenticated as admin user "alice"
+    And I am authenticated as agent with API key "test-agent-key"
+    And set "currentClientId" to the current client ID
+    When I call PUT "/v1/admin/checkpoints/${currentClientId}" with body:
+      """
+      {
+        "contentType": "application/example+json",
+        "value": { "cursor": "client-a" }
+      }
+      """
+    Then the response status should be 200
+    Given I am authenticated as admin user "alice"
+    And I am authenticated as agent with API key "test-agent-key-b"
+    When I call GET "/v1/admin/checkpoints/${currentClientId}"
+    Then the response status should be 404
+```
+
+## Tasks
+
+- [x] Add OpenAPI admin contract for checkpoint get/put operations.
+- [x] Regenerate Go admin OpenAPI bindings.
+- [x] Add admin route handlers and wrapper route registration.
+- [x] Add generic checkpoint store interface.
+- [x] Encrypt checkpoint values at rest.
+- [x] Bind checkpoints to the authenticated admin client ID when present.
+- [x] Implement checkpoint storage for PostgreSQL, SQLite, and MongoDB.
+- [x] Forward checkpoint operations through the metrics store wrapper.
+- [x] Add BDD feature coverage for create, read, replace, validation, and authorization behavior.
+
+## Files to Modify
+
+| File | Changes |
+| --- | --- |
+| `contracts/openapi/openapi-admin.yml` | Add checkpoint endpoints and schemas. |
+| `internal/generated/admin/admin.gen.go` | Regenerate admin server bindings. |
+| `internal/plugin/route/admin/checkpoints.go` | Add checkpoint get/put handlers. |
+| `internal/plugin/route/admin/admin.go` | Mount checkpoint routes for direct admin route registration. |
+| `internal/cmd/serve/wrapper_routes.go` | Register generated-wrapper checkpoint routes. |
+| `internal/registry/store/plugin.go` | Add `ClientCheckpoint` and `AdminCheckpointStore`. |
+| `internal/plugin/store/postgres/checkpoints.go` | Implement PostgreSQL checkpoint operations. |
+| `internal/plugin/store/postgres/db/schema.sql` | Add `admin_checkpoints` table with encrypted value bytes keyed by `client_id`. |
+| `internal/plugin/store/sqlite/checkpoints.go` | Implement SQLite checkpoint operations. |
+| `internal/plugin/store/sqlite/db/schema.sql` | Add `admin_checkpoints` table with encrypted value bytes keyed by `client_id`. |
+| `internal/plugin/store/mongo/checkpoints.go` | Implement MongoDB checkpoint operations. |
+| `internal/plugin/store/mongo/mongo.go` | Add unique checkpoint key index. |
+| `internal/plugin/store/metrics/metrics.go` | Forward checkpoint operations through the metrics wrapper. |
+| `internal/bdd/testdata/features/admin-checkpoints-rest.feature` | Add REST behavior coverage. |
+| `internal/bdd/feature_selection.go` | Run checkpoint feature serially. |
+
+## Verification
+
+```bash
+# Regenerate admin OpenAPI bindings
+go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config=internal/generated/admin/cfg.yaml contracts/openapi/openapi-admin.yml
+
+# Compile affected Go packages
+go test ./internal/registry/store ./internal/plugin/route/admin ./internal/plugin/store/sqlite ./internal/plugin/store/postgres ./internal/plugin/store/mongo ./internal/plugin/store/metrics ./internal/cmd/serve -run '^$'
+
+# Run serial SQLite BDD coverage, including admin-checkpoints-rest.feature
+go test -tags sqlite_fts5 ./internal/bdd -run TestFeaturesSQLiteSerial -count=1
+```
+
+## Non-Goals
+
+This enhancement does not define a processor-specific checkpoint payload schema, retention policy, or checkpoint history. A checkpoint is a replace-in-place document keyed by the processor's admin `clientId`.
+
+## Security Considerations
+
+Checkpoints can contain durable event cursors and processor state, so the API is admin-only rather than auditor-readable. The payload is encrypted at rest using the existing database encryption service. Processors should use dedicated admin credentials with a stable `clientId` and pass that `clientId` as the checkpoint key; when they do, other admin clients receive `404` for that key. Processors should still avoid storing long-lived secrets in checkpoint payloads.

--- a/internal/bdd/feature_selection.go
+++ b/internal/bdd/feature_selection.go
@@ -9,6 +9,7 @@ import (
 
 var serialFeatureFiles = map[string]bool{
 	"admin-rest.feature":             true,
+	"admin-checkpoints-rest.feature": true,
 	"admin-attachments-rest.feature": true,
 	"admin-stats-rest.feature":       true,
 	"eviction-rest.feature":          true,

--- a/internal/bdd/steps_auth.go
+++ b/internal/bdd/steps_auth.go
@@ -15,6 +15,7 @@ func init() {
 		ctx.Step(`^I am authenticated as indexer user "([^"]*)"$`, a.iAmAuthenticatedAsIndexerUser)
 		ctx.Step(`^I am not authenticated$`, a.iAmNotAuthenticated)
 		ctx.Step(`^I authenticate as user "([^"]*)"$`, a.iAmAuthenticatedAsUser)
+		ctx.Step(`^set "([^"]*)" to the current client ID$`, a.setToCurrentClientID)
 	})
 }
 
@@ -124,5 +125,10 @@ func (a *authSteps) iAmNotAuthenticated() error {
 	session.Header.Del("X-Client-ID")
 	session.TestUser = nil
 	a.s.CurrentUser = ""
+	return nil
+}
+
+func (a *authSteps) setToCurrentClientID(name string) error {
+	a.s.Variables[name] = a.s.Session().Header.Get("X-Client-ID")
 	return nil
 }

--- a/internal/bdd/steps_auth.go
+++ b/internal/bdd/steps_auth.go
@@ -11,6 +11,7 @@ func init() {
 		ctx.Step(`^I am authenticated as user "([^"]*)"$`, a.iAmAuthenticatedAsUser)
 		ctx.Step(`^I am authenticated as admin user "([^"]*)"$`, a.iAmAuthenticatedAsAdminUser)
 		ctx.Step(`^I am authenticated as agent with API key "([^"]*)"$`, a.iAmAuthenticatedAsAgentWithAPIKey)
+		ctx.Step(`^I am authenticated as admin client with API key "([^"]*)"$`, a.iAmAuthenticatedAsAdminClientWithAPIKey)
 		ctx.Step(`^I am authenticated as auditor user "([^"]*)"$`, a.iAmAuthenticatedAsAuditorUser)
 		ctx.Step(`^I am authenticated as indexer user "([^"]*)"$`, a.iAmAuthenticatedAsIndexerUser)
 		ctx.Step(`^I am not authenticated$`, a.iAmNotAuthenticated)
@@ -103,6 +104,10 @@ func (a *authSteps) iAmAuthenticatedAsAgentWithAPIKey(apiKey string) error {
 	session := a.s.Session()
 	session.Header.Set("X-Client-ID", a.s.IsolatedClientID(apiKey))
 	return nil
+}
+
+func (a *authSteps) iAmAuthenticatedAsAdminClientWithAPIKey(apiKey string) error {
+	return a.iAmAuthenticatedAsAgentWithAPIKey(apiKey)
 }
 
 func (a *authSteps) iAmAuthenticatedAsAuditorUser(userID string) error {

--- a/internal/bdd/testdata/features/admin-checkpoints-rest.feature
+++ b/internal/bdd/testdata/features/admin-checkpoints-rest.feature
@@ -94,38 +94,39 @@ Feature: Admin checkpoint REST API
     And the response body field "value.mode" should be "full"
     And the response body field "value.cursor" should be null
 
-  Scenario: Admin client IDs scope checkpoint ownership
-    Given I am authenticated as agent with API key "test-agent-key"
-    And set "currentClientId" to the current client ID
-    When I call PUT "/v1/admin/checkpoints/${currentClientId}" with body:
+  Scenario: Admin clients can only access checkpoints for their own client ID
+    Given I am authenticated as admin client with API key "test-agent-key"
+    And set "ownerClientId" to the current client ID
+    When I call PUT "/v1/admin/checkpoints/${ownerClientId}" with body:
     """
     {
       "contentType": "application/example+json",
       "value": {
-        "cursor": "client-a"
+        "cursor": "owner-client"
       }
     }
     """
     Then the response status should be 200
     Given I am authenticated as admin user "alice"
-    And I am authenticated as agent with API key "test-agent-key-b"
-    When I call GET "/v1/admin/checkpoints/${currentClientId}"
+    And I am authenticated as admin client with API key "test-agent-key-b"
+    When I call GET "/v1/admin/checkpoints/${ownerClientId}"
     Then the response status should be 404
-    When I call PUT "/v1/admin/checkpoints/${currentClientId}" with body:
+    When I call PUT "/v1/admin/checkpoints/${ownerClientId}" with body:
     """
     {
       "contentType": "application/example+json",
       "value": {
-        "cursor": "client-b"
+        "cursor": "other-client"
       }
     }
     """
     Then the response status should be 404
     Given I am authenticated as admin user "alice"
-    And I am authenticated as agent with API key "test-agent-key"
-    When I call GET "/v1/admin/checkpoints/${currentClientId}"
+    And I am authenticated as admin client with API key "test-agent-key"
+    When I call GET "/v1/admin/checkpoints/${ownerClientId}"
     Then the response status should be 200
-    And the response body field "value.cursor" should be "client-a"
+    And the response body field "clientId" should be "${ownerClientId}"
+    And the response body field "value.cursor" should be "owner-client"
 
   Scenario: Admin gets not found for an unknown checkpoint
     When I call GET "/v1/admin/checkpoints/missing-client"

--- a/internal/bdd/testdata/features/admin-checkpoints-rest.feature
+++ b/internal/bdd/testdata/features/admin-checkpoints-rest.feature
@@ -1,0 +1,180 @@
+Feature: Admin checkpoint REST API
+  As an administrator
+  I want to manage remote client checkpoints through the admin API
+  So that standalone processors can resume safely with typed checkpoint payloads
+
+  Background:
+    Given I am authenticated as admin user "alice"
+
+  Scenario: Admin can create a checkpoint with typed generic JSON data
+    When I call PUT "/v1/admin/checkpoints/generic-client-a" with body:
+    """
+    {
+      "contentType": "application/vnd.memory-service.checkpoint+json;v=1",
+      "value": {
+        "cursor": "cursor-123",
+        "processed": 3,
+        "recentConversationIds": ["conv-a", "conv-b"],
+        "state": {
+          "mode": "live"
+        }
+      }
+    }
+    """
+    Then the response status should be 200
+    And the response body field "clientId" should be "generic-client-a"
+    And the response body field "contentType" should be "application/vnd.memory-service.checkpoint+json;v=1"
+    And the response body field "value.cursor" should be "cursor-123"
+    And the response body field "value.processed" should be "3"
+    And the response body field "value.recentConversationIds[0]" should be "conv-a"
+    And the response body field "value.recentConversationIds[1]" should be "conv-b"
+    And the response body field "value.state.mode" should be "live"
+    And the response body field "updatedAt" should not be null
+
+  Scenario: Admin can read a previously stored checkpoint
+    Given I call PUT "/v1/admin/checkpoints/generic-client-b" with body:
+    """
+    {
+      "contentType": "application/vnd.memory-service.checkpoint+json;v=1",
+      "value": {
+        "cursor": "cursor-456",
+        "batch": {
+          "size": 10
+        }
+      }
+    }
+    """
+    And the response status should be 200
+    When I call GET "/v1/admin/checkpoints/generic-client-b"
+    Then the response status should be 200
+    And the response body should contain json:
+    """
+    {
+      "clientId": "generic-client-b",
+      "contentType": "application/vnd.memory-service.checkpoint+json;v=1",
+      "value": {
+        "cursor": "cursor-456",
+        "batch": {
+          "size": 10
+        }
+      }
+    }
+    """
+    And the response body field "updatedAt" should not be null
+
+  Scenario: Admin can replace a checkpoint with a different typed JSON payload
+    Given I call PUT "/v1/admin/checkpoints/generic-client-c" with body:
+    """
+    {
+      "contentType": "application/vnd.memory-service.checkpoint+json;v=1",
+      "value": {
+        "cursor": "cursor-old"
+      }
+    }
+    """
+    And the response status should be 200
+    When I call PUT "/v1/admin/checkpoints/generic-client-c" with body:
+    """
+    {
+      "contentType": "application/example+json",
+      "value": {
+        "positions": [1, 2],
+        "mode": "full"
+      }
+    }
+    """
+    Then the response status should be 200
+    And the response body field "contentType" should be "application/example+json"
+    And the response body field "value.positions[0]" should be "1"
+    And the response body field "value.positions[1]" should be "2"
+    And the response body field "value.mode" should be "full"
+    When I call GET "/v1/admin/checkpoints/generic-client-c"
+    Then the response status should be 200
+    And the response body field "contentType" should be "application/example+json"
+    And the response body field "value.mode" should be "full"
+    And the response body field "value.cursor" should be null
+
+  Scenario: Admin client IDs scope checkpoint ownership
+    Given I am authenticated as agent with API key "test-agent-key"
+    And set "currentClientId" to the current client ID
+    When I call PUT "/v1/admin/checkpoints/${currentClientId}" with body:
+    """
+    {
+      "contentType": "application/example+json",
+      "value": {
+        "cursor": "client-a"
+      }
+    }
+    """
+    Then the response status should be 200
+    Given I am authenticated as admin user "alice"
+    And I am authenticated as agent with API key "test-agent-key-b"
+    When I call GET "/v1/admin/checkpoints/${currentClientId}"
+    Then the response status should be 404
+    When I call PUT "/v1/admin/checkpoints/${currentClientId}" with body:
+    """
+    {
+      "contentType": "application/example+json",
+      "value": {
+        "cursor": "client-b"
+      }
+    }
+    """
+    Then the response status should be 404
+    Given I am authenticated as admin user "alice"
+    And I am authenticated as agent with API key "test-agent-key"
+    When I call GET "/v1/admin/checkpoints/${currentClientId}"
+    Then the response status should be 200
+    And the response body field "value.cursor" should be "client-a"
+
+  Scenario: Admin gets not found for an unknown checkpoint
+    When I call GET "/v1/admin/checkpoints/missing-client"
+    Then the response status should be 404
+    And the response body field "error" should be "checkpoint not found"
+
+  Scenario: Admin cannot write a checkpoint without contentType
+    When I call PUT "/v1/admin/checkpoints/generic-client-invalid" with body:
+    """
+    {
+      "value": {
+        "cursor": "cursor-789"
+      }
+    }
+    """
+    Then the response status should be 400
+    And the response body field "error" should contain "contentType"
+
+  Scenario: Auditor cannot read or write checkpoints
+    Given I am authenticated as auditor user "charlie"
+    When I call GET "/v1/admin/checkpoints/generic-client-a"
+    Then the response status should be 403
+    When I call PUT "/v1/admin/checkpoints/generic-client-a" with body:
+    """
+    {
+      "contentType": "application/vnd.memory-service.checkpoint+json;v=1",
+      "value": {
+        "cursor": "cursor-000"
+      }
+    }
+    """
+    Then the response status should be 403
+
+  Scenario: Regular users cannot read or write checkpoints
+    Given I am authenticated as user "bob"
+    When I call GET "/v1/admin/checkpoints/generic-client-a"
+    Then the response status should be 403
+    When I call PUT "/v1/admin/checkpoints/generic-client-a" with body:
+    """
+    {
+      "contentType": "application/vnd.memory-service.checkpoint+json;v=1",
+      "value": {
+        "cursor": "cursor-000"
+      }
+    }
+    """
+    Then the response status should be 403
+
+  Scenario: Unauthenticated callers cannot read checkpoints
+    Given I am not authenticated
+    When I call GET "/v1/admin/checkpoints/generic-client-a"
+    Then the response status should be 401

--- a/internal/bdd/testdata/features/admin-checkpoints-rest.feature
+++ b/internal/bdd/testdata/features/admin-checkpoints-rest.feature
@@ -109,6 +109,7 @@ Feature: Admin checkpoint REST API
     Then the response status should be 200
     Given I am authenticated as admin user "alice"
     And I am authenticated as admin client with API key "test-agent-key-b"
+    And set "otherClientId" to the current client ID
     When I call GET "/v1/admin/checkpoints/${ownerClientId}"
     Then the response status should be 404
     When I call PUT "/v1/admin/checkpoints/${ownerClientId}" with body:
@@ -121,12 +122,30 @@ Feature: Admin checkpoint REST API
     }
     """
     Then the response status should be 404
+    When I call PUT "/v1/admin/checkpoints/${otherClientId}" with body:
+    """
+    {
+      "contentType": "application/example+json",
+      "value": {
+        "cursor": "other-client"
+      }
+    }
+    """
+    Then the response status should be 200
+    And the response body field "clientId" should be "${otherClientId}"
+    When I call GET "/v1/admin/checkpoints/${otherClientId}"
+    Then the response status should be 200
+    And the response body field "value.cursor" should be "other-client"
+    When I call GET "/v1/admin/checkpoints/${ownerClientId}"
+    Then the response status should be 404
     Given I am authenticated as admin user "alice"
     And I am authenticated as admin client with API key "test-agent-key"
     When I call GET "/v1/admin/checkpoints/${ownerClientId}"
     Then the response status should be 200
     And the response body field "clientId" should be "${ownerClientId}"
     And the response body field "value.cursor" should be "owner-client"
+    When I call GET "/v1/admin/checkpoints/${otherClientId}"
+    Then the response status should be 404
 
   Scenario: Admin gets not found for an unknown checkpoint
     When I call GET "/v1/admin/checkpoints/missing-client"

--- a/internal/cmd/serve/wrapper_routes.go
+++ b/internal/cmd/serve/wrapper_routes.go
@@ -156,6 +156,8 @@ func registerAPIRoutes(router *gin.Engine, auth gin.HandlerFunc, cfg *config.Con
 	register(http.MethodGet, "/v1/admin/attachments/:id", adminWrapper.AdminGetAttachment)
 	register(http.MethodGet, "/v1/admin/attachments/:id/content", adminWrapper.AdminGetAttachmentContent)
 	register(http.MethodGet, "/v1/admin/attachments/:id/download-url", adminWrapper.AdminGetAttachmentDownloadUrl)
+	register(http.MethodGet, "/v1/admin/checkpoints/:clientId", adminWrapper.AdminGetCheckpoint)
+	register(http.MethodPut, "/v1/admin/checkpoints/:clientId", adminWrapper.AdminPutCheckpoint)
 	register(http.MethodGet, "/v1/admin/conversations", adminWrapper.AdminListConversations)
 	register(http.MethodPost, "/v1/admin/conversations/search", adminWrapper.AdminSearchConversations)
 	register(http.MethodGet, "/v1/admin/conversations/:id", adminWrapper.AdminGetConversation)
@@ -341,6 +343,18 @@ func (p *proxyAdminServer) AdminSubscribeEvents(c *gin.Context, _ generatedadmin
 		return
 	}
 	routeadmin.HandleAdminSSEEvents(c, p.store, p.eventBus, p.cfg)
+}
+func (p *proxyAdminServer) AdminGetCheckpoint(c *gin.Context, _ string) {
+	if !p.authorize(c) {
+		return
+	}
+	routeadmin.HandleAdminGetCheckpoint(c, p.store)
+}
+func (p *proxyAdminServer) AdminPutCheckpoint(c *gin.Context, _ string) {
+	if !p.authorize(c) {
+		return
+	}
+	routeadmin.HandleAdminPutCheckpoint(c, p.store)
 }
 func (p *proxyAdminServer) AdminTriggerMemoryIndex(c *gin.Context) {
 	if !p.authorize(c) {

--- a/internal/generated/admin/admin.gen.go
+++ b/internal/generated/admin/admin.gen.go
@@ -131,6 +131,24 @@ type AdminAttachment struct {
 	UserId     *string `json:"userId,omitempty"`
 }
 
+// AdminCheckpoint defines model for AdminCheckpoint.
+type AdminCheckpoint struct {
+	ClientId    string    `json:"clientId"`
+	ContentType string    `json:"contentType"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+
+	// Value Processor-defined JSON payload for this client checkpoint. Stored encrypted at rest.
+	Value interface{} `json:"value"`
+}
+
+// AdminCheckpointPutRequest defines model for AdminCheckpointPutRequest.
+type AdminCheckpointPutRequest struct {
+	ContentType string `json:"contentType"`
+
+	// Value Processor-defined JSON payload to persist for this client checkpoint. Stored encrypted at rest.
+	Value interface{} `json:"value"`
+}
+
 // AdminChildConversationSummary defines model for AdminChildConversationSummary.
 type AdminChildConversationSummary struct {
 	// AccessLevel Access level of a user for a conversation.
@@ -757,6 +775,9 @@ type AdminPutMemoryPoliciesJSONRequestBody = MemoryPolicyBundle
 // AdminDeleteAttachmentJSONRequestBody defines body for AdminDeleteAttachment for application/json ContentType.
 type AdminDeleteAttachmentJSONRequestBody = AdminActionRequest
 
+// AdminPutCheckpointJSONRequestBody defines body for AdminPutCheckpoint for application/json ContentType.
+type AdminPutCheckpointJSONRequestBody = AdminCheckpointPutRequest
+
 // AdminSearchConversationsJSONRequestBody defines body for AdminSearchConversations for application/json ContentType.
 type AdminSearchConversationsJSONRequestBody = AdminSearchEntriesRequest
 
@@ -804,6 +825,12 @@ type ServerInterface interface {
 	// Get signed download URL for any attachment (admin/auditor)
 	// (GET /v1/admin/attachments/{id}/download-url)
 	AdminGetAttachmentDownloadUrl(c *gin.Context, id openapi_types.UUID, params AdminGetAttachmentDownloadUrlParams)
+	// Get an admin client checkpoint
+	// (GET /v1/admin/checkpoints/{clientId})
+	AdminGetCheckpoint(c *gin.Context, clientId string)
+	// Upsert an admin client checkpoint
+	// (PUT /v1/admin/checkpoints/{clientId})
+	AdminPutCheckpoint(c *gin.Context, clientId string)
 	// List all conversations (admin/auditor)
 	// (GET /v1/admin/conversations)
 	AdminListConversations(c *gin.Context, params AdminListConversationsParams)
@@ -1255,6 +1282,58 @@ func (siw *ServerInterfaceWrapper) AdminGetAttachmentDownloadUrl(c *gin.Context)
 	}
 
 	siw.Handler.AdminGetAttachmentDownloadUrl(c, id, params)
+}
+
+// AdminGetCheckpoint operation middleware
+func (siw *ServerInterfaceWrapper) AdminGetCheckpoint(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "clientId" -------------
+	var clientId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "clientId", c.Param("clientId"), &clientId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter clientId: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	c.Set(BearerAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.AdminGetCheckpoint(c, clientId)
+}
+
+// AdminPutCheckpoint operation middleware
+func (siw *ServerInterfaceWrapper) AdminPutCheckpoint(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "clientId" -------------
+	var clientId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "clientId", c.Param("clientId"), &clientId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter clientId: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	c.Set(BearerAuthScopes, []string{})
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.AdminPutCheckpoint(c, clientId)
 }
 
 // AdminListConversations operation middleware
@@ -2115,6 +2194,8 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/v1/admin/attachments/:id", wrapper.AdminGetAttachment)
 	router.GET(options.BaseURL+"/v1/admin/attachments/:id/content", wrapper.AdminGetAttachmentContent)
 	router.GET(options.BaseURL+"/v1/admin/attachments/:id/download-url", wrapper.AdminGetAttachmentDownloadUrl)
+	router.GET(options.BaseURL+"/v1/admin/checkpoints/:clientId", wrapper.AdminGetCheckpoint)
+	router.PUT(options.BaseURL+"/v1/admin/checkpoints/:clientId", wrapper.AdminPutCheckpoint)
 	router.GET(options.BaseURL+"/v1/admin/conversations", wrapper.AdminListConversations)
 	router.POST(options.BaseURL+"/v1/admin/conversations/search", wrapper.AdminSearchConversations)
 	router.GET(options.BaseURL+"/v1/admin/conversations/:id", wrapper.AdminGetConversation)
@@ -2562,6 +2643,91 @@ func (response AdminGetAttachmentDownloadUrldefaultJSONResponse) VisitAdminGetAt
 	w.WriteHeader(response.StatusCode)
 
 	return json.NewEncoder(w).Encode(response.Body)
+}
+
+type AdminGetCheckpointRequestObject struct {
+	ClientId string `json:"clientId"`
+}
+
+type AdminGetCheckpointResponseObject interface {
+	VisitAdminGetCheckpointResponse(w http.ResponseWriter) error
+}
+
+type AdminGetCheckpoint200JSONResponse AdminCheckpoint
+
+func (response AdminGetCheckpoint200JSONResponse) VisitAdminGetCheckpointResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminGetCheckpoint401Response struct {
+}
+
+func (response AdminGetCheckpoint401Response) VisitAdminGetCheckpointResponse(w http.ResponseWriter) error {
+	w.WriteHeader(401)
+	return nil
+}
+
+type AdminGetCheckpoint403Response struct {
+}
+
+func (response AdminGetCheckpoint403Response) VisitAdminGetCheckpointResponse(w http.ResponseWriter) error {
+	w.WriteHeader(403)
+	return nil
+}
+
+type AdminGetCheckpoint404JSONResponse ErrorResponse
+
+func (response AdminGetCheckpoint404JSONResponse) VisitAdminGetCheckpointResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminPutCheckpointRequestObject struct {
+	ClientId string `json:"clientId"`
+	Body     *AdminPutCheckpointJSONRequestBody
+}
+
+type AdminPutCheckpointResponseObject interface {
+	VisitAdminPutCheckpointResponse(w http.ResponseWriter) error
+}
+
+type AdminPutCheckpoint200JSONResponse AdminCheckpoint
+
+func (response AdminPutCheckpoint200JSONResponse) VisitAdminPutCheckpointResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminPutCheckpoint400JSONResponse ErrorResponse
+
+func (response AdminPutCheckpoint400JSONResponse) VisitAdminPutCheckpointResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type AdminPutCheckpoint401Response struct {
+}
+
+func (response AdminPutCheckpoint401Response) VisitAdminPutCheckpointResponse(w http.ResponseWriter) error {
+	w.WriteHeader(401)
+	return nil
+}
+
+type AdminPutCheckpoint403Response struct {
+}
+
+func (response AdminPutCheckpoint403Response) VisitAdminPutCheckpointResponse(w http.ResponseWriter) error {
+	w.WriteHeader(403)
+	return nil
 }
 
 type AdminListConversationsRequestObject struct {
@@ -3416,6 +3582,12 @@ type StrictServerInterface interface {
 	// Get signed download URL for any attachment (admin/auditor)
 	// (GET /v1/admin/attachments/{id}/download-url)
 	AdminGetAttachmentDownloadUrl(ctx context.Context, request AdminGetAttachmentDownloadUrlRequestObject) (AdminGetAttachmentDownloadUrlResponseObject, error)
+	// Get an admin client checkpoint
+	// (GET /v1/admin/checkpoints/{clientId})
+	AdminGetCheckpoint(ctx context.Context, request AdminGetCheckpointRequestObject) (AdminGetCheckpointResponseObject, error)
+	// Upsert an admin client checkpoint
+	// (PUT /v1/admin/checkpoints/{clientId})
+	AdminPutCheckpoint(ctx context.Context, request AdminPutCheckpointRequestObject) (AdminPutCheckpointResponseObject, error)
 	// List all conversations (admin/auditor)
 	// (GET /v1/admin/conversations)
 	AdminListConversations(ctx context.Context, request AdminListConversationsRequestObject) (AdminListConversationsResponseObject, error)
@@ -3815,6 +3987,68 @@ func (sh *strictHandler) AdminGetAttachmentDownloadUrl(ctx *gin.Context, id open
 		ctx.Status(http.StatusInternalServerError)
 	} else if validResponse, ok := response.(AdminGetAttachmentDownloadUrlResponseObject); ok {
 		if err := validResponse.VisitAdminGetAttachmentDownloadUrlResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// AdminGetCheckpoint operation middleware
+func (sh *strictHandler) AdminGetCheckpoint(ctx *gin.Context, clientId string) {
+	var request AdminGetCheckpointRequestObject
+
+	request.ClientId = clientId
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.AdminGetCheckpoint(ctx, request.(AdminGetCheckpointRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "AdminGetCheckpoint")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(AdminGetCheckpointResponseObject); ok {
+		if err := validResponse.VisitAdminGetCheckpointResponse(ctx.Writer); err != nil {
+			ctx.Error(err)
+		}
+	} else if response != nil {
+		ctx.Error(fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// AdminPutCheckpoint operation middleware
+func (sh *strictHandler) AdminPutCheckpoint(ctx *gin.Context, clientId string) {
+	var request AdminPutCheckpointRequestObject
+
+	request.ClientId = clientId
+
+	var body AdminPutCheckpointJSONRequestBody
+	if err := ctx.ShouldBindJSON(&body); err != nil {
+		ctx.Status(http.StatusBadRequest)
+		ctx.Error(err)
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx *gin.Context, request interface{}) (interface{}, error) {
+		return sh.ssi.AdminPutCheckpoint(ctx, request.(AdminPutCheckpointRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "AdminPutCheckpoint")
+	}
+
+	response, err := handler(ctx, request)
+
+	if err != nil {
+		ctx.Error(err)
+		ctx.Status(http.StatusInternalServerError)
+	} else if validResponse, ok := response.(AdminPutCheckpointResponseObject); ok {
+		if err := validResponse.VisitAdminPutCheckpointResponse(ctx.Writer); err != nil {
 			ctx.Error(err)
 		}
 	} else if response != nil {
@@ -4363,135 +4597,140 @@ func (sh *strictHandler) GetHealth(ctx *gin.Context) {
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+w9a3MbOXJ/BcVLVSQXRVGytTkrdZWSX7u67K4VS85VsnRZ4EyTxGkIzAIYytwt//cU",
-	"ujFvDB96WNqNvrhkzgzQ6Hc3Go3fe5Gap0qCtKZ3/Hsv5ZrPwYLG/51bbs1bGbu/YzCRFqkVSvaOe29l",
-	"zNSEWTEHprmcAts5PX/P/vrd8AB/NJbP090BewMTniXWMKuYVNeDXr8n3Pe/ZqCXvX5P8jn0jnsg416/",
-	"Z6IZzLmbbKL0nNvecS/mFvbcgL1+zy5T966xWshp7+vXPsF3brm2bQjx561hPGAzlWnGp6oLVIPT3RxY",
-	"SNuwfgCjksz9hxkLKZsozewMCHQDWoBhOzCYDvps1PtuaEY998fRfNRrgO+fdsMOaQ30mL7tHbvvAlB/",
-	"7fc0mFRJA8gQb7VW2v0RKWlBItp5miYi4g76/X8at57fKzP8i4ZJ77j3l/2Sz/bpqdnH0T748Wm2Bpe5",
-	"F5gu3uj3flb2ncqII78NDI42mY6ASWXZBOd2L/nv3fAnUQTG/AgLSNqkpYcscU8dN3KWGdBIYc4iJReg",
-	"DcLtaAYym/eOf+mpawm61+/NueRT/OtaC4t/aOAx6N6nFq36vZN4LuRJ5Ab7AL9mYBA18IXP0wTcn//M",
-	"jBUTj6fece+jg0TTqxAzHkUqk5ZFCXCZpSwFzUyWpkpbZkV0BZb95eDw+Qs3V6pVCtoKYovGwG325kbJ",
-	"gqu5g5NxBJTtICayWFiWqOnuICg6/hc1/idEtlyqjmZiAfGFsjxB6UINVoOM+3dqmDg46JdCK6T97oXD",
-	"tZBi7tA/LOYT0oJD/9d+TyUxGJvPeBLQN+/xDeYnLBWMXza3jo+Jk9zwSO4coN7h8PC7veHzvcOji+HL",
-	"44Oj4+Hwf3v9sGaRWZLwsfvM6gwCfGAdPmoLfvl8ywWj3P+aCe0w94sfsV9i81MnTazl0WzuxbKbFg1d",
-	"vZR2BlZEBfomCZ+yGLR7n020miPnOPi05En+WlyiucI4Y6UcBzuYvIq4wAe/t1EVaeA2p+cmetzJqNXL",
-	"07j2QZaJeBPKwJdUaDArpls7xEQkQNo8sBwRBKv1mobJayfpbUL8nM3HoFFPFYRkGiKlY8PMjLsRkBKG",
-	"O8tkleZTYONEjSv4r4iNmfHDo++CsBrxG9SgzfkyMArN85+wDI7kFCoRZFPN8Xomkvh1RfmeZ/M518sA",
-	"z9Z1+ypLUjUDX/sPwu3bc7MIwPdRil8zYCIG6bS6t1YOosjhrWW11vJbwo39CYzhUzjTsBBw7SZdy+po",
-	"BT92EbdPnhjEr5ZvbyGSVlgyjmvfzNJ4O+x2s18FgchkSfJ+0jv+ZQ1/NT/NmfZrv8m1E6WvHKTVt08D",
-	"lK4+Z6dviPWuZyKaMTsTpkZpds0No4FDRF+vuDxMFWLVgXkntLEs5drpHNSyDL5ESRZDzMZLAsgNMmA/",
-	"Z0mCPKmVsjUgDeMyZuOEy6s9k3AL+IUh+yvkDLSwTKrqLALMjdZTcF8byTcf6+ac3Ga2TyF2+16rLN3G",
-	"V/q3+3OVLguJuqy4S3yu5LRUeTXqdjpNB8O7d5oODoffymu6b1M0BWmJq9bi4SHMViI2h+/+bdxjs26P",
-	"Q788jKV8o65lonj8USdFjN4SDO9VnwYiz48ffmQLnohY2CWLM02WTEhmIFIyNmGvNdOBQP5CzGEvEXPh",
-	"QmUjphJi5oZ3fBN7MHPvuHSet4ln32d2rL50KGevVbu1qQbLhQNK4TAMFs7C1UTvm6nOF4eHd6M6i1V3",
-	"qs5zcGrmLRnyStqjoTsnFvTrTBvKXjW8IPwdCZnyqZDIJP/uEJppaZiwMDcMRyAnRIPJEqTsnH/5EeTU",
-	"znrHB8PhBqgSEh2ak5qS9Sm4CU8MNLNPp/RB7qmQlu02jm3l6mdEwa9NRxDWZ/vHDOzMLVMx/x2y88T5",
-	"W+SRCemXbwbsHKx7E+F2f2iIswiKdB1zER67noFkSiZLNgfLY245E4ZJgJj8yDbEKGM1UJ0hrgP6E//i",
-	"WInJIl71UBEcjnCePsRxB0NHnoIBD0JST7nSdkjMbaZ5whIup5mLdvG9NvVp/OKH/qo4ten4Jo63DHKy",
-	"W0Ddo3WGovSA3SCNyQ+PjjZxD6vyRWvtFipMVZMj0q13o6Zfadb6JSvcUcrWlOveaKxK6s+nZjxsW345",
-	"h7na+NNA3tHZc1S7bxf5TsoWQV1V8X/91KRlk3YBtDdRV6KisrQGiJ3EX5VODXjJfz26C1XfCc1H9CWq",
-	"PFNR8lvguJ4Xb4fMK/xeUnOXjhaX7q/c/VWaXaLyw18zWaR+G14kxqDMaoCQwgsHbq9nXMrQfsKPaioi",
-	"nrCIXsANrhl47Xwt7EzIoBubby3MhLEK94QwN/rFBrcSqvh+p/RVJShpIIce0M4Ghfj1tSstyKS6oM4y",
-	"zqZiAZLgdXB1q5TTrdz2wNwbee83iCduml25noGGAlimoijT+hFlU75J2mTTKCLkJVcR+hM4y29mIr3L",
-	"SPnm/PctGG+rRHfh8TUkrFQsq/CS659yD8V9ga5w7/j3cj6uNV8GdlrqaHuD/xuDob0DnGOf1pwrMP89",
-	"wwEHI/mWDIw5ZqPenKJr2vX+8fWLv9Nf56lb/cnpqBfE752QkgSF5GcMiZJT52LeF4EhVdEsuCnSIS0V",
-	"93W7LEehf9cuo2S67VxMHK1BhH7BfnWGKZmsiraQT1Dfrg+4pHF4Zyx20XFC2iGOhYOHJ2eVb2tLKueD",
-	"vOBhE4lbiMgigOhiBYpmsJyBAnPj/lkIzs7P3zIxYeA+RmfBwdm2jAUgoSG9gDB6Nna29tqp7ms3ybVW",
-	"cloP/99wy8fcIKtLKOeFeLN0Ba70TKupBmM6Fps/Dq03znAjMV9ze7Wp/zgwLOgIpHWrVRWsORWWgIWY",
-	"7Qz3DobD3dqCXYBUjQXXOqjhFXemF7arfyiADtQ+lDT6r4xrCzpZMgyaq0UZGpysuBFSlYhoGd7jpWID",
-	"J18BNP4DN3lqFQkYOyNsg5Hcqwehx+wkmHNgKafUE8FTW8EvjaDkU7+wH4U32nqj7S807Ewx1xlooQI6",
-	"ryjxytN9A5aX8Jgyc+I0OeZzuFfxXAObcR3vxYB8VDNBZy+Hb9jOyyGL+dLs9tnZwf+wnQO2BK7d/y4O",
-	"X/zAdg5fYO2YadDRfdtbpyybq2rSL6QKf+RjSCC+EHM4hzx4bRQfsYReqlWS+SiBs3mWWLHnf83TNm1h",
-	"dPwXzofmIyKHpkpIazyXC0NTYyVaTvVVDke5DKecztxYIfLjoIGoyP2c27klpWGFaZTOuTWRUZd8Dg0y",
-	"kdmp7cyuIxrB0if8BCkkjL1Q6U8uAl9+dBq623IVSNoMW7VRTy3M28gKqTH66FTG8OVDJjuCfOdZxzFU",
-	"Hc2Kn+HsRKZ9OqD1NAUZO1yFH2rlvO2ukc2VSFOIP0v1mUDoHGgBkVX6M4mqWflOlhrQNvjOGgQ57GSm",
-	"m2KVpXYV0eS5Fx/6XQo3LsSfub3ELGiWJDUfrKsEZg2kF1pMp7DCLTI5oVfxVIg33MQ0eI1oK5IXOWBn",
-	"aJleZTJOAgBxa7UYZzaktD7AVDFvl5wyuUx5dOXsfY7NQfn15SBk+3hmZ7/daGD3YXjMCSZpbzIofXk5",
-	"WKtPCOx+FTnFvJ86Eb1Gr0zARrOi2muDYquEG/vOfXTbDbyfnHUhlV4Fr5HIr5og2zQpE/RtrRaRYVOt",
-	"spSSF5xsS1uvOxh22waMhghMjr9Xw6OiyNpYpeFzwi3IaPk5fXlEISf9bGdaZdNZmtlRr2FGmi+EWMl0",
-	"WGvERZrUyr77DHg0Q5NdLLtu5oAws7GhbbsNATObSWGD4aQltcZNpgGLA0uM0Y4q4akgidk3ELWwVH+8",
-	"VjA8/TxYBQJDMkHbgR9wM2j1jsVmOYEyO1GmBFysyoUsvIzNY+nqMBd5IqzpVtkEtps2XKK6eX6cMkVf",
-	"PzU32S5mwOYcNYGfjL2XyTLfGoxpb6+6weiMmgukmU9C+9ryQaNutuGwv8mX25jsJLnmS8NSDRg84kY7",
-	"QLqXCHklKKRdi/GZmM4SMZ2R+VtfKBEpXa9KnSSKV6SYNhzDCi/kwgZcciPkNIGKz8zQGa8IfVuDFdv4",
-	"YT+cKqc8FsuBB11b+q11L3iSBZjxv93PjFtiuHAtwYvDQXUHKFaZQ3AIYbVdn2JB+eSfVmK024K04hDa",
-	"/vWWAo8aoPvDQMYUotwywrnrkOYG1snL1WfNrc+KYnrI/7+hbKsvBxN82+t6P6RX7u6XlNIy3krmpiAM",
-	"yc2UfmeUFYiFWor/qqN03AWCJuUR1CKvtUmIzM20mT9dd88CegMdgijTwi7P3ZcE8CvgGvRJZjEdPMb/",
-	"vctl7O//uMhPcaE3jk9LhM6sTekkk5ATFVBBKBQnZ6cUrBOc7Bz0QkQwYBczMFBKC0u1WojYH9sRxjrL",
-	"vQBGmywjaRXjSdKswo20MgYfZAa06XszIaqlnXmKwwxG0h+T8gxgvODm6TEs9U1o+5TMZq8ONSvW5PQJ",
-	"aEMrXRzgznwKkqeid9x7PjgYDJ30cztDNO/jPPuLg/3cXd/HGG3fYPDnXpkCSkfhsjgTRij8HmwrXOw1",
-	"DswdDod3dlStOzYNHZ1LhVGx0x/ufYd3WtKAsuG+siY8YbECOh1X41H0Jqrc+csn5zmYfIO49z1YBvnk",
-	"c6JSAcOvGWTgIXHE5FPjZB3R2fvk5umkiI9DUbaV6aKJD4UrqPpGFGnG4AGSnOZYiJaR8/Lpi0ri7Z4p",
-	"40FkSkI3hRC2jUmD+WevY72gNMNjKqJDbzbTGqRNlnj2bwHs/dnJPsbPlMZmeZbWaaUGgE70V4ngWQ7I",
-	"vVO7ltgIUPk1rbJcgF/cGL+4dyLnFbM5jpuErkEToHO/56LWAB3ThGMGvTFsnYbOVeIyZjNl9zQ4OAwD",
-	"59/5IyTCzlSGJyEt17aDqGdZiKjoOrxS8fLe6Vl6IVh+1eKoF4FdqXzxvvT53sn8MUUib0vdsBQX7swG",
-	"tg79GTShZaOAX9o1k96tYgamznU0A/YBUuCWKRkBnSymJ+Qhpglu3FJUFjq5LnMmKAlTPce+uetm7BL9",
-	"BxewYBlYaDbnLq6arum5frp3rdN0I1tqB19geIAbtCn2Gk0KkQse4pxDrmCJzPmC2Hg1Yxan7R/AZ0Cm",
-	"9OfkfchMZNmCp/etSlfzdXuLZnPeTjVMxJc7Y3EarnePbG1Uo3NF2f4B08SfkX0qxYL1XxNu7OcJpYY/",
-	"81DhYNfEVNIdnJl24zev075XWVuxYRfqDMHlFcSeUbW6vn/f2sHHrEo7hMXBwDIZg5MZ2eDTjSXndxF/",
-	"JRIlYKFDbt7gQ0LUOonxoVo1kfHx4+kbRjmj3aJZiYvKSp4R8UoVvCbzF2CTF6EUC0KWb/nfN/neKR2B",
-	"LzBgXLaoOF6y0zcddFoceFKVZ4u6vW7HJ6ZyCqkdkNOOAm0uYVAu48rhl8EIK6UpEvcBuFPEGGTnkXiH",
-	"Nj2pwLeGMfzBh/GSZejOgKbmKKdvuhrY+GK0Vba43z1LIlBgqZqve5I8U70Nu62YlaLdYz97n2Uy/4sO",
-	"rsV9xC1tBXd0HKJwOaS4eZJUFDaNjEmz4k8/S6+P737aAPbggSgvtGrCnB3AU1G7XRBXj1vdCovtcz5V",
-	"pi7O+rCdOf/CDn3Z15YW6GhLA9RfWd4lzNr+NiH46hVk9+lrrjwYt3aDJM+Ub5QAb3aE2aBEpW1lT1ji",
-	"rF6d9N/G0jptGVCipEB3vDom9bi7hdoOWNhmuTTWtTAul/U+LFOu4wSMcdjA88NmJlKnPZyw5wm+kfxo",
-	"sJ5rAhpkBHvovzkl71jRzLiGuGjdcgVLU9P261Q8wVYh6hodX775EA7A3ScNQoeJ2n3Sgt5GBRVVj+NR",
-	"RWJvcuekxnk7Ph0vk+VuMGe0MvdXHPxEVVgbuWNfAPsN3dQJ+R7sH4A9/+BWZCu1H1DqJdpz7nicWQne",
-	"BvS2mn+/guSg3JxbDXxOOfOxkFwvi9Mxzgo2BGi8TLkxToBKixDNILpyAvROaXb+fG/Mo6tS6feLo+2c",
-	"PR8eMg2x0BDhKUdeaW1wJwL4ujjY8SSHt5ZDFVmwewb5oy6PxTKJYcKtPOsLfUWsNRFJcfrKrWeGDSYR",
-	"mNc8msGeo6BWSffB2FSLBbfQZ1LtYf3bJdXqEFMZz807b17lDIh468aJA/X58DBkUEpG9Wyad97AVhw7",
-	"LVbfveWK5vzLHp/C30bZcPg8yusa3H/gksqVioZ4ZUcQDLiW69f4uAx/sW9USmKudW6r8HIi7fnGKiu9",
-	"BaqE2qTTSl0TjmS+u8QzO3MqJCqOf9xWiVXa0DwpsgdyKEKtgAJa7bytFx6nZxFSYG0HeVvZa7XQWJEf",
-	"XF2yM2Dn1PvXVNKE4yWjFFx/JH0M48POPqYQY259r22zVu5GciSfPXun9BW70ADsFcz4Qij97Nkxe10D",
-	"LeKSjYsj/lYxOqzDxprLaOamOqEj7FdmJDHALXuUjmpFt1QrPeoh/1NPhl2seGKXcxXDJStkG5WfVokZ",
-	"SWqIWMcW9uHB0uxiIDxClhcfrkiQvm606lipTtwHDvEOOmSPessf5k2ZYSEgqwCNZAjknTZydvH03yVP",
-	"ksvjogtQu8JrRytlabMfEe8/w18vj6njT/51oE3jTv2/2GjAgUtNtsvxEm7B2D33UwUcHB0rhhUeP4yo",
-	"rMRvvtfLplM69ewbcIwkYxdOG1IrnUmW+KyIukaTkm81avBlx1TsVm/nUSAy7+kRUp2OYh0528qiKrlb",
-	"yuQiAnGzrXxn8402LiMwFn8JTZwPHp4Su7tqkBvliH1+e5NWRXeVyK/wOrWpCvfBQj7Ke130i2p1zLIX",
-	"tcH43IgFJMvOJHbeESaMSz9DBZvlL35OpwNkstwCn8flmrhFfVm2HcMC8eIGg911YJ9MqGH8tvcUrAVs",
-	"DBOFGnZ7mF7hp3cA1KodiqaX9e32Jho6rdqJ7L53xZ82JbbalAi3Ub7V7kSjF9+32p9omNVbeIv71ICu",
-	"WmDbar3ghMQwA3Pu4qu8ZV3FdayN2GcqpU4bydI7kc4RKZzIG4ZmdMZrKzfqAaThnrYegv0uNypbfLQS",
-	"WTuzdyMppBGKzpT3LXznS2NhvnctYmjJwq0kMN8Y7EqQaAELJyx1fxTLRoI7KXWddPN0bqMtwkpRq3U9",
-	"e0qB3KXs18gQEIOLVh+yR7mlIpd1/l0vMnhih0xTo+oVIz5P2D26LqkR/xnLLVQtTTUDcQ4Ww+vLXGQu",
-	"K60e/W+0EXM9UwlUAkmWfyoss2ok806QRRtIU3b6y8PEgHC121s+Yvm6T7vW3eczuL3+jSWrhvRqjf+j",
-	"ki7CYZeAdW7frzFI+0VeYG0ldetenYBjdi9q/44Dvcdew/zNw6Wu+5JuGTP57bz2tULfKIDqnv8GYlLp",
-	"Pr3Gf6s3c69NHHLjRrKR9L2pG/e2aAr9h/HgHmeiJyfgbVI8ty47LSuMqaDZt9bsAqXsvLmZXSw6wD60",
-	"W70qDyzy3YwKRXzydcAupZJwyXY8ynfZRCWJujYjWXhmeb6cOS4e0K5HUR1TF9N8h6lrQfiwI1fsAKkk",
-	"iv1/O8qx/0DGwXeOuYkReJv3kH6UZ9FqlN8+XllnKohX1lZCeJZrbXDgblljn7O1x8Y4RiAjSQ3Xa3Eh",
-	"e8urglPs1FHMkneTFbgJQUImrAdlJLmMi8uJqfEM9gHqaMKO18b5nr645XtBvYuou0TeXKLUIdgGwioC",
-	"TkhS1r6JfosU/ZHsKIq+oZF0XsE7L8h/bBu54v6aqA773VrTtU2i11tX33v+IW3r0+5Jl1fQcTHEjWzA",
-	"u5By05DgJr5VbW79V4N67vEZDYwmiG9DeuoOTMa8uO9gkwij8nboqvEbRxA/VaD4E2tIPIUo4m114R3o",
-	"virhnjTgY9eAlUtIbqQAK+L0OB3hlh65pWKDxcpzyyfVwfCmAKoeJ483hkS4mdExppHK2IzajI1keRyi",
-	"hL0sYGztAzQ7jDn/FIpta1bjYLr5rVIiKIxj/ynErJSHzMBIokPsXduYKiPnfMnGkDc4870zCYbaJCMJ",
-	"zumNqOMeusqOd2OmyMU2oBdUVhXaGc/GdNGKv+NrjYp+ny9Tl8Ju/BBCTvvt1fmFYWXcAJuvOXpESk7E",
-	"NNNktf0SQ4tz1t3JQt4Y1BQdgZSEe8kUzOd8z4DDgvMp6CqKKyFjijGQLbrmxde2mw+7JC1z3swNChSs",
-	"gHcSjBNshWWUrnCje8tf3DkBbjONNyqOISf/SlO0HZDIGyzlSyw7potRWAKL7tQRvdOR28gVRpneKH+Z",
-	"ZDdNcVj4YklbBI+7rD3c4nSHv3iENIhKQULMTIYRpgMs74MzDLSklXhpbM6mpcjXGhnOBSmaupLoEmwW",
-	"lmsPxEFAGdaOMRSaw3/wvKuvY0Oj1b87Ck3kudYvFmI2dgJJzGioBhzLZSVfcIGWdLBlvUSulphvFqmB",
-	"J1jrl4uK36E6P3+7gQkRkV1ZpDTnkuqBNczVgq628J3l0I7M+ALYGByZ8kIJp+EqV4JQhrDsnVS5cAXv",
-	"5xhQDXHZeFwYJrQG7Dw59rXtZEjyN3TmHE3JxtjjGNUPOmTiN+rYi9fxJCq6yk/dUBuOkXz2LD/ugEXg",
-	"5vjZs5HcY8+enS9lNNNKqsw8e1ZmOY/ZKzeMo5cVSfuGHFMe/zscvmA/K+aP6A38sIXVFXLqBr78D26W",
-	"MvobbYorzS5PoghSe8xaQnq5e8zy04v5FT4jyfyOqWHceJuxd+6kgKyUB9TDV6anSHx912vDLn8fFdcC",
-	"jXrH7Oevl25oulnhZ0cBvPhnwN5Lht1w+wzmwhp2iQMd04+X1PjEDYb/dyNVLhj7eok43/w4PN4LtM7O",
-	"EkoKjBToKK5/ksYCj53/P3a0c0qlhpRO24iUCStmf51w68aGe9rEr12QdKN6tKDKL5sHOyE5Zg0mGH51",
-	"5Ao+Olrx7GDoHjbwVi8oa3GptyPIPk1KDjY5b+koXXzoR9sha1HIlxOvTunaHYxkSDJagtEWipFsSsWo",
-	"VxWLUY8W1iUWaDyCTQ3etm/gqtrYQi8xU6qrouXpbtUE3w0b1u6HCzZhrZv2nTFv63efnuizTF5JdS3r",
-	"F2Xt3vvm9A/lRVSBdsmNS7c8zOvsJjZB34/wAOxM2D1sB75R21b3CZsJyzRWlxjGWVrewsZNo3n92jLD",
-	"3Kr5l860moOdgTNjx6y+PeDUnai9U70TZDCSp5PqM2HwAFEZj5S27mh4wH5Wlp06LnU+WOiM1vdg8YTw",
-	"D8J+oG7pDb0eonT5yj7dm225phuGN3n7LQbym44Mae9eywwDDfdDdYahe1rqbFL1Nr+NYFfYoM4DHpTn",
-	"DwJK3Wm+/4RNQ1grcqoWzrn152uqioLRVU9BdRGP91Klkr3MikT8VlxvuFZnxIELJt1ArDJQU5MM/N4g",
-	"CTceyTNspq7Z3Ged/EB0wMv3IV4YViL4j6153ozPlEo+VjD9pH42Vz8FxzXZ7EkTPYwm2kgF3EgpoYe6",
-	"uf+S1m6M/eHi4qxMP9KJESzjluzoyxfyhs2fzakhPnnyaLZTKcgLT97MA+qQQiLvxpvx1/ntpS+PNtIc",
-	"L49crE+TigRy3eGzcX40pzl8Y6A/m9r4kVZ49vLoSW9soTfOXh7lzPGkOB5GcTgStAT1RjrDuwqbuxtV",
-	"B4PU1k7hbtClAE5X7P7ZdIVP/T45GVsqiyqnPGmLh9EWbZG9karA3od7t3Uycm1F8or3AuDA5V4ilrlo",
-	"dQUSu4ex8bJxBXJ+UWP7Tvs+42kKMj6ZgsyPA+3+gTRPA5CfAFtK0DUO5w5LbYA0JA4eJYubpCdazUey",
-	"/e2AndINqoRvD5qQxuqM5u/7W22J30byWiQJFmnMU7sMqkUc+P+zHxW6BTxUCbf2HvCGEDx5WA/vYXWQ",
-	"pK2QtteilRvUN1Gi5etsp9STNX/rSZ/+afTpRfV6/Sd9ejf6tBShJ5X6MCq1myK31Kj5LGsUqb+flS4R",
-	"JDWTgjbCNHtqmn5+QrLP8mvD+nQwsKic9vWDZZUCFZFu1ha2qXF4bPxZ/WRJJd+WWt3kZceOqxF9ZsBO",
-	"LYsVICeNZF6MXJK1Q6044S3qVu+32Uh1slWsmN8kWyyubG7OrWGerN9eWi86cF+gnYncxORAEsjfZge8",
-	"C2vEY0IuQFr0Agpyr5SkGfCEbmEP9j75HuwP9MadHmEp7x8vK+DUVfDS/A26o9Ed6cIwWszyxoQoK5Rw",
-	"ILpoooJB6ozmkPe1+DFYplzeI1/cQ28qXdXKc8CN1q4yzlXPoKyCpHqndqX7+5xSPEEGFMY6f6W82n5S",
-	"qJ6Ym9lYcR3XKrxLrZEzUdWU+obXDdlEFAXg83zVhtKj8m0OVfmdx+bXT1//LwAA//8ZV/vsp7cAAA==",
+	"H4sIAAAAAAAC/+x9+3IbudLfq6D4pSqSi6IutjaflTqVkm+7Otm1FUvOqWTpssCZJomjITALYChzXXr3",
+	"FLoxdwwvuu9G/7hkzgzQaHT/utFoNH70IjVLlQRpTe/oRy/lms/Agsb/nVluzXsZu79jMJEWqRVK9o56",
+	"72XM1JhZMQOmuZwA2zo5+8T+86e9ffzRWD5LtwfsHYx5lljDrGJSXQ16/Z5w3/+RgV70+j3JZ9A76oGM",
+	"e/2eiaYw466zsdIzbntHvZhb2HEN9vo9u0jdu8ZqISe96+s+0XdmubZtCvHnjWncZ1OVacYnqotUg93d",
+	"nFhI27R+BqOSzP2HGQspGyvN7BSIdANagGFbMJgM+mzY+2nPDHvuj8PZsNcg3z/tph3SGukxfds7ct8F",
+	"qL7u9zSYVEkDKBDvtVba/REpaUEi23maJiLijvrdfxs3nh+VHv6LhnHvqPcfu6Wc7dJTs4utffbtU28N",
+	"KXMvMF280e99VPaDykgiH4YGNzeZjoBJZdkY+3Yv+e9d88dRBMb8CnNI2lNLD1ninjpp5CwzoHGGOYuU",
+	"nIM2SLebM5DZrHf0e09dSdC9fm/GJZ/gX1daWPxDA49B97625qrfO45nQh5HrrHP8EcGBlkD3/ksTcD9",
+	"+e/MWDH2fOod9b44SjS9CjHjUaQyaVmUAJdZylLQzGRpqrRlVkSXYNl/7B+8fOX6SrVKQVtBYtFouC3e",
+	"3ChZSDV3dDKOhLIt5EQWC8sSNdkeBFXH/6JG/4bIlkPV0VTMIT5XlieoXYhgNcq4f6fGif39fqm0Qtqf",
+	"XjleCylmjv17RX9CWnDsv+73VBKDsXmPxwG8+YRvMN9hCTB+2Nw6OSZJcs3jdOcE9Q72Dn7a2Xu5c3B4",
+	"vvf6aP/waG/v//b6YWSRWZLwkfvM6gwCcmAdP2oDfv1ywwGj3v+RCe0497tvsV9y82vnnFjLo+nMq2X3",
+	"XDSweiHtFKyICvaNEz5hMWj3PhtrNUPJcfRpyZP8tbhkc0VwRko5CXY0eYg4xwc/2qyKNHCbz+c6OO50",
+	"1OrFSVz7IMtEvM7MwPdUaDBLulvZxFgkQGgeGI4IktV6TcP4rdP09kR8zGYj0IhTxUQyDZHSsWFmyl0L",
+	"OBOGO8tkleYTYKNEjSr8r6iNmfKDw5+CtBrxJ9SozeUy0Ar18z9hEWzJASpNyLrI8XYK0WWqREhKo0SA",
+	"tMH2VstTlsabytOcJxm0Z+JUK2c4lN6JYSwkxOyfZ58+spQvEsVjDyrCMCKXRcWIBuzMKg0xAxnpRYrA",
+	"jthjBy29LsZaH1lOVHU8X1fz8jSzFbvT4OoKxt2MC1Y5I2WEsXfFkAAXloxcJPHbigk/y2YzrhcB5Kt7",
+	"CMv8kaozcd1/FMzcHBNFgL4vUvyRARMxSOcbeJ/HURQ5vrV8n5WolXBjfwNj+ARONcwFXLlOVwIm+lJf",
+	"uiCiT/48xG8W728B7FZYcrFWvrkxQnSDWIWBKGRJ8mncO/p9hXw1P82F9rrflNqx0peO0urbJ4GZrj5n",
+	"J+9I9K6mIpp6jaw+v+KGUcOhSV9t/jxNlcmqE/NBaGNZyrUDAbTVDL5HSRZDzEYLIsg1MmAfsyRBmdRK",
+	"2RqRhnEZs1HC5eWOSbgF/MKQFyfkFLSwTKpqLwLMjcZTSF+byTdv6+aS3Ba2ryFx+1mrLN3E4/5v9+dw",
+	"XxQadVFxuvlMyUkJebXZ7XS99/fu3vXeP9h7KN/7vk3RpPCLVvLhMcxWxW9bSd/927inZt2eBr48jqV8",
+	"p66k8xe/6KSI9LQUw6/NTgLxiy+ff2VznohY2AWLM02WTEhmIFIyNuG1T6YD4aBzMYOdRMyEc0ONmDiX",
+	"1jXv5Cb2ZOZrrHIJtklU5FNmR+p7Bzh7VO1GUw2Wo5+tsBkGc2fhaqr3YND56uDgbqCzGHUndJ6Bg5n3",
+	"ZMg7FzF8bEG/zbShGGjDC8LfcSJTPhESheS/O4ZmWhomLMwMwxbICdFgsgRndsa//wpyYqe9o/29vTVY",
+	"JSQ6NMc1kPWB3DFPDDRjmCf0Qe6pEMp2G8c2uPoeUfFr3RGF9d7+NQU7dcNUzH+H4jx2/hZ5ZEL64ZsB",
+	"OwPr3kS63R8a4iyCIujLjPgT2NUUJFMyWbAZWB5zy5kwTALE5Ee2KUYdq5HqDHGd0N/4dydKTBZRD08V",
+	"0eEmzs8PSdz+npueQgD3Q1pPEfd2YIXbTPOEJVxOMj4Bhu+1Z5/aL37oL4t2NB3fxMmWQUl2A6h7tM5Q",
+	"lB6wa6TR+cHh4TruYVW/aKzdSoUbHuSIdONu1PQrzUq/ZIk7SjGactxrtVUJIPsAn6dtwy9nMFNrfxqI",
+	"Xjt7jrD7fp7vx22wqKsC//XX5lwGIh1NtjdZV7KiMrQGiZ2TvywoH/CS//PwLqC+k5ov6EtUZaYC8hvw",
+	"uL670l4yL/F7CeYu3FxcuL9y91dpdoHgh79msthAaHiRuAZlVgOEAC+8cHs75VKGdqV+VRMR8YRF9AJu",
+	"k07Bo/OVsFMhg25svkE1FcYq3FnEiNl3G9yQqvL7g9KXlUVJgzn0gPbHaIlfH7vSgkyqW9RZxtlEzEES",
+	"vY6ubkg52chtD/S9lvd+g/XETaMrV1PQUBDLVBRlWj+haMqDhE3WXUWEvOQqQ38DZ/nNVKR3uVK+ufw9",
+	"hOBttF1SeHwNDSuBZRlfcvwpd07cF+gK945+lP1xrfkisL9SZ9s7/N8IDO1AYR+7NOYcwPz3DBscDOV7",
+	"MjDmiA17M1pdU+7Er29f/ZP+Okvd6I9Phr0gf+9kKklRSH9GkCg5cS7mfU0wpCqaBrfWOrSl4r5uFuUo",
+	"8HflMEqh28zFFHGvNQn9Qvya21a5kFXZFvIJ6kkfAZc0Du9SxW51nBA6xLFw9PDktPJtbUhlf5Cnzayj",
+	"cXMRWSQQXaxA6hUmxdDC3Lh/5oKzs7P3TIwZuI/RWXB0ti1jQUioSa8gjJ6NnK29ctB95Tq50kpO6sv/",
+	"d9zyETco6hLKfiFeL1yBIz3VaqLBmI7B5o9D440z3I7Ox9webeo/DjQLOgJp3WhVhWsOwhKwELOtvZ39",
+	"vb3t2oDdAqm6FlzpoIZH3Ble2CyLpiA6kEFTztH/yri2oJMFw0VzNbVHg9MV10KqEhEtwpkClLLi9CvA",
+	"xn/hJk8trwXXzkjbYCh36ovQI3YcjDmwlFPoieipjeD3xqLka7+wH4U32nqj7S807EzR1ylooQKYVyQK",
+	"5uG+AcsTwUwZOXFIjvEc7iGea2BTruOdGFCOaibo9PXeO7b1eo/FfGG2++x0//+wrX22AK7d/84PXv3C",
+	"tg5eYQaiacyj+7a3Ciybo2rOXwgKf+UjSCA+FzM4g3zx2khhYwm9VMtH9KsEzmZZYsWO/zUP27SV0clf",
+	"OB6at4gSilv2ptzOx64xnzGf9WUORzkMB06nmOERmH5sNLAqcj/ndm5BYVhhGgmYbkxk1CWfQWOayOzU",
+	"dmZXTRrR0if+BGdIGHuu0t/cCnzxxSF0t+UqmLQet2qtnliYtZkVgjH66ETG8P1zJjsW+c6zjmOoOpoV",
+	"P8PZiUz7cEDraQoydrwKP6SckK6WzaVIU4i/SfWNSOhsaA6RVfobqapZ+k6WGtA2+M4KBjnuZKZ7xipD",
+	"7UrFymMvful3IVy7EH/j9gKjoFmS1HywrkSqFZSeazGZwBK3yOQTvUymQrLhOqbGa5O2JHiRE3aKlulN",
+	"JuMkQBC3VotRZkOg9Rkminm75MDkIuXRpbP3OTcH5dcXg5Dt45md/nmjht2H4TbHGKS9SaP05cVgJZ4Q",
+	"2f0qc4p+v3YyegWujMFG0yJncI2UvYQb+8F9dNsNvN+cdSFIr5LXCORXTZBtmpQx+rZWi8iwiVZZSsEL",
+	"TraljeuOhu22AaMmAp3j79XlUZGqb6zS8C3hFmS0+Ja+PqQlJ/1sp1plk2ma2WGvYUaaL4REyXRYa+RF",
+	"mtQOD/QZ8GiKJrsYdt3MAXFmbUPbdhsCZjaTwgaXk5ZgjZtMA6aYlhyjHVXiUzElZtdA1OJS/fFKxfDz",
+	"58kqGBjSCdoO/IybQct3LNaLCZTRiTIk4NaqXMjCy1h/LV1t5jwPhDXdKpvAZt2GE53Xj49TpOj6a3OT",
+	"7XwKbMYRCXxn7JNMFvnWYEx7e9UNRmfU3EKa+SC0P6EwaGRfNxz2d/lwG50dJ1d8YViqARePuNEOkO4k",
+	"Ql4KWtKu5PhUTKaJmEzJ/K1OlIiUruc2jxPFK1pMG45hwAu5sAGX3Ag5SaDiMzN0xitK30awYhs/7IdT",
+	"5pTnYtnwoGtLf90k3v/tfmbcksCFcwleHQyqO0CxyhyDQwyr7foUA1qWrFtytNuCtNYhtP3rLQUeWEH3",
+	"h4GMaYlyyxXOXS9pbmCdvF5909z6qCiGh/z/G2BbfTkY4Nsc632THtzdLymFZbyVzE1BmJKbgX7nKiuw",
+	"FmoB/2XHAQS3EDQpj6C28loZhMhcT+v503X3LIAb6BBEmRZ2cea+JILfANegjzOL4eAR/u9DrmP//Nd5",
+	"fhYQvXF8WjJ0am1K5+GEHKsABKFSHJ+e0GKd6GRnoOciggE7n4KBUltYqtVcxP7wlzDWWe45MNpkGUqr",
+	"GE+SZhZupJUx+CAzoE3fmwlRTe3MQxxmMJT+sJ0XAOMVNw+PYapvQtunZDZ7dapZMSaHJ6ANjXS+jzvz",
+	"KUieit5R7+Vgf7DntJ/bKbJ5F/vZne/v5u76Lq7Rdg0u/twrE0DtKFwWZ8KIhT+DbS0Xe41jlwd7e3d2",
+	"4LF7bRo6gJkKo2KHH+59x3ca0oCi4T6zJtxhMQI6Y1mTUfQmqtL5+1fnOZh8g7j3M1gGeeczmqWChj8y",
+	"yMBT4iaTT4zTdWRn76vrp3NG/DoUdVuZrjnxS+EKqx5oRppr8MCUnORciBaR8/Lpi0rg7Z5nxpPIlITu",
+	"GULa1p4ajD97jPWK0lweUxIderOZ1iBtssATpHNgn06Pd3H9TGFslkdpHSo1CHSqv0wFT3NC7n22a4GN",
+	"wCy/pVGWA/CDG+EX9z7JecZszuPmRNeoCcxzv+dWrYF5TBOOEfRGs/U5dK4SlzGbKrujwdFhGDj/zh8h",
+	"EXaqMjrCxbXtmNTTLDSp6Dq8UfHi3uez9EIw/aolUa8Cu1L54H3q871P85cUJ3nT2Q1rceHOrGHr0J9B",
+	"E1qWm/i9nTPp3SpmYOJcRzNgnyEFbpmSEdD5dHpCHmKa4MYtrcpC9Q9kLgTlxFSrIazvuhm7QP/BLVgw",
+	"DSzUm3MXl3XX9Fy/3jvqNN3IFuzgCwzLAIA2xV6jSSFyi4c4l5BLWKBwviIxXi6YRc2GR/AZUCh9tQW/",
+	"ZKZp2UCmd61Kl8t1e4tmfdlONYzF9zsTcWqud49ibVSj/klZRATDxN9QfCrJgvVfE27stzGFhr/xUOJg",
+	"V8eU0h3smXbj18/TvlddW7JhF6ovwuUlxF5Qtbq6f9/a0cesSjuUxdHAMhmD0xnZkNO1NeeHiK9pihKw",
+	"0KE37/AhMWqVxvilWjWQ8eXLyTtGMaPtouSNW5WVMiPipRC8IvIXEJNXoRALUpZv+d/39H1QOgKfYMC4",
+	"bM3iaMFO3nXM03zfT1V5tqjb63ZyYiqnkNoLctpRoM0lXJTLuHL4ZTDETGlaifsFuANiXGTnK/EOND2u",
+	"0LdCMPzBh9GCZejOgKYSOyfvusog+WS0Zba4391LIlBhKZuvu5M8Ur2JuC3plVa7R773Pstk/hcdXIv7",
+	"yFvaCu6oW0XL5RBw8ySpADa1jEGz4k/fS6+P735dg/bggSivtGrMnB3AU1HbXRRXj1vdiovtcz5VoS7O",
+	"+rCtGf/ODnza14YW6HBDA9Rfmt4lzMoqSSH66hlk9+lrLj0Yt3KDJI+UrxUAb9YVWiNFpW1lj1nirF59",
+	"6h/G0jq0DIAoAeiWh2OCx+0NYDtgYZvp0pjXwrhc1Kv5TLiOEzDGcQPPD5upSB16OGXPA3xD+cVgPtcY",
+	"NMgIdtB/cyDvRNFMuYa4KAB0CQtTQ/tVEE+0VSZ1BcaXbz6GA3D3QYPQYaJ2tb2gt1FhRdXjeFIrsXe5",
+	"c1KTvC0fjpfJYjsYM1oa+ysOfiIU1lru2BfAqlU3dUJ+BvsXEM+/uBXZCPYDoF6yPZeOpxmV4G1Cb4v8",
+	"uxUmB/XmzGrgM4qZj4TkelGcjnFWsKFAo0XKjXEKVFoELKHlFOiD0uzs5c6IR5cl6PeLo+2cvdw7YBpi",
+	"oSHCU468UtrgThTwbXGw41kPb62HKrJgdwzKR10fi2GSwIQLwtYH+oZEayyS4vSVG88Uy5QiMW95NIUd",
+	"N4NaJd0HY1Mt5txCn0m1g/lvF5SrQ0JlvDRvvXuTCyDyrZsnjtSXewchg1IKqhfTvPIGluLYaon69i1H",
+	"NOPfd/gE/jHM9vZeRnleg/sPXFC6UlFWsawIgguuxeoxPi3DX+wblZqYo85tAS+fpB1fWGWpt0CZUOtU",
+	"Wqkj4VDmu0s8s1MHIVFx/OO2IFYpQ/MMZI/kUIRKAQVQ7ayNC0/TswgBWNtB3lT3yuKZZvdHXljrer3t",
+	"+eJTT4eXGGplwP41BV9agCcJaDblBl8qtQ3ivIbnybs+E5bNMmMJJvFDJ+8sJ6pb7yo1XlvKFtCbSinU",
+	"p7Fj1yxUG0oSaJY6JRHdDywaa2CWJ0jlK8eXXdldDtmaL796uNLr5ejL4uuDG3jfdRms8mvtzIVTKjOL",
+	"slrWkcVitE9D4k+zh5P4e4qHBCsJr5VL8bhal6drkH7sPZx+nEisSldLkL9P9d8stcSA3lD36jaoWcZp",
+	"yR7V8rTRATujWwxMZatqtGC0DdQfSh9H86HPPm5juRmlW0PMSt9vKIfyxYsPSl+ycw3A3sCUz4XSL14c",
+	"sbc10iIu2agoM2MVowOjbKS5jKauq2Mqo3JphhKDrGW19WHt4Aed1xn20AejukDbmHXLLmYqhgtWAAA6",
+	"4FolZiipKG+dW1gLDo8HFQ3hMeY8AX7JJt3bRrmopS6t+8Ax3lGHQFkvO8f8csqwEJFVgoYyRPJWmznb",
+	"eAL9gifJxVFRia6dZbyllbKUcIaM95/hrxdHVHUu/zpQKnir/l8sduPIJYtVtpdwC8buuJ8q5GDreGpF",
+	"4RH4iFIbPaLUj+6kVHnDF4EaSsbOnUdO5dzGWeIj8+oKlzV5uosGf/SFEq7rJaUKRuZ1pULuu5uxjn3D",
+	"yqAq+4e0m4gMxISP8p31kz24jMBY/CXUcd54uEusMK5BrrVP6fdY1ymXd1ebyRVZp1KJ4VqMKEd5vaV+",
+	"cWIKd3qL8yn43Ig5JIvOjdS8KlmYl76HCjfLX3yfDgNkstiAn0flmLhFvCxLX+IhpeIupu1VZB+P6eqb",
+	"TW9cWknYCMYKEXZzmt7gp3dA1LJd8uZK/+H2xxuYVq2Ged+ZWc8b4xttjIdL+d9qh7xRD/ah9sgbZnXD",
+	"iEX1410qglo95NFazTklMczAjDu/OC+bWnEday32mUqp2lOy8E6kc0QKJ/KG4UE6Z7yRG/UI2nBPy71g",
+	"zeV7WO49oEbWzo3fSAuphaI68n0r39nCWJjtXIkYWrpwKw3Mk1O64oVawNwpS90fxdTF4G5+HZNuvqXY",
+	"KM2zVNVqlTefw/B3GmGpTkNADc5btTCf5La+XNTld7XK4KlRMk2Nkxe44vMTu0MXPzbWf8ZyC1VLU41A",
+	"nIHF5fVFrjIXlXLD/jeK0F9NVQKVhSTLPxWWWTWUeTXiohSxKavN5svEgHK1Syw/Yf26T7vWXWs6mOL1",
+	"wJpVY3r1nNmT0i7iYZeCdaaQrTBIu0VcYOVpntbdbmatmPrtYf+OF3pP/RzNgy+Xuu7su+WayaeUtK+2",
+	"e6AFVHf/N1CTyg0IK/y3+oUitY5DbtxQNoK+N3Xj3hcXE/xlPLinGejJJ/A2IZ5bH30oT7nQoRpf3rmL",
+	"lLL683p2sahC/thu9bI4sMh3Myoz4oOvA3YhlYQLtuVZvs3GKknUlRnKwjPL4+W4WTygXY8iQ7OupvkO",
+	"U9eA8GFHrNgRUgkU+/92HAn6CxkHX73sJkbgfX6PwZM8D12b+c3XK6tMBcnKymw8L3KtDQ7cLWvsc7b2",
+	"2BjHFchQ0qUftXUhe8+rilPs1NGaJa9oLnATgpRMWE/KUHIZ42vltZFXea5G6BKSK278fm2MW77nVD+P",
+	"KhzlBY5KDMFSRFYRcUISWPuLXFpT0R/KjoM5NzSSziv44BX5r20jl9yhFtVpv1truvKigtXW1d9/8pi2",
+	"9Xn3pMsr6Lic6EY24EMI3DQkuIlvVVta/6tBnHt6RuNXf5n6pQni1B2YjFlx5846K4zK276MRx3/b7qC",
+	"+K1Cxd8YIfEkvIg3xcI7wL7qxD0j4FNHwMpFWDcCwIo6PU1HuIUjtwQ2mC+tnXFcbQxvq6ETTOTxxpAI",
+	"1zM6xtRSuTajUpdDWR7JK2kvExhb+wDNKpfOP4Vi25rVJJhuH62kCArjxH8CMSv1ITMwlOgQe9c2pszI",
+	"GV+wUZkXSj4z0VDrZCjBOb0RVX1FV9nJbswUudgG9JzSqkI749mILvvy90yugOhP+TB1qezGNyHkpN8e",
+	"nR8YZsYNsACom49IybGYZJqsth9iaHDOujtdyHNvTVGVTkm4l0jBbMZ3DDguOJ+CrkO6FDKmNQaKRVe/",
+	"+Npm/WGlvkUum7lBgUIU8F6cUYLlGI3SFWl0b/nLo8fAbabxVt8R5NO/1BRtRiTKBkv5Ao++0OVcLIF5",
+	"d+iI3umIbeSAUYY3yl/G2U1DHBa+W0KL4JHLlQcsHXb4y68IQVQKEmJmMlxhOsLyWmx7gbLo9RTxUuVr",
+	"xXRngoCmDhJdis3Cen3n6ecNRKt/dxjqyEutHyzEbOQUkoTRUA44pstKPucCLemGWe0FLDFfsFgDTzDX",
+	"L1cVv0N1dvZ+DRMiIrs0SWnGJeUDa5ipOV2v5Kuboh2Z8jmwEbhpyhMlHMJVrqWiCGFZv69y6RfeETWg",
+	"HOLy8gthmNAasPrxyOe2kyHJ39CZczQlG2GdfYQfdMjEn1Q1Hq+ES1R0mZ/8pFJQQ/niRX6YAZPAzdGL",
+	"F0O5w168OFvIaKqVVJl58aKMch6xN64ZN19WJO1b2kx5BP1g7xX7qJg/Jj7wzRZWV8iJa/jif3CzkNE/",
+	"aFNcaXZxHEWQ2iPWUtKL7SOWn6DPr5EbSuZ3TA3jxtuMnTOnBWSlPKGevjI8Rerrb14w7OLHsLiabtg7",
+	"Yh+vL1zTdLvPRzcDePncgH2SDCuy9xnMhDXsAhs6oh8vqPiWawz/71qqXHJ5fYE8X78kC95Nt8rOEksK",
+	"jhTsKK4glMYCj53/P3Jz50ClxpRO24gzEwZmf6V969age9rEr13Sd6N8tCDklwXsnZIcsYYQ7F276Qo+",
+	"OlzybH/PPWzwrZ5Q1pJSb0dQfJozOVjnzL+b6eJD39oWWYtCv5x6dWrX9mAoQ5rRUoy2UgxlUyuGvapa",
+	"DHs0sC61QOMRLKzzvn0LZNXGFrjETAlXRdnt7cFjn/5iWyPexncfnuizTF5KdSXrlzVu3/vm9C/lZYiB",
+	"kv2Nix89zavsJl7EsRthEYapsDt4JcVaZ5PdJ2wqLNOYXWIYZ2l5Eyg3jQtUVqYZ5lbNv3Sq1QzsFJwZ",
+	"O2L17QEHd6L2TvVeqsFQnoyrz4TBA0TleqS0dYd7++yjsuzESanzwUJntH4Gi1UqfhH2M93Y0cD10EyX",
+	"r+zixW1nlmu65X6dt9/jQn7dliHt3WuaYeDSl1CeYeiusLqYVL3Nh1HsihjUZcCT8vJRSKk7zfcfsGko",
+	"a0VP1dw5t/58TRUoGF03GISLeLSTKpXsZFYk4s/iit2VmBEHLjl2DbFKQ00kGfi9QVJuPJJn2FRdsZmP",
+	"OvmG6ICXr4U/N6xk8F8bed6NTpVKvlQ4/Qw/68NPIXFNMXtGosdBorUg4EaghB7q+v5LWru1/Jfz89My",
+	"/EgnRjCNW7LD79/JGzZ/N6eG5OTZo9kMUlAWnr2ZR8SQQiPvxpvxV8rupK8P10KO14durU+digRy7PDR",
+	"ON+aQw5fnO7vBhu/0ghPXx8+48YGuHH6+jAXjmfgeBzgcFPQUtQbYYZ3FdZ3N6oOBsHWVuFu0MU0Diu2",
+	"/25Y4UO/z07GhmBRlZRntHgctGir7I2gAuvv7tzWycjRivQV76bBhsu9RExz0eoSJFawZKNF4xr+/LJg",
+	"Srt+WztexNMUZHw8AZkfB9r+CyFPg5DfAEtK0FVCZ45LbYI0JI4eJXMaMGdoKNvfDtgJ3eJN/PakCWms",
+	"zqj/vr9ZneRtKK9EkmCSxiy1iyAsYsP/P/tRv7n19WpsxNd2PDjaEFA2lODZw3p8D6tjStqAtDmK2qlW",
+	"2WTqq4quBNHydbZV4mTN33rG078Nnp6XwvGMp3eFp6UKPUPq40Bq94zcElHzXlYAqb8jnC6yJZhJqYBz",
+	"85BOPz8h2Wf51ZV9OhhYZE77/MEyS4GSSNcrC9tEHB4bf1Y/WVDKt6VSN3nasZNqZJ8ZsBPLYgUoSUOZ",
+	"JyOX09oBK055i7zV+y02Uu1saSFvPx/F4MoLNrg1zE/rw2vreQfvC7YzkZuYnEgi+WF2wLu4RjIm5Byk",
+	"RS+gmO6lmjQFnthpZ+2Tn8H+Qm/c6REWf+9kLQNOXYbOOq1THU3PRYQGmAazuPFElBlK2BAVpq5wkCqj",
+	"OeZdFz8G05SFsZpK6x6fnhDWmEpVtfIccKO0q4xz6BmUWZCU79TOdP+UzxRPUACFsc5fyYHFH2nBSY+5",
+	"mY4U13Etw7tEjVyIqqbUF7xu6CayKECfl6s2lZ6V73Oqyu88N6+/Xv+/AAAA//9xDSClccAAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/plugin/route/admin/admin.go
+++ b/internal/plugin/route/admin/admin.go
@@ -80,6 +80,14 @@ func MountRoutes(r *gin.Engine, store registrystore.MemoryStore, attachStore reg
 		adminEvict(c, store, eventBus)
 	})
 
+	// Client checkpoints
+	g.GET("/checkpoints/:clientId", requireAdmin, func(c *gin.Context) {
+		adminGetCheckpoint(c, store)
+	})
+	g.PUT("/checkpoints/:clientId", requireAdmin, func(c *gin.Context) {
+		adminPutCheckpoint(c, store)
+	})
+
 	// Stats (Prometheus-backed parity with Java admin stats behavior)
 	stats := newPrometheusStatsHandler(cfg)
 	g.GET("/stats/request-rate", stats.rangeHandler(requestRateQuery, "request_rate", "requests/sec"))

--- a/internal/plugin/route/admin/checkpoints.go
+++ b/internal/plugin/route/admin/checkpoints.go
@@ -1,0 +1,114 @@
+package admin
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/chirino/memory-service/internal/plugin/route/routetx"
+	registrystore "github.com/chirino/memory-service/internal/registry/store"
+	"github.com/chirino/memory-service/internal/security"
+	"github.com/gin-gonic/gin"
+)
+
+type checkpointRequest struct {
+	ContentType string          `json:"contentType"`
+	Value       json.RawMessage `json:"value"`
+}
+
+func HandleAdminGetCheckpoint(c *gin.Context, store registrystore.MemoryStore) {
+	if !runMiddlewares(c, security.RequireAdminRole()) {
+		return
+	}
+	adminGetCheckpoint(c, store)
+}
+
+func HandleAdminPutCheckpoint(c *gin.Context, store registrystore.MemoryStore) {
+	if !runMiddlewares(c, security.RequireAdminRole()) {
+		return
+	}
+	adminPutCheckpoint(c, store)
+}
+
+func adminGetCheckpoint(c *gin.Context, store registrystore.MemoryStore) {
+	checkpoints, ok := store.(registrystore.AdminCheckpointStore)
+	if !ok {
+		c.JSON(http.StatusNotImplemented, gin.H{"error": "checkpoint storage unavailable"})
+		return
+	}
+	clientID := strings.TrimSpace(c.Param("clientId"))
+	if !allowCheckpointClient(c, clientID) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "checkpoint not found"})
+		return
+	}
+	var checkpoint *registrystore.ClientCheckpoint
+	err := routetx.MemoryRead(c, store, func(ctx context.Context) error {
+		var err error
+		checkpoint, err = checkpoints.AdminGetCheckpoint(ctx, clientID)
+		return err
+	})
+	if err != nil {
+		var notFound *registrystore.NotFoundError
+		var validation *registrystore.ValidationError
+		switch {
+		case errors.As(err, &notFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "checkpoint not found"})
+		case errors.As(err, &validation):
+			c.JSON(http.StatusBadRequest, gin.H{"error": validation.Error()})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		}
+		return
+	}
+	c.JSON(http.StatusOK, checkpoint)
+}
+
+func adminPutCheckpoint(c *gin.Context, store registrystore.MemoryStore) {
+	checkpoints, ok := store.(registrystore.AdminCheckpointStore)
+	if !ok {
+		c.JSON(http.StatusNotImplemented, gin.H{"error": "checkpoint storage unavailable"})
+		return
+	}
+	clientID := strings.TrimSpace(c.Param("clientId"))
+	if !allowCheckpointClient(c, clientID) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "checkpoint not found"})
+		return
+	}
+	var body checkpointRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	var checkpoint *registrystore.ClientCheckpoint
+	err := routetx.MemoryWrite(c, store, func(ctx context.Context) error {
+		var err error
+		checkpoint, err = checkpoints.AdminPutCheckpoint(ctx, registrystore.ClientCheckpoint{
+			ClientID:    clientID,
+			ContentType: body.ContentType,
+			Value:       body.Value,
+		})
+		return err
+	})
+	if err != nil {
+		var notFound *registrystore.NotFoundError
+		var validation *registrystore.ValidationError
+		switch {
+		case errors.As(err, &notFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "checkpoint not found"})
+			return
+		case errors.As(err, &validation):
+			c.JSON(http.StatusBadRequest, gin.H{"error": validation.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, checkpoint)
+}
+
+func allowCheckpointClient(c *gin.Context, clientID string) bool {
+	authenticatedClientID := strings.TrimSpace(security.GetClientID(c))
+	return authenticatedClientID == "" || authenticatedClientID == clientID
+}

--- a/internal/plugin/store/metrics/metrics.go
+++ b/internal/plugin/store/metrics/metrics.go
@@ -308,6 +308,24 @@ func (m *metricsStore) FailTask(ctx context.Context, taskID uuid.UUID, errMsg st
 	return m.inner.FailTask(ctx, taskID, errMsg, retryDelay)
 }
 
+func (m *metricsStore) AdminGetCheckpoint(ctx context.Context, clientID string) (*store.ClientCheckpoint, error) {
+	checkpoints, ok := m.inner.(store.AdminCheckpointStore)
+	if !ok {
+		return nil, &store.NotFoundError{Resource: "checkpoint", ID: clientID}
+	}
+	defer observe("admin_get_checkpoint", time.Now())
+	return checkpoints.AdminGetCheckpoint(ctx, clientID)
+}
+
+func (m *metricsStore) AdminPutCheckpoint(ctx context.Context, checkpoint store.ClientCheckpoint) (*store.ClientCheckpoint, error) {
+	checkpoints, ok := m.inner.(store.AdminCheckpointStore)
+	if !ok {
+		return nil, &store.ValidationError{Field: "checkpoint", Message: "checkpoint storage unavailable"}
+	}
+	defer observe("admin_put_checkpoint", time.Now())
+	return checkpoints.AdminPutCheckpoint(ctx, checkpoint)
+}
+
 func (m *metricsStore) AdminGetAttachmentByStorageKey(ctx context.Context, storageKey string) (*store.AdminAttachment, error) {
 	defer observe("admin_get_attachment_by_storage_key", time.Now())
 	return m.inner.AdminGetAttachmentByStorageKey(ctx, storageKey)
@@ -372,3 +390,4 @@ func (m *metricsStore) AdminStatsSummary(ctx context.Context) (*store.AdminStats
 var _ store.EventOutboxStore = (*metricsStore)(nil)
 var _ store.OutboxEnabledProvider = (*metricsStore)(nil)
 var _ store.AdminStatsSummaryProvider = (*metricsStore)(nil)
+var _ store.AdminCheckpointStore = (*metricsStore)(nil)

--- a/internal/plugin/store/mongo/checkpoints.go
+++ b/internal/plugin/store/mongo/checkpoints.go
@@ -1,0 +1,95 @@
+//go:build !nomongo
+
+package mongo
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	registrystore "github.com/chirino/memory-service/internal/registry/store"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+type checkpointDoc struct {
+	ClientID    string    `bson:"client_id"`
+	ContentType string    `bson:"content_type"`
+	Value       []byte    `bson:"value"`
+	UpdatedAt   time.Time `bson:"updated_at"`
+}
+
+func (s *MongoStore) AdminGetCheckpoint(ctx context.Context, clientID string) (*registrystore.ClientCheckpoint, error) {
+	clientID = strings.TrimSpace(clientID)
+	if clientID == "" {
+		return nil, &registrystore.ValidationError{Field: "clientId", Message: "clientId is required"}
+	}
+	var doc checkpointDoc
+	err := s.db.Collection("admin_checkpoints").FindOne(ctx, bson.M{
+		"client_id": clientID,
+	}).Decode(&doc)
+	if err != nil {
+		if strings.Contains(err.Error(), "no documents") {
+			return nil, &registrystore.NotFoundError{Resource: "checkpoint", ID: clientID}
+		}
+		return nil, err
+	}
+	value, err := s.decrypt(doc.Value)
+	if err != nil {
+		return nil, err
+	}
+	return &registrystore.ClientCheckpoint{
+		ClientID:    doc.ClientID,
+		ContentType: doc.ContentType,
+		Value:       append(json.RawMessage(nil), value...),
+		UpdatedAt:   doc.UpdatedAt.UTC(),
+	}, nil
+}
+
+func (s *MongoStore) AdminPutCheckpoint(ctx context.Context, checkpoint registrystore.ClientCheckpoint) (*registrystore.ClientCheckpoint, error) {
+	clientID := strings.TrimSpace(checkpoint.ClientID)
+	contentType := strings.TrimSpace(checkpoint.ContentType)
+	value := append(json.RawMessage(nil), checkpoint.Value...)
+	if clientID == "" {
+		return nil, &registrystore.ValidationError{Field: "clientId", Message: "clientId is required"}
+	}
+	if contentType == "" {
+		return nil, &registrystore.ValidationError{Field: "contentType", Message: "contentType is required"}
+	}
+	if !json.Valid(value) {
+		return nil, &registrystore.ValidationError{Field: "value", Message: "value must be valid JSON"}
+	}
+	encryptedValue, err := s.encrypt(value)
+	if err != nil {
+		return nil, err
+	}
+	doc := checkpointDoc{
+		ClientID:    clientID,
+		ContentType: contentType,
+		Value:       encryptedValue,
+		UpdatedAt:   time.Now().UTC(),
+	}
+	_, err = s.db.Collection("admin_checkpoints").UpdateOne(
+		ctx,
+		bson.M{
+			"client_id": clientID,
+		},
+		bson.M{"$set": doc},
+		options.UpdateOne().SetUpsert(true),
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "duplicate key") {
+			return nil, &registrystore.NotFoundError{Resource: "checkpoint", ID: clientID}
+		}
+		return nil, err
+	}
+	return &registrystore.ClientCheckpoint{
+		ClientID:    doc.ClientID,
+		ContentType: doc.ContentType,
+		Value:       append(json.RawMessage(nil), value...),
+		UpdatedAt:   doc.UpdatedAt,
+	}, nil
+}
+
+var _ registrystore.AdminCheckpointStore = (*MongoStore)(nil)

--- a/internal/plugin/store/mongo/mongo.go
+++ b/internal/plugin/store/mongo/mongo.go
@@ -134,6 +134,12 @@ func (m *mongoMigrator) Migrate(ctx context.Context) error {
 				Options: options.Index().SetUnique(true).SetSparse(true),
 			},
 		},
+		"admin_checkpoints": {
+			{
+				Keys:    bson.D{{Key: "client_id", Value: 1}},
+				Options: options.Index().SetUnique(true),
+			},
+		},
 		"encryption_deks": {
 			{
 				Keys:    bson.D{{Key: "provider", Value: 1}},

--- a/internal/plugin/store/postgres/checkpoints.go
+++ b/internal/plugin/store/postgres/checkpoints.go
@@ -1,0 +1,89 @@
+//go:build !nopostgresql
+
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	registrystore "github.com/chirino/memory-service/internal/registry/store"
+	"gorm.io/gorm/clause"
+)
+
+type postgresCheckpointRow struct {
+	ClientID    string          `gorm:"column:client_id;primaryKey"`
+	ContentType string          `gorm:"column:content_type"`
+	Value       json.RawMessage `gorm:"column:value"`
+	UpdatedAt   time.Time       `gorm:"column:updated_at"`
+}
+
+func (postgresCheckpointRow) TableName() string { return "admin_checkpoints" }
+
+func (s *PostgresStore) AdminGetCheckpoint(ctx context.Context, clientID string) (*registrystore.ClientCheckpoint, error) {
+	clientID = strings.TrimSpace(clientID)
+	if clientID == "" {
+		return nil, &registrystore.ValidationError{Field: "clientId", Message: "clientId is required"}
+	}
+	var row postgresCheckpointRow
+	result := s.dbFor(ctx).
+		Where("client_id = ?", clientID).
+		Limit(1).
+		Find(&row)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return nil, &registrystore.NotFoundError{Resource: "checkpoint", ID: clientID}
+	}
+	value, err := s.decrypt(row.Value)
+	if err != nil {
+		return nil, err
+	}
+	return &registrystore.ClientCheckpoint{
+		ClientID:    row.ClientID,
+		ContentType: row.ContentType,
+		Value:       append(json.RawMessage(nil), value...),
+		UpdatedAt:   row.UpdatedAt.UTC(),
+	}, nil
+}
+
+func (s *PostgresStore) AdminPutCheckpoint(ctx context.Context, checkpoint registrystore.ClientCheckpoint) (*registrystore.ClientCheckpoint, error) {
+	clientID := strings.TrimSpace(checkpoint.ClientID)
+	contentType := strings.TrimSpace(checkpoint.ContentType)
+	value := append(json.RawMessage(nil), checkpoint.Value...)
+	if clientID == "" {
+		return nil, &registrystore.ValidationError{Field: "clientId", Message: "clientId is required"}
+	}
+	if contentType == "" {
+		return nil, &registrystore.ValidationError{Field: "contentType", Message: "contentType is required"}
+	}
+	if !json.Valid(value) {
+		return nil, &registrystore.ValidationError{Field: "value", Message: "value must be valid JSON"}
+	}
+	encryptedValue, err := s.encrypt(value)
+	if err != nil {
+		return nil, err
+	}
+	row := postgresCheckpointRow{
+		ClientID:    clientID,
+		ContentType: contentType,
+		Value:       encryptedValue,
+		UpdatedAt:   time.Now().UTC(),
+	}
+	if err := s.dbFor(ctx).Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "client_id"}},
+		DoUpdates: clause.Assignments(map[string]any{"content_type": row.ContentType, "value": row.Value, "updated_at": row.UpdatedAt}),
+	}).Create(&row).Error; err != nil {
+		return nil, err
+	}
+	return &registrystore.ClientCheckpoint{
+		ClientID:    row.ClientID,
+		ContentType: row.ContentType,
+		Value:       append(json.RawMessage(nil), value...),
+		UpdatedAt:   row.UpdatedAt,
+	}, nil
+}
+
+var _ registrystore.AdminCheckpointStore = (*PostgresStore)(nil)

--- a/internal/plugin/store/postgres/db/schema.sql
+++ b/internal/plugin/store/postgres/db/schema.sql
@@ -213,6 +213,17 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_name
     ON tasks (task_name) WHERE task_name IS NOT NULL;
 
 ------------------------------------------------------------
+-- Admin client checkpoints
+------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS admin_checkpoints (
+    client_id   TEXT PRIMARY KEY,
+    content_type TEXT NOT NULL,
+    value       BYTEA NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+------------------------------------------------------------
 -- Event outbox
 ------------------------------------------------------------
 

--- a/internal/plugin/store/sqlite/checkpoints.go
+++ b/internal/plugin/store/sqlite/checkpoints.go
@@ -1,0 +1,87 @@
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	registrystore "github.com/chirino/memory-service/internal/registry/store"
+	"gorm.io/gorm/clause"
+)
+
+type sqliteCheckpointRow struct {
+	ClientID    string          `gorm:"column:client_id;primaryKey"`
+	ContentType string          `gorm:"column:content_type"`
+	Value       json.RawMessage `gorm:"column:value"`
+	UpdatedAt   time.Time       `gorm:"column:updated_at"`
+}
+
+func (sqliteCheckpointRow) TableName() string { return "admin_checkpoints" }
+
+func (s *SQLiteStore) AdminGetCheckpoint(ctx context.Context, clientID string) (*registrystore.ClientCheckpoint, error) {
+	clientID = strings.TrimSpace(clientID)
+	if clientID == "" {
+		return nil, &registrystore.ValidationError{Field: "clientId", Message: "clientId is required"}
+	}
+	var row sqliteCheckpointRow
+	result := s.dbFor(ctx).
+		Where("client_id = ?", clientID).
+		Limit(1).
+		Find(&row)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return nil, &registrystore.NotFoundError{Resource: "checkpoint", ID: clientID}
+	}
+	value, err := s.decrypt(row.Value)
+	if err != nil {
+		return nil, err
+	}
+	return &registrystore.ClientCheckpoint{
+		ClientID:    row.ClientID,
+		ContentType: row.ContentType,
+		Value:       append(json.RawMessage(nil), value...),
+		UpdatedAt:   row.UpdatedAt.UTC(),
+	}, nil
+}
+
+func (s *SQLiteStore) AdminPutCheckpoint(ctx context.Context, checkpoint registrystore.ClientCheckpoint) (*registrystore.ClientCheckpoint, error) {
+	clientID := strings.TrimSpace(checkpoint.ClientID)
+	contentType := strings.TrimSpace(checkpoint.ContentType)
+	value := append(json.RawMessage(nil), checkpoint.Value...)
+	if clientID == "" {
+		return nil, &registrystore.ValidationError{Field: "clientId", Message: "clientId is required"}
+	}
+	if contentType == "" {
+		return nil, &registrystore.ValidationError{Field: "contentType", Message: "contentType is required"}
+	}
+	if !json.Valid(value) {
+		return nil, &registrystore.ValidationError{Field: "value", Message: "value must be valid JSON"}
+	}
+	encryptedValue, err := s.encrypt(value)
+	if err != nil {
+		return nil, err
+	}
+	row := sqliteCheckpointRow{
+		ClientID:    clientID,
+		ContentType: contentType,
+		Value:       encryptedValue,
+		UpdatedAt:   time.Now().UTC(),
+	}
+	if err := s.writeDBFor(ctx, "sqlite store put checkpoint").Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "client_id"}},
+		DoUpdates: clause.Assignments(map[string]any{"content_type": row.ContentType, "value": row.Value, "updated_at": row.UpdatedAt}),
+	}).Create(&row).Error; err != nil {
+		return nil, err
+	}
+	return &registrystore.ClientCheckpoint{
+		ClientID:    row.ClientID,
+		ContentType: row.ContentType,
+		Value:       append(json.RawMessage(nil), value...),
+		UpdatedAt:   row.UpdatedAt,
+	}, nil
+}
+
+var _ registrystore.AdminCheckpointStore = (*SQLiteStore)(nil)

--- a/internal/plugin/store/sqlite/db/schema.sql
+++ b/internal/plugin/store/sqlite/db/schema.sql
@@ -106,6 +106,13 @@ CREATE TABLE IF NOT EXISTS tasks (
 CREATE INDEX IF NOT EXISTS idx_tasks_ready
     ON tasks(task_type, retry_at);
 
+CREATE TABLE IF NOT EXISTS admin_checkpoints (
+    client_id TEXT PRIMARY KEY,
+    content_type TEXT NOT NULL,
+    value BLOB NOT NULL,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
 CREATE TABLE IF NOT EXISTS outbox_events (
     seq INTEGER PRIMARY KEY AUTOINCREMENT,
     event TEXT NOT NULL,

--- a/internal/registry/store/plugin.go
+++ b/internal/registry/store/plugin.go
@@ -197,6 +197,18 @@ type AdminStatsSummaryProvider interface {
 	AdminStatsSummary(ctx context.Context) (*AdminStatsSummary, error)
 }
 
+type ClientCheckpoint struct {
+	ClientID    string          `json:"clientId"`
+	ContentType string          `json:"contentType"`
+	Value       json.RawMessage `json:"value"`
+	UpdatedAt   time.Time       `json:"updatedAt"`
+}
+
+type AdminCheckpointStore interface {
+	AdminGetCheckpoint(ctx context.Context, clientID string) (*ClientCheckpoint, error)
+	AdminPutCheckpoint(ctx context.Context, checkpoint ClientCheckpoint) (*ClientCheckpoint, error)
+}
+
 type DeletedConversationGroup struct {
 	ConversationGroupID uuid.UUID
 	ConversationIDs     []uuid.UUID


### PR DESCRIPTION
## Summary
Add an admin-only checkpoint API so external processors can persist encrypted JSON progress state by admin client ID.

## Changes
- Add admin OpenAPI get/put checkpoint endpoints and regenerated Go bindings.
- Implement encrypted checkpoint storage for SQLite, PostgreSQL, and MongoDB.
- Add admin route handlers, metrics forwarding, BDD coverage, and Enhancement 097 documentation.
