### PR TITLE
docs(cognition): add cognition processor proposals

### DIFF
--- a/docs/enhancements/097-quarkus-cognition-processor.md
+++ b/docs/enhancements/097-quarkus-cognition-processor.md
@@ -1,0 +1,809 @@
+---
+status: proposed
+---
+
+# Enhancement 097: Quarkus + LangChain4j Cognition Processor
+
+> **Status**: Proposed.
+
+## Summary
+
+Build a reference cognition processor as a standalone Quarkus application that uses LangChain4j as its model abstraction. The processor consumes substrate events from the existing Memory Service admin SSE stream, builds bounded evidence packs, runs LangChain4j-backed structured extraction and verification, and writes durable derived memories plus short-lived retrieval/cache state back through the public episodic memory APIs. Agent applications retrieve cognition output through enhanced `/v1/memories` search.
+
+## Motivation
+
+`docs/memory-cognition.md` defines a clean architectural split between the Memory Service substrate and a pluggable cognition layer that interprets, consolidates, and injects memory. The substrate is the durable system of record; cognition is meant to evolve faster, run as one or more replaceable processors, and be evaluated against shared evidence.
+
+Today the JVM ecosystem already has the building blocks for a high-quality cognition runtime:
+
+- the Memory Service publishes a replayable admin event feed (`/v1/admin/events`) plus admin and public episodic-memory APIs
+- generated OpenAPI clients and gRPC stubs exist for those APIs in `java/memory-service-contracts` and `java/quarkus/memory-service-proto-quarkus`
+- `io.quarkiverse.langchain4j:quarkus-langchain4j-openai` (already used by `java/quarkus/examples/chat-quarkus`) gives us declarative `@RegisterAiService` interfaces, structured JSON output, prompt caching, and a pluggable model layer
+- Quarkus provides the operational primitives we need (scheduler, REST clients, virtual threads, dev services, health, metrics)
+
+What is missing is a concrete cognition processor implementation that turns substrate events into durable derived memories and retrieval-ready working notes with replayable provenance. The failure mode to avoid is a naive "run one prompt after every append and save the answer" design, which produces low-precision memory because it:
+
+- extracts from too much raw text and too little curated evidence
+- has weak provenance and poor debuggability
+- creates duplicate or contradictory memories on replay
+- couples prompt assembly to extraction latency
+- makes benchmarking across processors difficult
+
+A high-quality cognition processor must optimize for precision first, then recall. Memories must be supported by cited evidence, scoped correctly, and worth surfacing again later.
+
+## Design
+
+### Recommendation
+
+Build the reference processor as a **standalone Quarkus application** (`java/quarkus/cognition-processor-quarkus`) that talks to the Memory Service entirely through its public/admin HTTP and SSE APIs. The same pipeline runs in two operational modes:
+
+- **Worker mode** (default): subscribes to `/v1/admin/events`, persists a replay cursor, processes coalesced scope jobs, and writes derived memories through `/v1/memories`.
+- **Replay/shadow mode**: reprocesses an event window or runs extraction/scoring without affecting production cognition memories.
+
+Durable facts, preferences, procedures, decisions, rolling summaries, bridge notes, topic notes, and any cached retrieval candidates are all stored as memory items under fixed cognition namespaces. Agent applications fetch the next-turn memory material with `/v1/memories/search`, using substrate-level retrieval improvements described below. This keeps cognition responsible for producing better memory, while the Memory Service remains the single retrieval API for memory products.
+
+The standalone worker authenticates as a dedicated **service principal** (admin API key `cognition-processor`) and writes cognition memories through the public episodic memory API on behalf of conversation owners. The built-in episodic memory policy only allows `["user", <subject>, ...]` access for the authenticated subject, so deploying this processor requires a custom episodic-memory policy that allows the cognition service principal to write under the configured cognition namespaces. That policy is a Phase 1 prerequisite, not optional later hardening.
+
+### Processor Contract
+
+The processor exposes two cooperating capabilities:
+
+1. **Asynchronous consolidation** — observe substrate events, coalesce them into impacted scopes, extract and verify candidate memories, upsert/archive derived memories idempotently.
+2. **Retrieval materialization** — write short-lived summaries, bridge notes, topic notes, and candidate memories so the normal memory search API can retrieve next-turn context without running cognition code on the agent hot path.
+
+```java
+public interface CognitionProcessor {
+    String runtimeId();
+
+    Uni<Void> process(ScopeJob job);
+}
+```
+
+`ScopeJob` is a coalesced unit of work. The initial scope is one conversation; later phases may add user-level or `(user, agent)` scope jobs once conversation identity migration in [089](partial/089-single-agent-conversations.md) is more complete.
+
+### Module Layout
+
+```
+java/quarkus/
+  cognition-processor-quarkus/             # standalone Quarkus application
+    src/main/java/io/github/chirino/cognition/
+      runtime/                             # Processor impl, scope jobs, scheduler
+      evidence/                            # Evidence pack builders + registry
+      extractor/                           # LangChain4j AiService extractors
+      verifier/                            # LangChain4j AiService verifiers
+      consolidator/                        # Idempotent merge / supersede / archive
+      retrieval/                           # Search payload shaping and retrieval metadata
+      cache/                               # Cognition cache namespace helpers
+      remote/                              # Admin SSE client + episodic memory client
+      admin/                               # /admin/v1/cognition/* admin endpoints
+      config/                              # @ConfigMapping types
+    src/main/resources/
+      application.properties
+    src/test/java/...                      # unit + Quarkus integration tests
+```
+
+The processor depends on the existing modules:
+
+- `java/memory-service-contracts` — generated OpenAPI client stubs and DTOs
+- `java/quarkus/memory-service-proto-quarkus` — generated gRPC stubs (used only when an admin gRPC stream is preferred over SSE)
+
+LangChain4j is wired via `io.quarkiverse.langchain4j:quarkus-langchain4j-openai`. The actual provider is pluggable: switching to Anthropic or Gemini is a configuration change once their Quarkus extensions are added as optional dependencies.
+
+### Event Ingress and Scheduling
+
+The processor consumes replayable business events from the substrate, reduces them to impacted scopes instead of processing one event at a time, enqueues coalesced jobs with retry semantics, and processes those jobs out of band.
+
+Triggers:
+
+- `entry.created` and `entry.updated` events
+- `conversation.created` and `conversation.updated` events when archive or fork changes visible transcript shape
+- manual rebuild requests for a user, conversation group, or namespace
+- optional periodic sweeps for user-owned episodic memory namespaces that should invalidate cognition state
+
+Phase 1 does not depend on episodic memory lifecycle events as a primary trigger source. The replayable admin event stream covers conversation, entry, response, and membership events but not `/v1/memories/events`. The processor therefore treats same-user episodic memories as pull-time evidence during a scope job, and uses manual rebuilds or periodic sweeps when user-authored memory changes must force reprocessing.
+
+Implementation details:
+
+- A `ReactiveAdminEventClient` consumes `/v1/admin/events` using JAX-RS SSE (`SseEventSource`) with exponential backoff and resume-from-cursor semantics.
+- The current cursor is persisted to `/v1/admin/checkpoints/{workerId}` on a configurable cadence, where `{workerId}` is supplied by `cognition.worker.id` and identifies one logical processor instance.
+- Incoming events are reduced to `ScopeJob` records keyed by conversation ID and pushed onto a singleton task queue (`Map<UUID, ScopeJob>` guarded by a serializable `Mutiny` workflow). Duplicate events for the same conversation while a job is pending coalesce into the existing job.
+- Scope jobs are dispatched on virtual threads (`@RunOnVirtualThread`) so blocking REST calls do not consume reactive event-loop capacity.
+- `@Scheduled` triggers run optional periodic sweeps and rebuild requests.
+
+### Evidence Pack Builder
+
+Before any LLM call, the processor builds a bounded evidence pack. This is the core quality control step.
+
+Evidence packs include:
+
+- a recent transcript window for the impacted conversation, loaded through `/v1/conversations/{id}/entries`
+- the latest per-conversation `context` checkpoint if present
+- relevant episodic memories under the same user scope, queried through `/v1/memories`
+- related derived memories already written by this runtime
+- optional knowledge-cluster signals from [090](090-adaptive-knowledge-clustering.md) when clustering is enabled
+
+Evidence packs are aggressively bounded:
+
+- deduplicate repeated content
+- drop low-signal assistant boilerplate
+- keep only cited tool outputs or excerpts, not full logs
+- cap transcript size before extraction
+- include stable identifiers for every source item
+
+Before any heuristic stage, the bounded evidence text is normalized into prose:
+
+- strip fenced code blocks and obviously code-like lines
+- keep natural-language lines that mention commands as part of prose
+- avoid extracting durable memory directly from shell transcripts, stack traces, or source blocks unless a later model-assisted stage explicitly cites them
+
+Evidence pack assembly is exposed as a registry of CDI-managed `@ApplicationScoped` `EvidenceLoader` beans so additional sources can be plugged in without changing the runtime. The registry supports a `cognition.profile` selector so shadow/benchmark runs can swap loaders side by side.
+
+#### Evidence packs are ephemeral
+
+Evidence packs themselves are **not persisted**. They are rebuilt from the substrate on every scope job and held only in memory while the extractor and verifier run. Persisting raw evidence would duplicate encrypted user data into a second store and add a new lifecycle to govern.
+
+What is persisted is the minimum needed to make extraction replayable and auditable:
+
+- a **`provenance.source_hash`** computed over the canonicalized evidence pack — written onto every durable cognition memory so consolidation can no-op on replay when the same evidence produces the same candidate
+- **citation identifiers** — `provenance.conversation_ids`, `provenance.entry_ids`, and `provenance.memory_ids` on every durable cognition memory, pointing back at the substrate rows the candidate was supported by
+- **runtime attribution** — `runtime.id` and `runtime.version` so a given memory can be traced to the processor build that produced it
+
+This is sufficient for replay (recompute the pack, hash, compare) and for audit (follow citations back to the substrate). It deliberately leaves out the raw assembled prose, the prose-normalization decisions, and the per-stage prompt that the model actually saw.
+
+If a deployment needs deeper post-hoc inspection, two opt-in extensions are available without changing the durable storage shape:
+
+- **debug evidence dumps** — gated by `cognition.debug.persist-evidence=true`, the runtime can write the assembled pack to the cognition cache namespace under `evidence:<conversation-id>:<source-hash>` with a short TTL. This is intended for troubleshooting bad extractions, not steady-state operation.
+- **evidence manifests** — an optional compact manifest (ordered source IDs, per-source token counts, normalization flags) embedded in `provenance` alongside `source_hash`. Small, replayable, and free of raw content.
+
+Both are explicit non-defaults so steady-state runs do not accumulate redundant copies of substrate data.
+
+### Model-Backed Extraction Pipeline
+
+The processor uses a staged pipeline, not a single monolithic prompt. All durable memory extraction is model-backed; deterministic extractors only produce short-lived cache aids.
+
+Stages:
+
+1. **Structured extraction** — one batched LangChain4j `@RegisterAiService` call covers `fact`, `preference`, `procedure`, `problem_solution`, and `decision` candidates over the bounded evidence pack. A separate batched call produces a `topic_summary` cache note. Strict JSON output is enforced via LangChain4j's response schema support and verified again with a Jackson validator.
+2. **Verification** — one batched verifier call checks all durable candidates against their cited evidence, rejects unsupported or weakly-supported items, and normalizes language into concise, stable statements.
+3. **Deterministic consolidation** — verified candidates are compared against existing derived memories, duplicates are merged, stale or contradicted items are superseded, and freshness/confidence updates rewrite in place rather than appending.
+4. **Cache-only heuristic notes** — lightweight deterministic extractors produce cache-only `bridge` and `topic` notes for retrieval scoring. These are not durable memories and do not require a model provider.
+
+LangChain4j AiService interfaces:
+
+```java
+@RegisterAiService(modelName = "memory")
+public interface DurableMemoryExtractor {
+
+    @SystemMessage(fromResource = "/prompts/durable-extractor-system.md")
+    @UserMessage(fromResource = "/prompts/durable-extractor-user.md")
+    DurableExtractionResponse extract(EvidencePack pack);
+}
+
+@RegisterAiService(modelName = "memory")
+public interface DurableMemoryVerifier {
+
+    @SystemMessage(fromResource = "/prompts/durable-verifier-system.md")
+    DurableVerificationResponse verify(VerificationRequest request);
+}
+
+@RegisterAiService(modelName = "topic-summary")
+public interface TopicSummaryExtractor {
+
+    @SystemMessage(fromResource = "/prompts/topic-summary-system.md")
+    TopicSummaryResponse summarize(TopicSummaryRequest request);
+}
+```
+
+Prompt layout is token-aware:
+
+- one batched durable-extraction prompt with a stable system prefix and shared evidence catalog
+- one batched durable-verification prompt with a stable system prefix and shared evidence catalog
+- one separate `topic_summary` prompt because its output contract is different and its prompt prefix is stable on its own
+
+Each AiService can specify a stable per-stage cache identifier so provider adapters can opt in to native prompt-prefix caching:
+
+- OpenAI prompt cache keys via `quarkus.langchain4j.openai.chat-model.user` plus `prompt-cache-key`
+- Anthropic cache breakpoints on static system blocks
+- Gemini cached system-instruction content
+
+> **Caching is opt-in and must be evaluated, not assumed.** Provider prompt caching only pays off when the static prefix is large relative to the dynamic evidence and when the same prefix is hit frequently enough to amortize the cache write cost. For this processor the dynamic part of every call is the evidence pack, which changes per scope job, and the durable extractor/verifier prompts are large but not extreme. Some providers also charge a write surcharge on cache misses, which can make caching net-negative under low hit rates.
+>
+> The benchmark harness should record per-stage cache hit rate, cached vs. uncached token cost, and end-to-end latency so we can decide per stage and per provider whether caching is on. Default the `cognition.langchain4j.<stage>.prompt-cache.enabled` flags to `false` until the data shows a stage benefits.
+
+Models are routed by **named model configurations** in `application.properties` so durable extraction, verification, and topic summarization can target different models or providers if quality/cost tradeoffs require it.
+
+### Cache-Only Bridge and Topic Notes
+
+Not all retrieval aids should become durable user memories. The processor supports cache-only working notes that improve memory retrieval but never enter the durable store unless an extractor explicitly upgrades them:
+
+- **bridge notes** — explicit current-focus, goal, concern, and relevant background phrases extracted from user turns via lightweight heuristics; conversation-scoped; TTL-backed
+- **topic notes** — short TTL-backed retrieval aids built from stronger bridge/procedure-style cues and recent topical phrases
+
+Both live in the cognition cache namespace and are indexed for `/v1/memories/search` so query vocabulary can match short-lived working context.
+
+### Memory Types
+
+The initial durable memory types stay narrow:
+
+| Type | Durability | Notes |
+| --- | --- | --- |
+| `fact` | durable | Stable user/project facts backed by explicit evidence |
+| `preference` | durable | Repeated user preferences or defaults |
+| `procedure` | durable | Reusable steps or workflows; can feed [091](partial/091-skill-extraction.md) |
+| `problem_solution` | durable | Reusable issue-resolution patterns; can feed [091](partial/091-skill-extraction.md) |
+| `decision` | durable | Reusable decision rules or selection criteria; can feed [091](partial/091-skill-extraction.md) |
+| `bridge` | cache-only | Short-lived current-focus / concern / goal / background notes used only for retrieval |
+| `topic` | cache-only | Short-lived topic diary note summarizing recent conversation themes for retrieval only |
+| `summary` | rolling | Conversation or project summary stored in a short-lived cognition cache |
+
+Graph memories, relationship graphs, and broad autonomous world models are explicit non-goals for the first iteration.
+
+### Storage Strategy
+
+The processor reuses the existing substrate instead of creating a separate derived-memory datastore.
+
+#### Durable outputs: `/v1/memories`
+
+Derived durable memories are stored under fixed user-owned namespaces so existing governance, namespace-depth limits, archive semantics, and vector indexing still apply:
+
+```text
+["user", <sub>, "cognition.v1.facts"]
+["user", <sub>, "cognition.v1.preferences"]
+["user", <sub>, "cognition.v1.procedures"]
+["user", <sub>, "cognition.v1.problem_solutions"]
+["user", <sub>, "cognition.v1.decisions"]
+```
+
+`runtime.id` remains part of the stored memory payload for attribution and debugging, but it does not partition the namespace layout.
+
+Recommended value shape:
+
+```json
+{
+  "kind": "fact",
+  "title": "Preferred editor",
+  "statement": "The user prefers Neovim for local editing.",
+  "scope": {
+    "level": "user",
+    "conversation_group_id": "optional-uuid"
+  },
+  "confidence": "high",
+  "freshness": "stable",
+  "provenance": {
+    "conversation_ids": ["uuid"],
+    "entry_ids": ["uuid"],
+    "memory_ids": [],
+    "source_hash": "sha256:..."
+  },
+  "runtime": {
+    "id": "quarkus-reference-v1",
+    "version": 1
+  },
+  "observed_at": "2026-04-29T12:00:00Z",
+  "updated_at": "2026-04-29T12:00:00Z"
+}
+```
+
+Recommended index payload:
+
+```json
+{
+  "statement": "prefers neovim local editing terminal workflow",
+  "title": "preferred editor neovim"
+}
+```
+
+This gives us encrypted durable values, existing namespace scoping and archive semantics, vector search via the current episodic memory indexing, and no new core storage engine.
+
+#### Short-lived outputs: TTL-backed cognition cache
+
+Short-lived cognition cache entries hold rolling conversation summaries, retrieval hints, and per-conversation working notes that have not been promoted to durable memory (including cache-only bridge notes).
+
+API-compatible cache namespace shape:
+
+```text
+["user", <sub>, "cognition.v1.cache"]
+```
+
+Key prefixes are `summary:<conversation-id>`, `bridge:<conversation-id>`, `topic:<conversation-id>`, and `candidate:<conversation-id>`. The fixed `cognition.v1.*` layout keeps cognition storage within the default episodic namespace-depth limits without needing a runtime-specific segment.
+
+External Quarkus workers cannot generically write conversation `context` through today's agent APIs, because context reads/writes are authorized by the conversation's stored `clientId` and the service does not support admin impersonation. The Quarkus processor therefore does not mirror summaries into `context`.
+
+### Consolidation Rules
+
+The consolidator is idempotent and replay-safe:
+
+- each promoted memory gets a stable natural key derived from type, scope, and normalized subject/facet
+- each write carries a `source_hash` over the evidence pack so replays can no-op
+- contradictory memories archive or supersede prior rows instead of coexisting indefinitely
+- confidence and freshness update in place by rewriting the active memory row for the same natural key
+- low-confidence candidates never become durable memories; they may remain only as short-lived retrieval candidates
+
+Concurrency is handled with optimistic compare-and-set on the existing memory `revision`/`version` field. On conflict, the consolidator reloads, replays the merge, and retries up to a small bound before deferring the job.
+
+### Scope Rules
+
+High-quality memory depends on not widening scope incorrectly:
+
+- promote **user-scoped** durable memories first
+- keep **conversation-scoped summaries** separate from durable user memories in the short-lived cognition cache
+- do not promote cross-client or cross-agent durable memories until the conversation identity migration in [089](partial/089-single-agent-conversations.md) is more complete
+
+This avoids polluting one app/agent's memory with assumptions learned from another scope while the underlying `clientId`/`agentId` storage migration is still partial.
+
+### Quality Controls
+
+The runtime supports three operating modes:
+
+- **active** — writes durable and short-lived cognition memories
+- **shadow** — runs extraction and scoring but does not affect production cognition memories
+- **replay** — rebuilds memory state from a stored cursor or a time window
+
+Each candidate and each retrieval-ready memory exposes:
+
+- why it was included
+- which evidence supported it
+- which runtime produced it
+
+### Evaluation and Benchmarking
+
+Quality is measured explicitly before broad rollout. A replay harness feeds the same event window to multiple runtimes and records:
+
+- extraction precision
+- contradiction rate
+- duplicate churn rate
+- retrieval hit rate on evaluation prompts
+- token cost
+- latency per scope job
+
+The harness is exposed as a Quarkus CLI subcommand (`mvn quarkus:dev` plus `-Dcognition.benchmark.scenario=...`, or a packaged uber-jar entry point) so scenarios can be run against a local memory-service instance using dev services.
+
+The current [090](090-adaptive-knowledge-clustering.md) implementation is treated as one upstream evidence signal source, not the full cognition system. [091](partial/091-skill-extraction.md) is treated as a downstream consumer of verified procedural memories.
+
+### API Surface
+
+The public surface is intentionally small at first.
+
+- no new user-facing CRUD API for cognition memories
+- inspect durable outputs through existing `/v1/memories` APIs under cognition namespaces
+- admin/debug endpoints for runtime status and rebuilds at `/admin/v1/cognition/status`, `/admin/v1/cognition/rebuild`, and `/admin/v1/cognition/conversations/{conversationId}/retrieval`
+
+Instead, improve `POST /v1/memories/search` enough that agent applications can request cognition-produced memories directly. Replace the single `namespace_prefix` request field with required `namespace_prefixes`; single-prefix callers send a one-element array.
+
+```json
+{
+  "namespace_prefixes": [
+    ["user", "alice", "cognition.v1.preferences"],
+    ["user", "alice", "cognition.v1.procedures"],
+    ["user", "alice", "cognition.v1.cache"]
+  ],
+  "query": "help me continue the deployment fix",
+  "filter": {
+    "conversationIds": {"$in": ["uuid"]},
+    "memoryKind": ["preference", "procedure", "summary", "bridge", "topic"],
+    "runtimeId": "quarkus-reference-v1"
+  },
+  "limit": 12,
+  "order": "relevance",
+  "include_usage": true,
+  "after_cursor": null
+}
+```
+
+Example response:
+
+```json
+{
+  "items": [
+    {
+      "id": "uuid",
+      "namespace": ["user", "alice", "cognition.v1.procedures"],
+      "key": "procedure:deployment-debugging",
+      "value": {
+        "kind": "procedure",
+        "statement": "User usually debugs deployments by checking logs, then environment drift, then rollout history.",
+        "provenance": {
+          "entry_ids": ["uuid"]
+        },
+        "runtime": {
+          "id": "quarkus-reference-v1",
+          "version": 1
+        }
+      },
+      "score": 0.87
+    }
+  ],
+  "afterCursor": "opaque-cursor-or-null"
+}
+```
+
+#### Enhanced Search Contract
+
+`SearchMemoriesRequest` becomes:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `namespace_prefixes` | yes | Non-empty array of up to 10 namespace prefixes. Each prefix is independently validated against `EpisodicMaxDepth` and independently passed through OPA filter injection. Empty segments are invalid. |
+| `query` | no | Free text semantic query. When present and an embedder is configured, search uses vector retrieval per effective prefix, then merges results. |
+| `filter` | no | Attribute filter expression. Existing flat equality filters still work; operator form is added below. |
+| `limit` | no | Default 10, maximum 100, applied after merging results across prefixes. |
+| `order` | no | `relevance` (default when `query` is set), `createdAtDesc`, or `createdAtAsc`. `relevance` without `query` falls back to `createdAtDesc`. |
+| `include_usage` | no | Includes usage metadata without incrementing usage counters, matching current search behavior. |
+| `archived` | no | Existing `exclude|include|only` archive filter, applied consistently to every prefix. |
+| `after_cursor` | no | Opaque cursor for the selected order. `offset` is removed because it is ambiguous after multi-prefix merge. |
+
+`SearchMemoriesResponse` adds nullable `afterCursor`. The cursor is opaque to clients. The server may encode a request hash, order keys, effective prefix position, and the last memory ID, but clients must only replay it with the same request fields except `after_cursor`. A cursor replayed with different search fields returns `400`.
+
+The gRPC `SearchMemoriesRequest` must stay semantically aligned with REST. Because protobuf cannot represent a repeated list of repeated strings directly, add a small message:
+
+```protobuf
+message MemoryNamespacePrefix {
+  repeated string segments = 1;
+}
+
+message SearchMemoriesRequest {
+  repeated MemoryNamespacePrefix namespace_prefixes = 1;
+  string query = 2;
+  optional google.protobuf.Struct filter = 3;
+  int32 limit = 4;
+  bool include_usage = 5;
+  ArchiveFilter archived = 6;
+  string order = 7;
+  optional string after_cursor = 8;
+}
+
+message SearchMemoriesResponse {
+  repeated MemoryItem items = 1;
+  optional string after_cursor = 2;
+}
+```
+
+The old protobuf `namespace_prefix` and `offset` fields are removed under the repo's pre-release no-compatibility rule.
+
+#### Filter Expression
+
+The filter language stays intentionally small and maps to plaintext policy attributes, not encrypted memory values. A field may be:
+
+- a scalar, equivalent to `$eq`
+- an array, equivalent to `$in`
+- an operator object with one of `$eq`, `$ne`, `$in`, `$nin`, `$exists`, `$gte`, `$lte`
+
+Example:
+
+```json
+{
+  "memoryKind": {"$in": ["procedure", "summary", "bridge"]},
+  "runtimeId": "quarkus-reference-v1",
+  "conversationIds": {"$in": ["uuid"]},
+  "confidence": {"$in": ["medium", "high"]},
+  "freshness": {"$ne": "stale"}
+}
+```
+
+Unsupported operators return `400`. Type mismatches simply do not match rows. OPA filter injection receives the parsed filter and may narrow it, but may not broaden it.
+
+#### Cognition Attributes
+
+The processor's memory policy must extract these safe attributes for every cognition memory:
+
+| Attribute | Source | Purpose |
+| --- | --- | --- |
+| `memoryKind` | `value.kind` | Filter facts, preferences, procedures, decisions, summaries, bridge notes, and topic notes. |
+| `runtimeId` | `value.runtime.id` | Isolate active, shadow, or benchmark processor outputs. |
+| `runtimeVersion` | `value.runtime.version` | Debug and benchmark processor versions. |
+| `confidence` | `value.confidence` | Filter weak or medium-confidence candidates. |
+| `freshness` | `value.freshness` | Exclude stale or contradicted memories from retrieval. |
+| `conversationIds` | `value.provenance.conversation_ids` | Retrieve items related to a conversation lineage. |
+| `entryIds` | `value.provenance.entry_ids` | Audit and targeted debug lookups. |
+| `sourceHash` | `value.provenance.source_hash` | Idempotent replay and debug lookup. |
+
+These attributes are safe to expose as `MemoryItem.attributes`; they must not contain raw evidence text, `clientId`, provider prompts, or provider cache keys.
+
+#### Multi-Prefix Execution
+
+The route executes each requested prefix as an independent authorized search and then merges the results:
+
+1. Validate all prefixes and reject malformed requests with `400`.
+2. For each prefix, call `policy.InjectFilter` with that prefix and the requested filter.
+3. If policy narrows a prefix to no accessible namespace, that prefix contributes zero rows. Do not leak whether inaccessible rows exist.
+4. Run semantic or attribute search for each effective prefix.
+5. Deduplicate by memory `id`; if a memory appears through multiple prefixes, keep the highest score and most specific namespace match.
+6. Sort the merged set by the selected order. For `relevance`, sort by score descending, then `createdAt` descending, then `id` ascending for deterministic ties.
+7. Return up to `limit` rows plus `afterCursor` when more rows are available.
+
+The implementation may over-fetch per prefix to produce a stable merged page. Start with `min(limit * 3, 100)` per prefix and tune only if tests show poor recall.
+
+Needed `/v1/memories/search` improvements:
+
+- accept multiple namespace prefixes in one request while preserving OPA filter injection for each prefix
+- support filter operators for the extracted memory attributes used by cognition (`memoryKind`, `conversationIds`, `runtimeId`, `confidence`, `freshness`)
+- return stable relevance scores for semantic results and deterministic secondary ordering
+- optionally return usage metadata without incrementing counters, matching the current search behavior
+- keep `clientId` internal; cognition memory values and search responses must not expose it
+
+This is the middle ground between a bespoke cognition endpoint and forcing every agent app to hand-code many memory queries. The API remains a generic memory retrieval surface, while cognition remains an external producer of better memory items.
+
+#### Admin Debug Endpoints
+
+The admin endpoints are implementation/debug surfaces only:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /admin/v1/cognition/status` | Return runtime ID/version, mode, profile, last processed event cursor, queue depth, last successful job time, and error counts. |
+| `POST /admin/v1/cognition/rebuild` | Enqueue rebuild jobs for a `conversationId`, `userId`, namespace prefix, or cursor/time range. Returns accepted job IDs. |
+| `GET /admin/v1/cognition/conversations/{conversationId}/retrieval` | Return the exact `/v1/memories/search` request the processor expects an agent app to use for that conversation, plus debug-only scoring details. |
+
+The retrieval debug endpoint must not return raw evidence packs unless `cognition.debug.persist-evidence=true` and the caller is admin.
+
+### Configuration
+
+All configuration is exposed via Quarkus `@ConfigMapping` types under the `cognition.*` prefix.
+
+```properties
+# Identity / connectivity
+cognition.worker.id=cognition-worker-1
+cognition.runtime.id=quarkus-reference-v1
+cognition.memory-service.base-url=http://memory-service:8082
+cognition.memory-service.api-key=${COGNITION_API_KEY}
+
+# Operating mode
+cognition.mode=active                       # active | shadow | replay
+cognition.profile=default                   # selects evidence/extractor/verifier registry filters
+
+# Pipeline shape
+cognition.evidence.transcript.max-entries=40
+cognition.evidence.transcript.max-tokens=4000
+cognition.evidence.episodic.max-memories=20
+cognition.consolidation.max-revision-retries=3
+
+# Debug-only: persist assembled evidence packs to the cognition cache for inspection
+cognition.debug.persist-evidence=false
+cognition.debug.persist-evidence.ttl=PT1H
+
+# Cache TTLs
+cognition.cache.summary.ttl=PT2H
+cognition.cache.candidate.ttl=PT15M
+cognition.cache.bridge.ttl=PT45M
+cognition.cache.topic.ttl=PT2H
+
+# LangChain4j model routing (per stage)
+quarkus.langchain4j.openai.memory.api-key=${OPENAI_API_KEY}
+quarkus.langchain4j.openai.memory.chat-model.model-name=gpt-4o-mini
+quarkus.langchain4j.openai.topic-summary.api-key=${OPENAI_API_KEY}
+quarkus.langchain4j.openai.topic-summary.chat-model.model-name=gpt-4o-mini
+```
+
+Worker mode is the default. Replay/shadow processing is enabled by mode; the user-facing retrieval path remains `/v1/memories/search`.
+
+### Compose Integration
+
+The repo `compose.yaml` already runs a separate cognition processor service against the main `memory-service` container. The Quarkus processor publishes a Docker image (`Dockerfile` in the new module) and replaces the existing entry by:
+
+- consuming `/v1/admin/events` from the main `memory-service` container with the dedicated admin API key/client ID `cognition-processor`
+- using `COGNITION_WORKER_ID` for checkpoint identity
+- writing cognition memories back through the public episodic memory APIs
+
+The compose service depends on `memory-service` plus its vector backend (`qdrant`/`pgvector`) and uses TCP-based readiness probes that match the dev images already in use.
+
+## Design Decisions
+
+### Standalone Quarkus Application, Not an Embedded Extension
+
+`docs/memory-cognition.md` is directionally clear: cognition should evolve faster than the substrate. Shipping the processor as a separate Quarkus application keeps that separation strict, makes shadow benchmarking trivial, and avoids forcing memory-service deployments to take cognition release cadence.
+
+### LangChain4j as the Model Layer
+
+LangChain4j gives us declarative AiService interfaces, structured output, prompt caching, and a pluggable provider model that already aligns with how `chat-quarkus` integrates models. Reusing it avoids building a second model abstraction inside this repo and keeps the cognition stack consistent with the demo agent.
+
+### Reuse `/v1/memories` Instead of a New Derived Store
+
+This keeps governance, indexing, archive semantics, and encryption aligned with the rest of the system. Adding substrate extensions is deferred until the current memory primitives prove too weak.
+
+### Improve `/v1/memories/search`
+
+The proposed cognition outputs are already stored as memory items. The generic memory search API should be strong enough to retrieve cognition-produced facts, preferences, procedures, summaries, bridge notes, and topic notes through the same governed surface as any other memory.
+
+The tradeoff is that agent applications remain responsible for assembling the final LLM prompt from returned memory items and recent conversation entries. That is preferable for now because prompt assembly is application-specific, while retrieval of relevant memory products is a substrate responsibility.
+
+### Use a Verifier Step
+
+The extractor alone should never be trusted to create durable memory. Requiring explicit citations and a verifier pass is the simplest way to improve precision without giving up model-assisted reasoning.
+
+### Use Existing Replay Surfaces in Phase 1
+
+The existing replayable admin SSE stream is sufficient as long as cognition jobs are driven by conversation and entry activity plus manual or periodic rebuilds. A dedicated cognition replay feed should not be added until the current surfaces prove too coarse or until memory-lifecycle-triggered reprocessing becomes a measured bottleneck.
+
+### Use Fixed Versioned Cognition Namespaces
+
+The default episodic API validates namespaces against `EpisodicMaxDepth=5`. Using fixed third-segment namespaces such as `["user", sub, "cognition.v1.cache"]` keeps cognition storage well within that limit while avoiding a generic `["user", sub, "cognition", ...]` prefix that would invite broad queries across processor-specific shapes.
+
+### Service Principal With Custom Episodic Policy
+
+The default episodic policy only allows `["user", <subject>, ...]` access for the authenticated subject. The Quarkus processor authenticates as a dedicated `cognition-processor` admin API key/client and ships with a custom episodic-memory policy that allows writes only under the configured cognition namespaces. This is a Phase 1 prerequisite, not optional later hardening.
+
+## Testing
+
+### Cucumber Scenarios
+
+```gherkin
+Feature: Quarkus cognition processor
+  Scenario: Durable preference is extracted from repeated evidence
+    Given conversation "conv-1" contains turns showing user preference for "neovim"
+    And the cognition processor is running in active mode
+    When the processor replays admin events for "conv-1"
+    Then a memory exists under namespace ["user","alice","cognition.v1.preferences"]
+    And the memory value field "statement" contains "Neovim"
+    And the memory value field "provenance.entry_ids[0]" is not null
+
+  Scenario: Replay is idempotent
+    Given the cognition processor already extracted memories for "conv-1"
+    When the same admin event window is replayed again
+    Then no duplicate active cognition memory rows are created
+
+  Scenario: Weak evidence is not promoted
+    Given conversation "conv-2" contains one speculative assistant message without user confirmation
+    When the processor runs
+    Then no durable cognition memory is created
+
+  Scenario: Memory search prefers relevant durable cognition memory over cache notes
+    Given durable cognition memories exist for deployment troubleshooting
+    And short-lived cognition cache memories exist for "conv-3"
+    When POST /v1/memories/search is called with query "deployment fix" across the cognition namespaces
+    Then the response status should be 200
+    And the response body field "items[0].value.kind" should equal "procedure"
+
+  Scenario: Cognition writes are scoped to the configured namespaces
+    Given the cognition service principal is configured for namespaces under "cognition.v1.*"
+    When the processor attempts to write outside those namespaces
+    Then the episodic memory API rejects the write with 403
+
+  Scenario: Multi-prefix memory search applies authorization per prefix
+    Given Alice can read ["user","alice","cognition.v1.preferences"]
+    And Alice cannot read ["user","bob","cognition.v1.preferences"]
+    When Alice searches both namespace prefixes in one /v1/memories/search request
+    Then the response status should be 200
+    And every returned item namespace should start with ["user","alice"]
+
+  Scenario: Cognition filters support operator expressions
+    Given cognition memories exist with kinds "procedure", "bridge", and "decision"
+    When POST /v1/memories/search filters memoryKind with {"$in":["procedure","bridge"]}
+    Then the response status should be 200
+    And no returned item should have memoryKind "decision"
+
+  Scenario: Multi-prefix search pagination uses an opaque cursor
+    Given more than 12 cognition memories match query "deployment fix"
+    When POST /v1/memories/search is called with limit 12
+    Then the response body field "afterCursor" should not be null
+    When POST /v1/memories/search is called again with the same request and that after_cursor
+    Then the second page should not repeat memory ids from the first page
+```
+
+### Unit / Quarkus Integration Tests
+
+- `DurableMemoryExtractor` AiService is exercised against a recorded transcript fixture and a stubbed model that returns canned structured output, asserting that all durable kinds round-trip through the candidate schema.
+- `DurableMemoryVerifier` rejects candidates whose cited evidence does not appear in the bounded evidence pack.
+- `EvidencePackBuilder` deduplicates repeated content, drops fenced code blocks during the prose normalization step, and never exceeds the configured token cap.
+- `Consolidator` merges duplicates by stable natural key, supersedes contradicted memories, and produces no-op writes on identical `source_hash` replays.
+- Cache-only `bridge` and `topic` notes are written under the cognition cache namespace with the configured TTLs and surface in memory search.
+- The admin SSE consumer resumes from the persisted checkpoint, coalesces bursts into singleton scope jobs, and does not lose events across reconnect.
+- Memory search across cognition namespaces returns only memories authorized for the caller and does not expose internal `clientId` metadata.
+- Memory search rejects unsupported filter operators with `400`, treats type mismatches as non-matches, and returns deterministic order across repeated multi-prefix calls.
+- Search cursors are opaque, request-bound, and cannot be replayed with a different query/filter/order.
+- A Quarkus dev-services-backed integration test boots the full stack (memory-service container plus the processor) and verifies an end-to-end extraction-to-search flow against a `TestChatModel` that mimics the LangChain4j contract used in `chat-quarkus`.
+
+## Tasks
+
+- [ ] Create the `java/quarkus/cognition-processor-quarkus` Maven module with parent wiring, packaging, and Dockerfile.
+- [ ] Define the `CognitionProcessor` contract and `ScopeJob` types.
+- [ ] Wire the LangChain4j dependency and add named model configurations for durable extraction, verification, and topic summarization.
+- [ ] Implement the admin SSE consumer with checkpointed replay against `/v1/admin/events`.
+- [ ] Implement the singleton-per-conversation scope-job queue running on virtual threads.
+- [ ] Implement the evidence pack builder registry over transcript, `context`, episodic memory, and optional knowledge-cluster sources.
+- [ ] Implement the `DurableMemoryExtractor` AiService with strict structured output for fact, preference, procedure, problem_solution, and decision candidates.
+- [ ] Implement the `DurableMemoryVerifier` AiService with batched citation checking and normalization.
+- [ ] Implement the `TopicSummaryExtractor` AiService and TTL-backed topic-summary cache writes.
+- [ ] Implement deterministic consolidation with stable natural keys, `source_hash`-based no-op replay, and supersede semantics.
+- [ ] Implement cache-only `bridge` and `topic` heuristic extractors writing under `cognition.v1.cache`.
+- [ ] Implement TTL-backed rolling summary and retrieval candidate cache entries.
+- [ ] Replace `POST /v1/memories/search` request field `namespace_prefix` with `namespace_prefixes`.
+- [ ] Add memory search filter operators `$eq`, `$ne`, `$in`, `$nin`, `$exists`, `$gte`, and `$lte`.
+- [ ] Add deterministic multi-prefix result merge, `order`, and opaque `after_cursor` pagination.
+- [ ] Update memory policy attribute extraction so cognition memories expose safe filter attributes.
+- [ ] Implement admin status / rebuild / retrieval-debug endpoints.
+- [ ] Add the configurable `cognition.profile` selector for evidence/extractor/verifier registry filtering.
+- [ ] Add the replay/shadow benchmark harness and scenario format.
+- [ ] Add Cucumber-driven BDD coverage that drives the processor against a memory-service container with a stubbed LangChain4j model.
+- [ ] Provide the dedicated `cognition-processor` admin API key and a custom episodic policy that scopes writes to the configured cognition namespaces.
+- [ ] Update `compose.yaml` to run the Quarkus processor image as the cognition service.
+- [ ] Update `docs/memory-cognition.md`'s "Relationship to Existing Enhancement Work" list to point at this enhancement.
+
+## Files to Modify
+
+| File | Change |
+| --- | --- |
+| `docs/enhancements/097-quarkus-cognition-processor.md` | This enhancement doc |
+| `docs/memory-cognition.md` | Add a pointer to this enhancement under "Relationship to Existing Enhancement Work" |
+| `contracts/openapi/openapi.yml` | Extend `POST /v1/memories/search` with multi-prefix retrieval and richer filter/order options |
+| `contracts/openapi/openapi-admin.yml` | Add `/admin/v1/cognition/status`, `/admin/v1/cognition/rebuild`, and `/admin/v1/cognition/conversations/{conversationId}/retrieval` |
+| `contracts/protobuf/memory/v1/memory_service.proto` | Align `SearchMemoriesRequest`/`SearchMemoriesResponse` with multi-prefix search and cursor pagination |
+| `internal/generated/api/` and generated clients | Regenerate from OpenAPI after memory search and admin cognition contract changes |
+| `internal/generated/pb/` and generated gRPC clients | Regenerate from protobuf after `SearchMemories` contract changes |
+| `internal/registry/episodic/plugin.go` | Update search request/store contracts for multi-prefix search, operator filters, order, and cursor semantics |
+| `internal/plugin/route/memories/memories.go` | Parse enhanced search requests, apply per-prefix OPA injection, merge results, and emit `afterCursor` |
+| `internal/plugin/store/postgres/episodic_store.go` | Support operator filters and deterministic ordered memory search |
+| `internal/plugin/store/sqlite/episodic_store.go` | Support operator filters and deterministic ordered memory search |
+| `internal/plugin/store/mongo/episodic_store.go` | Support operator filters and deterministic ordered memory search |
+| `internal/episodic/policy.go` and configured `attributes.rego` examples | Extract safe cognition attributes from memory values/index payloads |
+| `java/pom.xml` | Register the new Quarkus cognition module in the reactor |
+| `java/quarkus/pom.xml` | Add the cognition processor module to the Quarkus reactor |
+| `java/quarkus/cognition-processor-quarkus/pom.xml` | New module with Quarkus + LangChain4j + memory-service-contracts dependencies |
+| `java/quarkus/cognition-processor-quarkus/Dockerfile` | Container image used by `compose.yaml` |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../runtime/*.java` | Processor implementation, scope job dispatch, scheduler |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../evidence/*.java` | Evidence loader registry plus transcript/context/episodic/cluster loaders |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../extractor/*.java` | LangChain4j durable extractor and topic-summary AiServices, plus heuristic bridge/topic extractors |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../verifier/*.java` | LangChain4j verifier AiService and normalization helpers |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../consolidator/*.java` | Idempotent consolidation, supersede, and natural-key logic |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../retrieval/*.java` | Search payload shaping and retrieval metadata |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../cache/*.java` | Cognition cache namespace helpers and TTL writes |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../remote/*.java` | Admin SSE client, episodic memory client, conversation/entry loader |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../admin/CognitionAdminResource.java` | Admin status/rebuild/retrieval-debug endpoints |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../config/CognitionConfig.java` | `@ConfigMapping` types for the `cognition.*` prefix |
+| `java/quarkus/cognition-processor-quarkus/src/main/resources/application.properties` | Default config and named LangChain4j model bindings |
+| `java/quarkus/cognition-processor-quarkus/src/main/resources/prompts/*.md` | Stable system/user prompt templates loaded by AiServices |
+| `java/quarkus/cognition-processor-quarkus/src/test/java/.../*.java` | Unit and Quarkus integration tests, including a stubbed LangChain4j model and a cucumber runner |
+| `compose.yaml` | Replace the existing cognition processor service with the Quarkus image |
+| `java/quarkus/FACTS.md` | Record any module-specific gotchas discovered during implementation |
+
+## Verification
+
+```bash
+# Regenerate Go/OpenAPI/protobuf artifacts touched by contract changes
+task generate:go
+
+# Regenerate Java REST clients after OpenAPI changes
+./java/mvnw -f java/pom.xml -pl quarkus/memory-service-rest-quarkus -am clean compile
+
+# Compile the new module
+./java/mvnw -f java/pom.xml -pl quarkus/cognition-processor-quarkus -am compile
+
+# Build affected Go packages after OpenAPI/search changes
+go build ./internal/registry/episodic ./internal/plugin/route/memories ./internal/plugin/store/postgres ./internal/plugin/store/sqlite ./internal/plugin/store/mongo ./internal/cmd/serve
+
+# Run unit tests
+./java/mvnw -f java/pom.xml -pl quarkus/cognition-processor-quarkus -am test > test.log 2>&1
+# Search for failures using Grep tool on test.log
+
+# Run focused Go tests for memory search behavior
+go test ./internal/plugin/route/memories ./internal/plugin/store/postgres ./internal/plugin/store/sqlite ./internal/plugin/store/mongo > go-test.log 2>&1
+# Search for failures using Grep tool on go-test.log
+
+# Build the runnable jar / native dev image
+./java/mvnw -f java/pom.xml -pl quarkus/cognition-processor-quarkus -am package -DskipTests
+
+# Local end-to-end smoke against the dev memory-service
+docker compose up -d memory-service qdrant
+docker compose up cognition-processor
+```
+
+## Non-Goals
+
+- replacing the existing conversation, search, or episodic-memory substrate APIs
+- building a general-purpose graph memory system in the first iteration
+- exposing raw cluster centroids or embedding-derived internals to non-admin callers
+- promoting low-confidence or uncited candidate memories just to improve recall numbers
+- sharing process space with the memory-service Go server
+
+## Security Considerations
+
+- derived memories must remain under the same effective user scope as their evidence
+- durable writes must preserve provenance so incorrect memories can be audited and rebuilt
+- the Quarkus processor requires a dedicated `cognition-processor` admin API key and a tightly-scoped episodic-memory policy that only allows writes under the configured cognition namespaces; the built-in default policy is not sufficient
+- user-facing memory search responses must not expose internal `clientId` metadata
+- admin/debug cognition endpoints must remain admin-only because they expose runtime internals and evidence traces
+- LangChain4j prompt cache identifiers must be derived from stable, non-sensitive inputs so cache keys do not leak per-user evidence into provider logs
+
+## Deferred Evaluation
+
+- Provider prompt-prefix caching must remain disabled by default until the benchmark harness shows a net benefit for a specific stage and provider. The benchmark must report cache hit rate, cache write/read token cost, and end-to-end latency before any stage's `prompt-cache.enabled` flag flips to `true`.
+
+All other Phase 1 interface choices are intentionally decided in this document: use per-memory writes first, use opaque cursor pagination for multi-prefix search, and do not add Quarkus dev-service automation until the processor module exists and local developer friction is measured.

--- a/docs/enhancements/099-quarkus-cognition-processor.md
+++ b/docs/enhancements/099-quarkus-cognition-processor.md
@@ -2,7 +2,7 @@
 status: proposed
 ---
 
-# Enhancement 097: Quarkus + LangChain4j Cognition Processor
+# Enhancement 099: Quarkus + LangChain4j Cognition Processor
 
 > **Status**: Proposed.
 
@@ -40,7 +40,7 @@ Build the reference processor as a **standalone Quarkus application** (`java/qua
 - **Worker mode** (default): subscribes to `/v1/admin/events`, persists a replay cursor, processes coalesced scope jobs, and writes derived memories through `/v1/memories`.
 - **Replay/shadow mode**: reprocesses an event window or runs extraction/scoring without affecting production cognition memories.
 
-Durable facts, preferences, procedures, decisions, rolling summaries, bridge notes, topic notes, and any cached retrieval candidates are all stored as memory items under fixed cognition namespaces. Agent applications fetch the next-turn memory material with `/v1/memories/search`, using substrate-level retrieval improvements described below. This keeps cognition responsible for producing better memory, while the Memory Service remains the single retrieval API for memory products.
+Durable facts, preferences, procedures, decisions, rolling summaries, bridge notes, topic notes, and any cached retrieval candidates are all stored as memory items under fixed cognition namespaces. Agent applications fetch the next-turn memory material with `/v1/memories/search`, using the substrate-level retrieval improvements defined by [100](100-enhanced-memory-search.md). This keeps cognition responsible for producing better memory, while the Memory Service remains the single retrieval API for memory products.
 
 The standalone worker authenticates as a dedicated **service principal** (admin API key `cognition-processor`) and writes cognition memories through the public episodic memory API on behalf of conversation owners. The built-in episodic memory policy only allows `["user", <subject>, ...]` access for the authenticated subject, so deploying this processor requires a custom episodic-memory policy that allows the cognition service principal to write under the configured cognition namespaces. That policy is a Phase 1 prerequisite, not optional later hardening.
 
@@ -105,7 +105,9 @@ Phase 1 does not depend on episodic memory lifecycle events as a primary trigger
 Implementation details:
 
 - A `ReactiveAdminEventClient` consumes `/v1/admin/events` using JAX-RS SSE (`SseEventSource`) with exponential backoff and resume-from-cursor semantics.
-- The current cursor is persisted to `/v1/admin/checkpoints/{workerId}` on a configurable cadence, where `{workerId}` is supplied by `cognition.worker.id` and identifies one logical processor instance.
+- The processor must use the admin checkpoint APIs to persist its event progress. On startup it calls `GET /v1/admin/checkpoints/{workerId}` and, when a checkpoint exists, subscribes to `/v1/admin/events?after=<lastEventCursor>` so restart catch-up begins near the last processed event instead of replaying the full retained window. A missing checkpoint means first run; subscribe from the configured bootstrap position.
+- After events are accepted into the coalesced scope-job queue, the processor writes a checkpoint with `PUT /v1/admin/checkpoints/{workerId}`. The checkpoint value includes at least `lastEventCursor`, `updatedAt`, `runtimeId`, `runtimeVersion`, and the highest event timestamp observed. `{workerId}` is supplied by `cognition.worker.id` and identifies one logical processor instance, not one container replica.
+- Checkpoint writes may be batched on a configurable cadence, but shutdown and idle transitions should flush the latest accepted cursor. The processor must not advance the checkpoint past an event that has not been reduced into a durable or retryable job, or restart could skip work.
 - Incoming events are reduced to `ScopeJob` records keyed by conversation ID and pushed onto a singleton task queue (`Map<UUID, ScopeJob>` guarded by a serializable `Mutiny` workflow). Duplicate events for the same conversation while a job is pending coalesce into the existing job.
 - Scope jobs are dispatched on virtual threads (`@RunOnVirtualThread`) so blocking REST calls do not consume reactive event-loop capacity.
 - `@Scheduled` triggers run optional periodic sweeps and rebuild requests.
@@ -247,11 +249,11 @@ The processor reuses the existing substrate instead of creating a separate deriv
 Derived durable memories are stored under fixed user-owned namespaces so existing governance, namespace-depth limits, archive semantics, and vector indexing still apply:
 
 ```text
-["user", <sub>, "cognition.v1.facts"]
-["user", <sub>, "cognition.v1.preferences"]
-["user", <sub>, "cognition.v1.procedures"]
-["user", <sub>, "cognition.v1.problem_solutions"]
-["user", <sub>, "cognition.v1.decisions"]
+["user", <sub>, "cognition.v1", "facts"]
+["user", <sub>, "cognition.v1", "preferences"]
+["user", <sub>, "cognition.v1", "procedures"]
+["user", <sub>, "cognition.v1", "problem_solutions"]
+["user", <sub>, "cognition.v1", "decisions"]
 ```
 
 `runtime.id` remains part of the stored memory payload for attribution and debugging, but it does not partition the namespace layout.
@@ -302,10 +304,10 @@ Short-lived cognition cache entries hold rolling conversation summaries, retriev
 API-compatible cache namespace shape:
 
 ```text
-["user", <sub>, "cognition.v1.cache"]
+["user", <sub>, "cognition.v1", "cache"]
 ```
 
-Key prefixes are `summary:<conversation-id>`, `bridge:<conversation-id>`, `topic:<conversation-id>`, and `candidate:<conversation-id>`. The fixed `cognition.v1.*` layout keeps cognition storage within the default episodic namespace-depth limits without needing a runtime-specific segment.
+Key prefixes are `summary:<conversation-id>`, `bridge:<conversation-id>`, `topic:<conversation-id>`, and `candidate:<conversation-id>`. The shared `["user", <sub>, "cognition.v1"]` prefix lets agents retrieve all cognition output with one `/v1/memories/search` request while keeping each memory kind in a distinct child namespace. The four-segment layout stays within the default `EpisodicMaxDepth=5`.
 
 External Quarkus workers cannot generically write conversation `context` through today's agent APIs, because context reads/writes are authorized by the conversation's stored `clientId` and the service does not support admin impersonation. The Quarkus processor therefore does not mirror summaries into `context`.
 
@@ -366,162 +368,10 @@ The public surface is intentionally small at first.
 
 - no new user-facing CRUD API for cognition memories
 - inspect durable outputs through existing `/v1/memories` APIs under cognition namespaces
+- retrieve cognition-produced memories through the enhanced `/v1/memories/search` contract defined by [100](100-enhanced-memory-search.md)
 - admin/debug endpoints for runtime status and rebuilds at `/admin/v1/cognition/status`, `/admin/v1/cognition/rebuild`, and `/admin/v1/cognition/conversations/{conversationId}/retrieval`
 
-Instead, improve `POST /v1/memories/search` enough that agent applications can request cognition-produced memories directly. Replace the single `namespace_prefix` request field with required `namespace_prefixes`; single-prefix callers send a one-element array.
-
-```json
-{
-  "namespace_prefixes": [
-    ["user", "alice", "cognition.v1.preferences"],
-    ["user", "alice", "cognition.v1.procedures"],
-    ["user", "alice", "cognition.v1.cache"]
-  ],
-  "query": "help me continue the deployment fix",
-  "filter": {
-    "conversationIds": {"$in": ["uuid"]},
-    "memoryKind": ["preference", "procedure", "summary", "bridge", "topic"],
-    "runtimeId": "quarkus-reference-v1"
-  },
-  "limit": 12,
-  "order": "relevance",
-  "include_usage": true,
-  "after_cursor": null
-}
-```
-
-Example response:
-
-```json
-{
-  "items": [
-    {
-      "id": "uuid",
-      "namespace": ["user", "alice", "cognition.v1.procedures"],
-      "key": "procedure:deployment-debugging",
-      "value": {
-        "kind": "procedure",
-        "statement": "User usually debugs deployments by checking logs, then environment drift, then rollout history.",
-        "provenance": {
-          "entry_ids": ["uuid"]
-        },
-        "runtime": {
-          "id": "quarkus-reference-v1",
-          "version": 1
-        }
-      },
-      "score": 0.87
-    }
-  ],
-  "afterCursor": "opaque-cursor-or-null"
-}
-```
-
-#### Enhanced Search Contract
-
-`SearchMemoriesRequest` becomes:
-
-| Field | Required | Notes |
-| --- | --- | --- |
-| `namespace_prefixes` | yes | Non-empty array of up to 10 namespace prefixes. Each prefix is independently validated against `EpisodicMaxDepth` and independently passed through OPA filter injection. Empty segments are invalid. |
-| `query` | no | Free text semantic query. When present and an embedder is configured, search uses vector retrieval per effective prefix, then merges results. |
-| `filter` | no | Attribute filter expression. Existing flat equality filters still work; operator form is added below. |
-| `limit` | no | Default 10, maximum 100, applied after merging results across prefixes. |
-| `order` | no | `relevance` (default when `query` is set), `createdAtDesc`, or `createdAtAsc`. `relevance` without `query` falls back to `createdAtDesc`. |
-| `include_usage` | no | Includes usage metadata without incrementing usage counters, matching current search behavior. |
-| `archived` | no | Existing `exclude|include|only` archive filter, applied consistently to every prefix. |
-| `after_cursor` | no | Opaque cursor for the selected order. `offset` is removed because it is ambiguous after multi-prefix merge. |
-
-`SearchMemoriesResponse` adds nullable `afterCursor`. The cursor is opaque to clients. The server may encode a request hash, order keys, effective prefix position, and the last memory ID, but clients must only replay it with the same request fields except `after_cursor`. A cursor replayed with different search fields returns `400`.
-
-The gRPC `SearchMemoriesRequest` must stay semantically aligned with REST. Because protobuf cannot represent a repeated list of repeated strings directly, add a small message:
-
-```protobuf
-message MemoryNamespacePrefix {
-  repeated string segments = 1;
-}
-
-message SearchMemoriesRequest {
-  repeated MemoryNamespacePrefix namespace_prefixes = 1;
-  string query = 2;
-  optional google.protobuf.Struct filter = 3;
-  int32 limit = 4;
-  bool include_usage = 5;
-  ArchiveFilter archived = 6;
-  string order = 7;
-  optional string after_cursor = 8;
-}
-
-message SearchMemoriesResponse {
-  repeated MemoryItem items = 1;
-  optional string after_cursor = 2;
-}
-```
-
-The old protobuf `namespace_prefix` and `offset` fields are removed under the repo's pre-release no-compatibility rule.
-
-#### Filter Expression
-
-The filter language stays intentionally small and maps to plaintext policy attributes, not encrypted memory values. A field may be:
-
-- a scalar, equivalent to `$eq`
-- an array, equivalent to `$in`
-- an operator object with one of `$eq`, `$ne`, `$in`, `$nin`, `$exists`, `$gte`, `$lte`
-
-Example:
-
-```json
-{
-  "memoryKind": {"$in": ["procedure", "summary", "bridge"]},
-  "runtimeId": "quarkus-reference-v1",
-  "conversationIds": {"$in": ["uuid"]},
-  "confidence": {"$in": ["medium", "high"]},
-  "freshness": {"$ne": "stale"}
-}
-```
-
-Unsupported operators return `400`. Type mismatches simply do not match rows. OPA filter injection receives the parsed filter and may narrow it, but may not broaden it.
-
-#### Cognition Attributes
-
-The processor's memory policy must extract these safe attributes for every cognition memory:
-
-| Attribute | Source | Purpose |
-| --- | --- | --- |
-| `memoryKind` | `value.kind` | Filter facts, preferences, procedures, decisions, summaries, bridge notes, and topic notes. |
-| `runtimeId` | `value.runtime.id` | Isolate active, shadow, or benchmark processor outputs. |
-| `runtimeVersion` | `value.runtime.version` | Debug and benchmark processor versions. |
-| `confidence` | `value.confidence` | Filter weak or medium-confidence candidates. |
-| `freshness` | `value.freshness` | Exclude stale or contradicted memories from retrieval. |
-| `conversationIds` | `value.provenance.conversation_ids` | Retrieve items related to a conversation lineage. |
-| `entryIds` | `value.provenance.entry_ids` | Audit and targeted debug lookups. |
-| `sourceHash` | `value.provenance.source_hash` | Idempotent replay and debug lookup. |
-
-These attributes are safe to expose as `MemoryItem.attributes`; they must not contain raw evidence text, `clientId`, provider prompts, or provider cache keys.
-
-#### Multi-Prefix Execution
-
-The route executes each requested prefix as an independent authorized search and then merges the results:
-
-1. Validate all prefixes and reject malformed requests with `400`.
-2. For each prefix, call `policy.InjectFilter` with that prefix and the requested filter.
-3. If policy narrows a prefix to no accessible namespace, that prefix contributes zero rows. Do not leak whether inaccessible rows exist.
-4. Run semantic or attribute search for each effective prefix.
-5. Deduplicate by memory `id`; if a memory appears through multiple prefixes, keep the highest score and most specific namespace match.
-6. Sort the merged set by the selected order. For `relevance`, sort by score descending, then `createdAt` descending, then `id` ascending for deterministic ties.
-7. Return up to `limit` rows plus `afterCursor` when more rows are available.
-
-The implementation may over-fetch per prefix to produce a stable merged page. Start with `min(limit * 3, 100)` per prefix and tune only if tests show poor recall.
-
-Needed `/v1/memories/search` improvements:
-
-- accept multiple namespace prefixes in one request while preserving OPA filter injection for each prefix
-- support filter operators for the extracted memory attributes used by cognition (`memoryKind`, `conversationIds`, `runtimeId`, `confidence`, `freshness`)
-- return stable relevance scores for semantic results and deterministic secondary ordering
-- optionally return usage metadata without incrementing counters, matching the current search behavior
-- keep `clientId` internal; cognition memory values and search responses must not expose it
-
-This is the middle ground between a bespoke cognition endpoint and forcing every agent app to hand-code many memory queries. The API remains a generic memory retrieval surface, while cognition remains an external producer of better memory items.
+The search request/response shape, filter language, cursor semantics, and safe retrieval attributes are owned by [100](100-enhanced-memory-search.md). This processor writes memory values compatible with that generic retrieval API.
 
 #### Admin Debug Endpoints
 
@@ -599,9 +449,9 @@ LangChain4j gives us declarative AiService interfaces, structured output, prompt
 
 This keeps governance, indexing, archive semantics, and encryption aligned with the rest of the system. Adding substrate extensions is deferred until the current memory primitives prove too weak.
 
-### Improve `/v1/memories/search`
+### Reuse Enhanced `/v1/memories/search`
 
-The proposed cognition outputs are already stored as memory items. The generic memory search API should be strong enough to retrieve cognition-produced facts, preferences, procedures, summaries, bridge notes, and topic notes through the same governed surface as any other memory.
+The proposed cognition outputs are already stored as memory items. This processor depends on [100](100-enhanced-memory-search.md) so cognition-produced facts, preferences, procedures, summaries, bridge notes, and topic notes can be retrieved through the same governed surface as any other memory.
 
 The tradeoff is that agent applications remain responsible for assembling the final LLM prompt from returned memory items and recent conversation entries. That is preferable for now because prompt assembly is application-specific, while retrieval of relevant memory products is a substrate responsibility.
 
@@ -615,7 +465,7 @@ The existing replayable admin SSE stream is sufficient as long as cognition jobs
 
 ### Use Fixed Versioned Cognition Namespaces
 
-The default episodic API validates namespaces against `EpisodicMaxDepth=5`. Using fixed third-segment namespaces such as `["user", sub, "cognition.v1.cache"]` keeps cognition storage well within that limit while avoiding a generic `["user", sub, "cognition", ...]` prefix that would invite broad queries across processor-specific shapes.
+The default episodic API validates namespaces against `EpisodicMaxDepth=5`. Using a shared versioned prefix plus kind segment, such as `["user", sub, "cognition.v1", "preferences"]`, keeps cognition storage within that limit and allows a single search under `["user", sub, "cognition.v1"]` to retrieve all cognition memory products.
 
 ### Service Principal With Custom Episodic Policy
 
@@ -631,7 +481,7 @@ Feature: Quarkus cognition processor
     Given conversation "conv-1" contains turns showing user preference for "neovim"
     And the cognition processor is running in active mode
     When the processor replays admin events for "conv-1"
-    Then a memory exists under namespace ["user","alice","cognition.v1.preferences"]
+    Then a memory exists under namespace ["user","alice","cognition.v1","preferences"]
     And the memory value field "statement" contains "Neovim"
     And the memory value field "provenance.entry_ids[0]" is not null
 
@@ -653,29 +503,9 @@ Feature: Quarkus cognition processor
     And the response body field "items[0].value.kind" should equal "procedure"
 
   Scenario: Cognition writes are scoped to the configured namespaces
-    Given the cognition service principal is configured for namespaces under "cognition.v1.*"
+    Given the cognition service principal is configured for namespaces under ["user", "*", "cognition.v1"]
     When the processor attempts to write outside those namespaces
     Then the episodic memory API rejects the write with 403
-
-  Scenario: Multi-prefix memory search applies authorization per prefix
-    Given Alice can read ["user","alice","cognition.v1.preferences"]
-    And Alice cannot read ["user","bob","cognition.v1.preferences"]
-    When Alice searches both namespace prefixes in one /v1/memories/search request
-    Then the response status should be 200
-    And every returned item namespace should start with ["user","alice"]
-
-  Scenario: Cognition filters support operator expressions
-    Given cognition memories exist with kinds "procedure", "bridge", and "decision"
-    When POST /v1/memories/search filters memoryKind with {"$in":["procedure","bridge"]}
-    Then the response status should be 200
-    And no returned item should have memoryKind "decision"
-
-  Scenario: Multi-prefix search pagination uses an opaque cursor
-    Given more than 12 cognition memories match query "deployment fix"
-    When POST /v1/memories/search is called with limit 12
-    Then the response body field "afterCursor" should not be null
-    When POST /v1/memories/search is called again with the same request and that after_cursor
-    Then the second page should not repeat memory ids from the first page
 ```
 
 ### Unit / Quarkus Integration Tests
@@ -685,10 +515,7 @@ Feature: Quarkus cognition processor
 - `EvidencePackBuilder` deduplicates repeated content, drops fenced code blocks during the prose normalization step, and never exceeds the configured token cap.
 - `Consolidator` merges duplicates by stable natural key, supersedes contradicted memories, and produces no-op writes on identical `source_hash` replays.
 - Cache-only `bridge` and `topic` notes are written under the cognition cache namespace with the configured TTLs and surface in memory search.
-- The admin SSE consumer resumes from the persisted checkpoint, coalesces bursts into singleton scope jobs, and does not lose events across reconnect.
-- Memory search across cognition namespaces returns only memories authorized for the caller and does not expose internal `clientId` metadata.
-- Memory search rejects unsupported filter operators with `400`, treats type mismatches as non-matches, and returns deterministic order across repeated multi-prefix calls.
-- Search cursors are opaque, request-bound, and cannot be replayed with a different query/filter/order.
+- The admin SSE consumer loads its checkpoint with `GET /v1/admin/checkpoints/{workerId}`, resumes `/v1/admin/events` after the saved `lastEventCursor`, persists progress with `PUT /v1/admin/checkpoints/{workerId}`, coalesces bursts into singleton scope jobs, and does not lose events across reconnect.
 - A Quarkus dev-services-backed integration test boots the full stack (memory-service container plus the processor) and verifies an end-to-end extraction-to-search flow against a `TestChatModel` that mimics the LangChain4j contract used in `chat-quarkus`.
 
 ## Tasks
@@ -696,19 +523,17 @@ Feature: Quarkus cognition processor
 - [ ] Create the `java/quarkus/cognition-processor-quarkus` Maven module with parent wiring, packaging, and Dockerfile.
 - [ ] Define the `CognitionProcessor` contract and `ScopeJob` types.
 - [ ] Wire the LangChain4j dependency and add named model configurations for durable extraction, verification, and topic summarization.
-- [ ] Implement the admin SSE consumer with checkpointed replay against `/v1/admin/events`.
+- [ ] Implement the admin SSE consumer with checkpointed replay against `/v1/admin/events` using `GET`/`PUT /v1/admin/checkpoints/{workerId}` for the last accepted event cursor.
 - [ ] Implement the singleton-per-conversation scope-job queue running on virtual threads.
 - [ ] Implement the evidence pack builder registry over transcript, `context`, episodic memory, and optional knowledge-cluster sources.
 - [ ] Implement the `DurableMemoryExtractor` AiService with strict structured output for fact, preference, procedure, problem_solution, and decision candidates.
 - [ ] Implement the `DurableMemoryVerifier` AiService with batched citation checking and normalization.
 - [ ] Implement the `TopicSummaryExtractor` AiService and TTL-backed topic-summary cache writes.
 - [ ] Implement deterministic consolidation with stable natural keys, `source_hash`-based no-op replay, and supersede semantics.
-- [ ] Implement cache-only `bridge` and `topic` heuristic extractors writing under `cognition.v1.cache`.
+- [ ] Implement cache-only `bridge` and `topic` heuristic extractors writing under `["user", <sub>, "cognition.v1", "cache"]`.
 - [ ] Implement TTL-backed rolling summary and retrieval candidate cache entries.
-- [ ] Replace `POST /v1/memories/search` request field `namespace_prefix` with `namespace_prefixes`.
-- [ ] Add memory search filter operators `$eq`, `$ne`, `$in`, `$nin`, `$exists`, `$gte`, and `$lte`.
-- [ ] Add deterministic multi-prefix result merge, `order`, and opaque `after_cursor` pagination.
-- [ ] Update memory policy attribute extraction so cognition memories expose safe filter attributes.
+- [ ] Use the enhanced memory search contract from [100](100-enhanced-memory-search.md) for retrieval examples and integration tests.
+- [ ] Update the cognition memory policy so cognition memories expose safe filter attributes.
 - [ ] Implement admin status / rebuild / retrieval-debug endpoints.
 - [ ] Add the configurable `cognition.profile` selector for evidence/extractor/verifier registry filtering.
 - [ ] Add the replay/shadow benchmark harness and scenario format.
@@ -721,19 +546,10 @@ Feature: Quarkus cognition processor
 
 | File | Change |
 | --- | --- |
-| `docs/enhancements/097-quarkus-cognition-processor.md` | This enhancement doc |
+| `docs/enhancements/099-quarkus-cognition-processor.md` | This enhancement doc |
 | `docs/memory-cognition.md` | Add a pointer to this enhancement under "Relationship to Existing Enhancement Work" |
-| `contracts/openapi/openapi.yml` | Extend `POST /v1/memories/search` with multi-prefix retrieval and richer filter/order options |
 | `contracts/openapi/openapi-admin.yml` | Add `/admin/v1/cognition/status`, `/admin/v1/cognition/rebuild`, and `/admin/v1/cognition/conversations/{conversationId}/retrieval` |
-| `contracts/protobuf/memory/v1/memory_service.proto` | Align `SearchMemoriesRequest`/`SearchMemoriesResponse` with multi-prefix search and cursor pagination |
-| `internal/generated/api/` and generated clients | Regenerate from OpenAPI after memory search and admin cognition contract changes |
-| `internal/generated/pb/` and generated gRPC clients | Regenerate from protobuf after `SearchMemories` contract changes |
-| `internal/registry/episodic/plugin.go` | Update search request/store contracts for multi-prefix search, operator filters, order, and cursor semantics |
-| `internal/plugin/route/memories/memories.go` | Parse enhanced search requests, apply per-prefix OPA injection, merge results, and emit `afterCursor` |
-| `internal/plugin/store/postgres/episodic_store.go` | Support operator filters and deterministic ordered memory search |
-| `internal/plugin/store/sqlite/episodic_store.go` | Support operator filters and deterministic ordered memory search |
-| `internal/plugin/store/mongo/episodic_store.go` | Support operator filters and deterministic ordered memory search |
-| `internal/episodic/policy.go` and configured `attributes.rego` examples | Extract safe cognition attributes from memory values/index payloads |
+| `internal/episodic/policy.go` and configured `attributes.rego` examples | Extract safe cognition attributes from cognition memory values/index payloads |
 | `java/pom.xml` | Register the new Quarkus cognition module in the reactor |
 | `java/quarkus/pom.xml` | Add the cognition processor module to the Quarkus reactor |
 | `java/quarkus/cognition-processor-quarkus/pom.xml` | New module with Quarkus + LangChain4j + memory-service-contracts dependencies |
@@ -746,6 +562,7 @@ Feature: Quarkus cognition processor
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../retrieval/*.java` | Search payload shaping and retrieval metadata |
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../cache/*.java` | Cognition cache namespace helpers and TTL writes |
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../remote/*.java` | Admin SSE client, episodic memory client, conversation/entry loader |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../remote/AdminCheckpointClient.java` | Client wrapper for `GET`/`PUT /v1/admin/checkpoints/{workerId}` |
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../admin/CognitionAdminResource.java` | Admin status/rebuild/retrieval-debug endpoints |
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../config/CognitionConfig.java` | `@ConfigMapping` types for the `cognition.*` prefix |
 | `java/quarkus/cognition-processor-quarkus/src/main/resources/application.properties` | Default config and named LangChain4j model bindings |
@@ -757,25 +574,12 @@ Feature: Quarkus cognition processor
 ## Verification
 
 ```bash
-# Regenerate Go/OpenAPI/protobuf artifacts touched by contract changes
-task generate:go
-
-# Regenerate Java REST clients after OpenAPI changes
-./java/mvnw -f java/pom.xml -pl quarkus/memory-service-rest-quarkus -am clean compile
-
 # Compile the new module
 ./java/mvnw -f java/pom.xml -pl quarkus/cognition-processor-quarkus -am compile
-
-# Build affected Go packages after OpenAPI/search changes
-go build ./internal/registry/episodic ./internal/plugin/route/memories ./internal/plugin/store/postgres ./internal/plugin/store/sqlite ./internal/plugin/store/mongo ./internal/cmd/serve
 
 # Run unit tests
 ./java/mvnw -f java/pom.xml -pl quarkus/cognition-processor-quarkus -am test > test.log 2>&1
 # Search for failures using Grep tool on test.log
-
-# Run focused Go tests for memory search behavior
-go test ./internal/plugin/route/memories ./internal/plugin/store/postgres ./internal/plugin/store/sqlite ./internal/plugin/store/mongo > go-test.log 2>&1
-# Search for failures using Grep tool on go-test.log
 
 # Build the runnable jar / native dev image
 ./java/mvnw -f java/pom.xml -pl quarkus/cognition-processor-quarkus -am package -DskipTests
@@ -798,7 +602,7 @@ docker compose up cognition-processor
 - derived memories must remain under the same effective user scope as their evidence
 - durable writes must preserve provenance so incorrect memories can be audited and rebuilt
 - the Quarkus processor requires a dedicated `cognition-processor` admin API key and a tightly-scoped episodic-memory policy that only allows writes under the configured cognition namespaces; the built-in default policy is not sufficient
-- user-facing memory search responses must not expose internal `clientId` metadata
+- cognition memory values and extracted attributes must not include internal `clientId` metadata, raw evidence dumps, provider prompts, or provider cache keys
 - admin/debug cognition endpoints must remain admin-only because they expose runtime internals and evidence traces
 - LangChain4j prompt cache identifiers must be derived from stable, non-sensitive inputs so cache keys do not leak per-user evidence into provider logs
 
@@ -806,4 +610,4 @@ docker compose up cognition-processor
 
 - Provider prompt-prefix caching must remain disabled by default until the benchmark harness shows a net benefit for a specific stage and provider. The benchmark must report cache hit rate, cache write/read token cost, and end-to-end latency before any stage's `prompt-cache.enabled` flag flips to `true`.
 
-All other Phase 1 interface choices are intentionally decided in this document: use per-memory writes first, use opaque cursor pagination for multi-prefix search, and do not add Quarkus dev-service automation until the processor module exists and local developer friction is measured.
+All other Phase 1 interface choices are intentionally decided in this document: use per-memory writes first, and do not add Quarkus dev-service automation until the processor module exists and local developer friction is measured.

--- a/docs/enhancements/100-enhanced-memory-search.md
+++ b/docs/enhancements/100-enhanced-memory-search.md
@@ -1,0 +1,284 @@
+---
+status: proposed
+---
+
+# Enhancement 100: Enhanced Episodic Memory Search
+
+> **Status**: Proposed.
+
+## Summary
+
+Enhance `POST /v1/memories/search` so clients can filter by safe policy attributes with a small operator language and page deterministically with opaque cursors. This gives cognition processors and agent applications a governed retrieval surface for durable and TTL-backed memory items under a shared namespace prefix.
+
+## Motivation
+
+The current episodic memory search API is optimized for simple namespace-prefix lookup with flat equality filters. Cognition processors need a stronger but still generic substrate retrieval primitive:
+
+- search under a shared namespace prefix such as `["user", "alice", "cognition.v1"]`, whose child namespaces hold facts, preferences, procedures, and short-lived cache notes
+- filter by safe plaintext policy attributes such as memory kind, runtime ID, confidence, freshness, and provenance IDs
+- sort semantic and attribute search results deterministically
+- page results with opaque cursors instead of offsets
+
+Without these improvements, applications either over-fetch broad search results and filter them client-side, or a separate cognition-specific retrieval API has to wrap memory search. The better substrate boundary is to make `/v1/memories/search` expressive enough for these retrieval patterns while keeping memory data under the existing governance, archive, indexing, and encryption model.
+
+[099](099-quarkus-cognition-processor.md) depends on this substrate enhancement for cognition-memory retrieval, but the API remains generic and is not coupled to that processor.
+
+## Design
+
+### REST Contract
+
+Keep the existing single `namespace_prefix` request field. Cognition processors should arrange their memory namespaces so one prefix can retrieve the relevant family of memory products, for example `["user", "alice", "cognition.v1"]`.
+
+Example request:
+
+```json
+{
+  "namespace_prefix": ["user", "alice", "cognition.v1"],
+  "query": "help me continue the deployment fix",
+  "filter": {
+    "conversationIds": {"$in": ["uuid"]},
+    "memoryKind": ["preference", "procedure", "summary", "bridge", "topic"],
+    "runtimeId": "quarkus-reference-v1"
+  },
+  "limit": 12,
+  "order": "relevance",
+  "include_usage": true,
+  "after_cursor": null
+}
+```
+
+Example response:
+
+```json
+{
+  "items": [
+    {
+      "id": "uuid",
+      "namespace": ["user", "alice", "cognition.v1", "procedures"],
+      "key": "procedure:deployment-debugging",
+      "value": {
+        "kind": "procedure",
+        "statement": "User usually debugs deployments by checking logs, then environment drift, then rollout history.",
+        "provenance": {
+          "entry_ids": ["uuid"]
+        },
+        "runtime": {
+          "id": "quarkus-reference-v1",
+          "version": 1
+        }
+      },
+      "score": 0.87
+    }
+  ],
+  "afterCursor": "opaque-cursor-or-null"
+}
+```
+
+`SearchMemoriesRequest` becomes:
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `namespace_prefix` | yes | Existing non-empty namespace prefix. It is validated against `EpisodicMaxDepth` and passed through OPA filter injection. Empty segments are invalid. |
+| `query` | no | Free text semantic query. When present and an embedder is configured, search uses vector retrieval under the effective prefix. |
+| `filter` | no | Attribute filter expression. Existing flat equality filters still work; operator form is added below. |
+| `limit` | no | Default 10, maximum 100. |
+| `order` | no | `relevance` (default when `query` is set), `createdAtDesc`, or `createdAtAsc`. `relevance` without `query` falls back to `createdAtDesc`. |
+| `include_usage` | no | Includes usage metadata without incrementing usage counters, matching current search behavior. |
+| `archived` | no | Existing `exclude|include|only` archive filter. |
+| `after_cursor` | no | Opaque cursor for the selected order. `offset` is replaced with cursor pagination for deterministic paging. |
+
+`SearchMemoriesResponse` adds nullable `afterCursor`. The cursor is opaque to clients. The server may encode a request hash, order keys, effective prefix position, and the last memory ID, but clients must only replay it with the same request fields except `after_cursor`. A cursor replayed with different search fields returns `400`.
+
+### gRPC Contract
+
+The gRPC `SearchMemoriesRequest` must stay semantically aligned with REST:
+
+```protobuf
+message SearchMemoriesRequest {
+  repeated string namespace_prefix = 1;
+  string query = 2;
+  optional google.protobuf.Struct filter = 3;
+  int32 limit = 4;
+  bool include_usage = 5;
+  ArchiveFilter archived = 6;
+  string order = 7;
+  optional string after_cursor = 8;
+}
+
+message SearchMemoriesResponse {
+  repeated MemoryItem items = 1;
+  optional string after_cursor = 2;
+}
+```
+
+The old protobuf `offset` field is removed under the repo's pre-release no-compatibility rule.
+
+### Filter Expression
+
+The filter language stays intentionally small and maps to plaintext policy attributes, not encrypted memory values. A field may be:
+
+- a scalar, equivalent to `$eq`
+- an array, equivalent to `$in`
+- an operator object with one of `$eq`, `$ne`, `$in`, `$nin`, `$exists`, `$gte`, `$lte`
+
+Example:
+
+```json
+{
+  "memoryKind": {"$in": ["procedure", "summary", "bridge"]},
+  "runtimeId": "quarkus-reference-v1",
+  "conversationIds": {"$in": ["uuid"]},
+  "confidence": {"$in": ["medium", "high"]},
+  "freshness": {"$ne": "stale"}
+}
+```
+
+Unsupported operators return `400`. Type mismatches do not match rows. OPA filter injection receives the parsed filter and may narrow it, but may not broaden it.
+
+### Cognition Attributes
+
+The default and example memory policies should document how cognition deployments can extract these safe attributes:
+
+| Attribute | Source | Purpose |
+| --- | --- | --- |
+| `memoryKind` | `value.kind` | Filter facts, preferences, procedures, decisions, summaries, bridge notes, and topic notes. |
+| `runtimeId` | `value.runtime.id` | Isolate active, shadow, or benchmark processor outputs. |
+| `runtimeVersion` | `value.runtime.version` | Debug and benchmark processor versions. |
+| `confidence` | `value.confidence` | Filter weak or medium-confidence candidates. |
+| `freshness` | `value.freshness` | Exclude stale or contradicted memories from retrieval. |
+| `conversationIds` | `value.provenance.conversation_ids` | Retrieve items related to a conversation lineage. |
+| `entryIds` | `value.provenance.entry_ids` | Audit and targeted debug lookups. |
+| `sourceHash` | `value.provenance.source_hash` | Idempotent replay and debug lookup. |
+
+These attributes are safe to expose as `MemoryItem.attributes`; they must not contain raw evidence text, `clientId`, provider prompts, or provider cache keys.
+
+### Search Execution
+
+The route executes a search under one authorized namespace prefix:
+
+1. Validate the prefix and reject malformed requests with `400`.
+2. Call `policy.InjectFilter` with the requested prefix and filter.
+3. If policy narrows the prefix to no accessible namespace, return zero rows. Do not leak whether inaccessible rows exist.
+4. Run semantic or attribute search for the effective prefix.
+5. Sort the result set by the selected order. For `relevance`, sort by score descending, then `createdAt` descending, then `id` ascending for deterministic ties.
+6. Return up to `limit` rows plus `afterCursor` when more rows are available.
+
+Cursor state should include the request hash and enough ordering keys to resume deterministically under the same effective prefix.
+
+## Design Decisions
+
+### Keep Retrieval Generic
+
+The API remains a generic memory retrieval surface, while cognition remains an external producer of better memory items. This avoids a separate cognition-specific retrieval endpoint for data that is already stored in `/v1/memories`.
+
+### Use Opaque Cursors
+
+Offset pagination is unstable when memory rows can be updated, archived, or inserted between pages. An opaque cursor can carry the request hash and ordering keys without exposing datastore-specific ordering details to clients.
+
+### Filter Policy Attributes Only
+
+Filtering encrypted memory values directly would undermine the storage model and create datastore-specific behavior. Policy-extracted plaintext attributes are already the right boundary for governed filtering.
+
+## Testing
+
+### Cucumber Scenarios
+
+```gherkin
+Feature: Enhanced episodic memory search
+  Scenario: Prefix memory search applies authorization
+    Given Alice can read ["user","alice","cognition.v1"]
+    And Alice cannot read ["user","bob","cognition.v1"]
+    When Alice searches namespace prefix ["user","alice","cognition.v1"]
+    Then the response status should be 200
+    And every returned item namespace should start with ["user","alice"]
+
+  Scenario: Memory filters support operator expressions
+    Given memories exist with memoryKind values "procedure", "bridge", and "decision"
+    When POST /v1/memories/search filters memoryKind with {"$in":["procedure","bridge"]}
+    Then the response status should be 200
+    And no returned item should have memoryKind "decision"
+
+  Scenario: Search pagination uses an opaque cursor
+    Given more than 12 memories match query "deployment fix"
+    When POST /v1/memories/search is called with limit 12
+    Then the response body field "afterCursor" should not be null
+    When POST /v1/memories/search is called again with the same request and that after_cursor
+    Then the second page should not repeat memory ids from the first page
+
+  Scenario: Search cursor is bound to the original request
+    Given a search response returned afterCursor "cursor-1"
+    When POST /v1/memories/search is called with after_cursor "cursor-1" and a different query
+    Then the response status should be 400
+
+  Scenario: Unsupported filter operators are rejected
+    When POST /v1/memories/search filters memoryKind with {"$regex":"proc.*"}
+    Then the response status should be 400
+```
+
+### Unit / Integration Tests
+
+- Search rejects unsupported filter operators with `400`.
+- Type mismatches in operator filters are treated as non-matches.
+- Search returns deterministic order across repeated calls.
+- OPA filter injection runs for the requested prefix and does not leak inaccessible rows.
+- `include_usage` enriches results without incrementing usage counters.
+- REST and gRPC request/response shapes remain semantically aligned.
+
+## Tasks
+
+- [ ] Add memory search filter operators `$eq`, `$ne`, `$in`, `$nin`, `$exists`, `$gte`, and `$lte`.
+- [ ] Add deterministic result ordering and opaque `after_cursor` pagination.
+- [ ] Align gRPC `SearchMemoriesRequest` and `SearchMemoriesResponse` with the REST contract.
+- [ ] Update memory policy docs/examples so cognition memories can expose safe filter attributes.
+- [ ] Regenerate REST and gRPC clients.
+- [ ] Add BDD and store/route tests for authorization, operators, deterministic ordering, and cursor binding.
+
+## Files to Modify
+
+| File | Change |
+| --- | --- |
+| `docs/enhancements/100-enhanced-memory-search.md` | This enhancement doc |
+| `contracts/openapi/openapi.yml` | Extend `POST /v1/memories/search` with richer filter/order options and cursor pagination |
+| `contracts/protobuf/memory/v1/memory_service.proto` | Align `SearchMemoriesRequest`/`SearchMemoriesResponse` with filter/order options and cursor pagination |
+| `internal/generated/api/` and generated clients | Regenerate from OpenAPI after memory search contract changes |
+| `internal/generated/pb/` and generated gRPC clients | Regenerate from protobuf after `SearchMemories` contract changes |
+| `internal/registry/episodic/plugin.go` | Update search request/store contracts for operator filters, order, and cursor semantics |
+| `internal/plugin/route/memories/memories.go` | Parse enhanced search requests, apply OPA injection, sort deterministically, and emit `afterCursor` |
+| `internal/plugin/store/postgres/episodic_store.go` | Support operator filters and deterministic ordered memory search |
+| `internal/plugin/store/sqlite/episodic_store.go` | Support operator filters and deterministic ordered memory search |
+| `internal/plugin/store/mongo/episodic_store.go` | Support operator filters and deterministic ordered memory search |
+| `internal/episodic/policy.go` and configured `attributes.rego` examples | Document or extract safe cognition attributes from memory values/index payloads |
+| `internal/bdd/testdata/features/memories-rest.feature` | Add REST coverage for operators, deterministic ordering, authorization, and cursors |
+| `internal/bdd/testdata/features/memories-grpc.feature` | Add gRPC coverage for aligned search semantics |
+
+## Verification
+
+```bash
+# Regenerate Go/OpenAPI/protobuf artifacts touched by contract changes
+task generate:go
+
+# Regenerate Java REST clients after OpenAPI changes
+./java/mvnw -f java/pom.xml -pl quarkus/memory-service-rest-quarkus -am clean compile
+
+# Build affected Go packages after search changes
+go build ./internal/registry/episodic ./internal/plugin/route/memories ./internal/plugin/store/postgres ./internal/plugin/store/sqlite ./internal/plugin/store/mongo ./internal/cmd/serve
+
+# Run focused Go tests for memory search behavior
+go test ./internal/plugin/route/memories ./internal/plugin/store/postgres ./internal/plugin/store/sqlite ./internal/plugin/store/mongo > go-test.log 2>&1
+# Search for failures using Grep tool on go-test.log
+```
+
+## Non-Goals
+
+- Adding a cognition-specific user-facing retrieval endpoint.
+- Filtering encrypted memory value fields directly.
+- Changing memory archive semantics.
+- Adding general-purpose SQL/Mongo query passthrough to the memory API.
+- Guaranteeing backward compatibility for the old `offset` request field.
+
+## Security Considerations
+
+- OPA filter injection is mandatory; enhanced search must not become a way to bypass namespace authorization.
+- Inaccessible prefixes contribute zero rows and must not reveal whether matching rows exist.
+- Search responses must not expose internal `clientId`, provider prompts, raw evidence text, or provider cache keys.
+- Cursor payloads must be signed or otherwise tamper-evident if they encode server state client-side.

--- a/docs/enhancements/implemented/098-embedded-mcp-server.md
+++ b/docs/enhancements/implemented/098-embedded-mcp-server.md
@@ -1,10 +1,10 @@
 ---
-status: proposed
+status: implemented
 ---
 
-# Enhancement 097: Embedded Memory Service in `mcp embedded`
+# Enhancement 098: Embedded Memory Service in `mcp embedded`
 
-> **Status**: Proposed.
+> **Status**: Implemented.
 
 ## Summary
 

--- a/docs/memory-cognition.md
+++ b/docs/memory-cognition.md
@@ -19,7 +19,7 @@ The next layer is memory cognition. This is the layer that interprets, organizes
 
 This document describes that cognition layer as a pluggable system that runs on top of the existing Memory Service substrate.
 
-For a concrete proposed implementation, see [Quarkus + LangChain4j Cognition Processor](enhancements/097-quarkus-cognition-processor.md).
+For a concrete proposed implementation, see [Quarkus + LangChain4j Cognition Processor](enhancements/099-quarkus-cognition-processor.md).
 
 ## Summary
 
@@ -139,6 +139,7 @@ Every cognition runtime should fit the same basic contract.
 
 - substrate event stream for new conversation and memory activity
 - replay or cursor-based catch-up so runtimes can resume after downtime
+- durable admin checkpoints via `GET`/`PUT /v1/admin/checkpoints/{clientId}` so processors can store the last accepted event cursor and resume quickly after restart
 - substrate read APIs for conversation windows, `context`, episodic memories, and search
 - optional periodic reprocessing triggers for backfills, rescoring, or global consolidation
 
@@ -307,9 +308,9 @@ Likely enhancements include:
 - richer query filters on derived memories, including type, confidence, freshness, provenance, and runtime id
 - graph-style access patterns for entity relationships, citations, and memory-to-memory links
 - first-class provenance fields instead of encoding source references only inside opaque payloads
-- multi-prefix and richer filtered memory search so runtimes can expose cognition outputs through `/v1/memories`
+- richer filtered memory search so runtimes can expose cognition outputs through `/v1/memories`
 
-Event replay and cursoring are especially important. A cognition runtime must be able to stop, resume, rebuild, and backfill without losing correctness.
+Event replay and cursoring are especially important. A cognition runtime must be able to stop, resume, rebuild, and backfill without losing correctness. Processors should persist their last accepted admin event cursor through the admin checkpoint APIs and use that checkpoint to reconnect to the event stream near their previous position instead of replaying from the beginning on every restart.
 
 ## Relationship to Existing Enhancement Work
 
@@ -317,7 +318,8 @@ This document is the top-level architecture for cognition. Existing enhancement 
 
 - [Adaptive Knowledge Clustering](enhancements/090-adaptive-knowledge-clustering.md) is one example of a cognition-stage implementation for organizing memory without LLM-heavy extraction.
 - [Skill Extraction](enhancements/partial/091-skill-extraction.md) is one example of a cognition-stage implementation that turns verified procedural memories into reusable user-facing skills.
-- [Quarkus + LangChain4j Cognition Processor](enhancements/097-quarkus-cognition-processor.md) is the concrete reference strategy for building a high-quality extraction, verification, consolidation, and memory-retrieval runtime on top of the substrate.
+- [Quarkus + LangChain4j Cognition Processor](enhancements/099-quarkus-cognition-processor.md) is the concrete reference strategy for building a high-quality extraction, verification, consolidation, and memory-retrieval runtime on top of the substrate.
+- [Enhanced Episodic Memory Search](enhancements/100-enhanced-memory-search.md) defines the generic `/v1/memories/search` improvements that cognition runtimes use for governed retrieval.
 
 Those enhancements describe specific cognition capabilities. This document defines the layer they belong to.
 

--- a/docs/memory-cognition.md
+++ b/docs/memory-cognition.md
@@ -1,0 +1,336 @@
+# Memory Cognition
+
+Memory Service today is primarily a memory substrate. It captures, stores, indexes, retrieves, scopes, and governs memory. It answers questions such as:
+
+- Where does memory live?
+- How is it keyed?
+- How is it searched?
+- Who can access it?
+- How long does it last?
+
+That layer remains necessary. It is the system of record.
+
+The next layer is memory cognition. This is the layer that interprets, organizes, updates, and injects memory so the agent can think better. It answers questions such as:
+
+- What should be remembered?
+- How should it be structured?
+- How should it be merged, summarized, or updated?
+- What should the agent see right now?
+
+This document describes that cognition layer as a pluggable system that runs on top of the existing Memory Service substrate.
+
+For a concrete proposed implementation, see [Quarkus + LangChain4j Cognition Processor](enhancements/097-quarkus-cognition-processor.md).
+
+## Summary
+
+The V2 architecture keeps the current memory-service focused on durable infrastructure:
+
+- conversation history and replay
+- per-conversation `context` state
+- episodic `/v1/memories`
+- search and indexing
+- identity, scoping, and governance
+- events and lifecycle management
+
+The cognition layer sits above that substrate and turns raw stored data into higher-level memory products:
+
+- typed memories
+- consolidated facts and preferences
+- skills and procedures
+- summaries and rollups
+- retrieval-ready memory products for the next model call
+
+The substrate remains the source of truth. Cognition runtimes are replaceable processors that read from the substrate, reason over it, and write derived state back through substrate APIs.
+
+## Goals
+
+- Preserve the current memory-service as the durable source of truth for raw entries, memories, access control, and lifecycle.
+- Make cognition pluggable so multiple implementations can run side by side and be benchmarked against each other.
+- Keep cognition mostly asynchronous and event-driven so extraction and consolidation do not bloat the agent hot path.
+- Preserve provenance, scope, and governance for all derived memories.
+- Support both external-process cognition runtimes and optional embedded runtimes when latency or deployment simplicity matters.
+- Make cognition outputs replayable and rebuildable from substrate data and event history.
+
+## Non-Goals
+
+- Replacing the current conversation, `context`, or `/v1/memories` substrate APIs.
+- Hard-coding one cognition strategy, one LLM provider, or one prompt format into the substrate.
+- Moving all reasoning into the memory-service process.
+- Treating cognition outputs as ungoverned side data that bypasses the substrate's access-control model.
+
+## Two-Layer Model
+
+The cleanest way to think about the system is as two layers with different responsibilities.
+
+| Layer | Responsibility | Typical Data |
+|------|----------------|--------------|
+| Substrate | Capture, persist, scope, search, govern, replay | conversation entries, `context` entries, episodic memories, events, embeddings, ACLs |
+| Cognition | Interpret, extract, consolidate, organize, inject | facts, preferences, skills, summaries, relationship views, retrieval-ready memory products |
+
+The substrate is about durability and control. The cognition layer is about usefulness.
+
+## Memory Layers Inside Cognition
+
+Different cognition runtimes may choose different internal models, but the architecture should support a common stack of memory products:
+
+| Memory Layer | Purpose | Likely Backing Store |
+|-------------|---------|----------------------|
+| Transcript layer | Raw conversation history and tool traces | conversation `entries` |
+| Working context layer | Per-conversation agent working state and checkpoints | conversation `context` entries |
+| Episodic layer | Durable user, project, or task memories across conversations | `/v1/memories` |
+| Semantic/profile layer | Facts, preferences, identity, stable traits | derived `/v1/memories` |
+| Procedural layer | Skills, workflows, decision policies, playbooks | derived `/v1/memories` or runtime-owned IR |
+| Runtime retrieval layer | The subset of cognition-produced memory candidates likely to help the next model call | `/v1/memories` search over durable and TTL-backed cognition namespaces |
+
+The first three layers already exist in the substrate. The latter layers are where cognition adds value.
+
+## High-Level Architecture
+
+The default deployment model should treat cognition as a separate runtime that uses the memory-service as its data plane.
+
+```mermaid
+flowchart LR
+    User[End User] --> Agent[Agent Application]
+    Agent --> LLM[LLM Provider]
+
+    subgraph MS["Memory Service Substrate"]
+        API[REST / gRPC APIs]
+        Entries[Conversation entries]
+        Context[Conversation context]
+        Memories[Episodic memories]
+        Search[Search, indexing, governance]
+        Events[Event stream and replay]
+    end
+
+    Agent --> API
+    API --- Entries
+    API --- Context
+    API --- Memories
+    API --- Search
+
+    Events --> CogA[Cognition runtime A]
+    Events --> CogB[Cognition runtime B]
+    Events --> CogC[Cognition runtime C]
+
+    CogA -->|read/write APIs| API
+    CogB -->|read/write APIs| API
+    CogC -->|read/write APIs| API
+
+    CogA --> Bench[Benchmark and evaluator]
+    CogB --> Bench
+    CogC --> Bench
+
+    Agent -->|search cognition memories| API
+    API --> Agent
+```
+
+This separation is important:
+
+- the substrate can stay focused on correctness, durability, and governance
+- cognition can evolve faster than the substrate
+- different cognition implementations can be tested without changing core storage
+- cognition can be written in the language and framework best suited to the algorithm
+
+## Cognition Runtime Contract
+
+Every cognition runtime should fit the same basic contract.
+
+### Inputs
+
+- substrate event stream for new conversation and memory activity
+- replay or cursor-based catch-up so runtimes can resume after downtime
+- substrate read APIs for conversation windows, `context`, episodic memories, and search
+- optional periodic reprocessing triggers for backfills, rescoring, or global consolidation
+
+### Outputs
+
+- create, update, archive, or supersede derived memories through substrate APIs
+- optional materialized per-conversation `context` updates
+- optional retrieval-ready memory products returned through `/v1/memories` search
+- metrics and evaluation records for benchmark comparison
+
+### Required invariants
+
+- derived memories must preserve provenance back to source entries or source memories
+- derived memories must never widen access beyond the source data's effective scope
+- consolidation must be idempotent so event replay does not duplicate memory state
+- runtimes must tolerate eventual consistency and partial failure
+
+## Reference Pipeline
+
+The cognition layer is not a single algorithm. It is a pipeline with replaceable stages.
+
+1. Observe: Subscribe to substrate events and identify impacted conversations, users, projects, or namespaces.
+2. Interpret: Read the relevant transcript and memory window, then extract candidate facts, preferences, summaries, skills, or relationships.
+3. Consolidate: Compare candidates to existing memory, resolve duplicates or conflicts, update freshness/confidence, and archive stale state.
+4. Inject: Retrieve cognition-produced memories and working notes that the agent app can assemble into the next model prompt.
+
+Some runtimes may use an LLM heavily. Others may use clustering, rules, graph updates, or deterministic summarization. The substrate should not care.
+
+## Event-Driven Extraction and Consolidation
+
+One common flow is an async cognition worker that listens for new conversation events, extracts candidate memory, and writes consolidated state back through the substrate.
+
+```mermaid
+sequenceDiagram
+    participant Agent as Agent App
+    participant MS as Memory Service Substrate
+    participant Cog as Cognition Runtime
+    participant LLM as Extractor / Reasoner
+
+    Agent->>MS: append conversation entry
+    MS-->>Cog: entry.created event
+    Cog->>MS: load recent entries + related memories
+    MS-->>Cog: transcript window + memory state
+    Cog->>LLM: extract candidate facts/preferences/skills
+    LLM-->>Cog: candidate memory objects
+    Cog->>Cog: dedupe, merge, score, attach provenance
+    Cog->>MS: upsert/archive derived memories
+    MS-->>Cog: versions and ids
+```
+
+This is the critical interaction between the two layers:
+
+- the substrate emits durable events and serves raw state
+- cognition interprets and consolidates
+- the substrate stores the resulting memory products under the same governance model
+
+## Runtime Context Injection
+
+Extraction is not enough. The cognition layer also needs to decide what the agent should see at inference time.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent as Agent App
+    participant MS as Memory Service Substrate
+    participant LLM as Model
+
+    User->>Agent: new turn
+    Agent->>MS: search cognition memory namespaces
+    MS-->>Agent: durable memories + short-lived working notes
+    Agent->>MS: load recent transcript/context as needed
+    MS-->>Agent: raw history + context entries
+    Agent->>Agent: assemble application-specific prompt
+    Agent->>LLM: prompt + selected memory
+    LLM-->>Agent: response
+    Agent->>MS: append assistant response
+```
+
+This keeps cognition outputs in the governed memory substrate without forcing the substrate to own application-specific prompt assembly.
+
+The memory retrieval step may return:
+
+- a compact set of facts and preferences
+- one or more relevant skills or procedures
+- short-lived bridge, topic, or summary notes
+- provenance fields so the agent can inspect why each item exists
+
+## Pluggability and Benchmarking
+
+We should assume there will be multiple cognition strategies, not one.
+
+Examples:
+
+- LLM-first extraction and summarization
+- clustering-first deterministic structuring plus light LLM labeling
+- rules plus embeddings plus targeted LLM conflict resolution
+- graph-backed entity memory with symbolic consolidation
+
+The system should support running these in parallel against the same substrate.
+
+### Recommended benchmark model
+
+- Feed each runtime the same event stream or replay window.
+- Isolate outputs by runtime identity, namespace, or another explicit partition key.
+- Measure extraction latency, token cost, memory churn, retrieval hit rate, and quality against evaluation tasks.
+- Allow one runtime to be active for production context injection while others run in shadow mode.
+
+Using the substrate as the shared source of truth makes this practical. Each runtime sees the same raw evidence and can be evaluated on both quality and cost.
+
+## Deployment Models
+
+### External process
+
+This should be the default.
+
+Benefits:
+
+- strongest isolation from substrate failures
+- independent scaling
+- polyglot implementations
+- easier A/B and shadow benchmarking
+- easier experimentation with different model providers and prompt stacks
+
+### Embedded runtime
+
+This should remain an option, not the default.
+
+Benefits:
+
+- lower latency for small deployments
+- simpler local development
+- fewer moving pieces for single-binary installs
+
+Tradeoff:
+
+- tighter coupling between substrate release cadence and cognition experiments
+
+## Data Ownership and Provenance
+
+The cognition layer will only be trustworthy if every derived memory can be explained.
+
+At minimum, derived memories should carry:
+
+- source conversation ids
+- source entry ids or source memory ids
+- runtime identifier
+- extraction or consolidation timestamp
+- confidence or freshness metadata
+
+That metadata is necessary for:
+
+- debugging incorrect memories
+- re-running or replacing a cognition runtime
+- supporting archive and supersede semantics
+- comparing multiple runtimes fairly
+
+## Likely Substrate Enhancements
+
+The current substrate is already close to what cognition needs, but this architecture will likely benefit from additional first-class support.
+
+Likely enhancements include:
+
+- batch read and batch write APIs so cognition workers do not need many small round trips
+- bulk upsert, archive, and supersede operations for derived memories
+- compare-and-set or version-aware writes to avoid consolidation races
+- richer query filters on derived memories, including type, confidence, freshness, provenance, and runtime id
+- graph-style access patterns for entity relationships, citations, and memory-to-memory links
+- first-class provenance fields instead of encoding source references only inside opaque payloads
+- multi-prefix and richer filtered memory search so runtimes can expose cognition outputs through `/v1/memories`
+
+Event replay and cursoring are especially important. A cognition runtime must be able to stop, resume, rebuild, and backfill without losing correctness.
+
+## Relationship to Existing Enhancement Work
+
+This document is the top-level architecture for cognition. Existing enhancement work can fit underneath it.
+
+- [Adaptive Knowledge Clustering](enhancements/090-adaptive-knowledge-clustering.md) is one example of a cognition-stage implementation for organizing memory without LLM-heavy extraction.
+- [Skill Extraction](enhancements/partial/091-skill-extraction.md) is one example of a cognition-stage implementation that turns verified procedural memories into reusable user-facing skills.
+- [Quarkus + LangChain4j Cognition Processor](enhancements/097-quarkus-cognition-processor.md) is the concrete reference strategy for building a high-quality extraction, verification, consolidation, and memory-retrieval runtime on top of the substrate.
+
+Those enhancements describe specific cognition capabilities. This document defines the layer they belong to.
+
+## Recommended Direction
+
+The near-term architecture should be:
+
+1. Keep memory-service focused on substrate responsibilities.
+2. Introduce a pluggable cognition runtime contract over events plus read/write APIs.
+3. Start with an external cognition process so multiple implementations can be benchmarked safely.
+4. Add substrate enhancements only where cognition proves the current primitives are too chatty or too weak.
+
+That gives us a clean split:
+
+- V1 memory-service: memory infrastructure
+- V2 memory-service ecosystem: memory cognition on top of that infrastructure


### PR DESCRIPTION
## Summary
Add the cognition architecture and Quarkus processor proposal docs, and split the generic memory-search API work into a separate enhancement. Also mark the embedded MCP server enhancement as implemented and resequence the affected enhancement docs.

## Changes
- Add the Quarkus + LangChain4j cognition processor proposal and memory cognition overview updates
- Add an enhanced episodic memory search proposal for filter operators, ordering, and cursor pagination
- Move embedded MCP server enhancement to implemented status and resequence enhancement numbers
