### PR TITLE
docs(enhancements): define cognition grpc parity

### DIFF
--- a/docs/enhancements/099-quarkus-cognition-processor.md
+++ b/docs/enhancements/099-quarkus-cognition-processor.md
@@ -8,7 +8,7 @@ status: proposed
 
 ## Summary
 
-Build a reference cognition processor as a standalone Quarkus application that uses LangChain4j as its model abstraction. The processor consumes substrate events from the existing Memory Service admin SSE stream, builds bounded evidence packs, runs LangChain4j-backed structured extraction and verification, and writes durable derived memories plus short-lived retrieval/cache state back through the public episodic memory APIs. Agent applications retrieve cognition output through enhanced `/v1/memories` search.
+Build a reference cognition processor as a standalone Quarkus application that uses LangChain4j as its model abstraction. The processor consumes substrate events from Memory Service over gRPC, builds bounded evidence packs, runs LangChain4j-backed structured extraction and verification, and writes durable derived memories plus short-lived retrieval/cache state back through gRPC episodic memory APIs. Agent applications retrieve cognition output through enhanced memory search.
 
 ## Motivation
 
@@ -16,10 +16,10 @@ Build a reference cognition processor as a standalone Quarkus application that u
 
 Today the JVM ecosystem already has the building blocks for a high-quality cognition runtime:
 
-- the Memory Service publishes a replayable admin event feed (`/v1/admin/events`) plus admin and public episodic-memory APIs
-- generated OpenAPI clients and gRPC stubs exist for those APIs in `java/memory-service-contracts` and `java/quarkus/memory-service-proto-quarkus`
+- the Memory Service has gRPC conversation, entry, event, search, and episodic-memory services, with the remaining gRPC parity work tracked by [101](101-grpc-api-parity-for-cognition.md)
+- generated gRPC stubs exist in `java/quarkus/memory-service-proto-quarkus`
 - `io.quarkiverse.langchain4j:quarkus-langchain4j-openai` (already used by `java/quarkus/examples/chat-quarkus`) gives us declarative `@RegisterAiService` interfaces, structured JSON output, prompt caching, and a pluggable model layer
-- Quarkus provides the operational primitives we need (scheduler, REST clients, virtual threads, dev services, health, metrics)
+- Quarkus provides the operational primitives we need (scheduler, gRPC clients, virtual threads, dev services, health, metrics)
 
 What is missing is a concrete cognition processor implementation that turns substrate events into durable derived memories and retrieval-ready working notes with replayable provenance. The failure mode to avoid is a naive "run one prompt after every append and save the answer" design, which produces low-precision memory because it:
 
@@ -35,14 +35,14 @@ A high-quality cognition processor must optimize for precision first, then recal
 
 ### Recommendation
 
-Build the reference processor as a **standalone Quarkus application** (`java/quarkus/cognition-processor-quarkus`) that talks to the Memory Service entirely through its public/admin HTTP and SSE APIs. The same pipeline runs in two operational modes:
+Build the reference processor as a **standalone Quarkus application** (`java/quarkus/cognition-processor-quarkus`) that talks to the Memory Service entirely through gRPC APIs. The same pipeline runs in two operational modes:
 
-- **Worker mode** (default): subscribes to `/v1/admin/events`, persists a replay cursor, processes coalesced scope jobs, and writes derived memories through `/v1/memories`.
-- **Replay/shadow mode**: reprocesses an event window or runs extraction/scoring without affecting production cognition memories.
+- **Worker mode** (default): subscribes to the gRPC event stream, persists a replay cursor through gRPC checkpoints, processes coalesced scope jobs, and writes derived memories through gRPC memory APIs.
+- **Replay mode**: rebuilds memory state from a stored cursor or a selected event/time window.
 
-Durable facts, preferences, procedures, decisions, rolling summaries, bridge notes, topic notes, and any cached retrieval candidates are all stored as memory items under fixed cognition namespaces. Agent applications fetch the next-turn memory material with `/v1/memories/search`, using the substrate-level retrieval improvements defined by [100](100-enhanced-memory-search.md). This keeps cognition responsible for producing better memory, while the Memory Service remains the single retrieval API for memory products.
+Durable facts, preferences, procedures, decisions, rolling summaries, bridge notes, topic notes, and any cached retrieval candidates are all stored as memory items under fixed cognition namespaces. Agent applications fetch the next-turn memory material with enhanced memory search, using the substrate-level retrieval improvements defined by [100](100-enhanced-memory-search.md). This keeps cognition responsible for producing better memory, while the Memory Service remains the single retrieval API for memory products.
 
-The standalone worker authenticates as a dedicated **service principal** (admin API key `cognition-processor`) and writes cognition memories through the public episodic memory API on behalf of conversation owners. The built-in episodic memory policy only allows `["user", <subject>, ...]` access for the authenticated subject, so deploying this processor requires a custom episodic-memory policy that allows the cognition service principal to write under the configured cognition namespaces. That policy is a Phase 1 prerequisite, not optional later hardening.
+The standalone worker authenticates as a dedicated **service principal** (for example `cognition-processor`) and writes cognition memories through gRPC memory APIs on behalf of conversation owners. The built-in episodic memory policy only allows `["user", <subject>, ...]` access for the authenticated subject, so deploying this processor requires the service-principal and on-behalf-of gRPC policy work from [101](101-grpc-api-parity-for-cognition.md). That policy is a Phase 1 prerequisite, not optional later hardening.
 
 ### Processor Contract
 
@@ -74,8 +74,7 @@ java/quarkus/
       consolidator/                        # Idempotent merge / supersede / archive
       retrieval/                           # Search payload shaping and retrieval metadata
       cache/                               # Cognition cache namespace helpers
-      remote/                              # Admin SSE client + episodic memory client
-      admin/                               # /admin/v1/cognition/* admin endpoints
+      remote/                              # gRPC event, checkpoint, conversation, entry, and memory clients
       config/                              # @ConfigMapping types
     src/main/resources/
       application.properties
@@ -84,8 +83,7 @@ java/quarkus/
 
 The processor depends on the existing modules:
 
-- `java/memory-service-contracts` — generated OpenAPI client stubs and DTOs
-- `java/quarkus/memory-service-proto-quarkus` — generated gRPC stubs (used only when an admin gRPC stream is preferred over SSE)
+- `java/quarkus/memory-service-proto-quarkus` — generated gRPC stubs
 
 LangChain4j is wired via `io.quarkiverse.langchain4j:quarkus-langchain4j-openai`. The actual provider is pluggable: switching to Anthropic or Gemini is a configuration change once their Quarkus extensions are added as optional dependencies.
 
@@ -100,16 +98,16 @@ Triggers:
 - manual rebuild requests for a user, conversation group, or namespace
 - optional periodic sweeps for user-owned episodic memory namespaces that should invalidate cognition state
 
-Phase 1 does not depend on episodic memory lifecycle events as a primary trigger source. The replayable admin event stream covers conversation, entry, response, and membership events but not `/v1/memories/events`. The processor therefore treats same-user episodic memories as pull-time evidence during a scope job, and uses manual rebuilds or periodic sweeps when user-authored memory changes must force reprocessing.
+Phase 1 does not depend on episodic memory lifecycle events as a primary trigger source. The replayable gRPC admin event stream defined by [101](101-grpc-api-parity-for-cognition.md) covers conversation, entry, response, and membership events but not memory-lifecycle events. The processor therefore treats same-user episodic memories as pull-time evidence during a scope job, and uses manual rebuilds or periodic sweeps when user-authored memory changes must force reprocessing.
 
 Implementation details:
 
-- A `ReactiveAdminEventClient` consumes `/v1/admin/events` using JAX-RS SSE (`SseEventSource`) with exponential backoff and resume-from-cursor semantics.
-- The processor must use the admin checkpoint APIs to persist its event progress. On startup it calls `GET /v1/admin/checkpoints/{workerId}` and, when a checkpoint exists, subscribes to `/v1/admin/events?after=<lastEventCursor>` so restart catch-up begins near the last processed event instead of replaying the full retained window. A missing checkpoint means first run; subscribe from the configured bootstrap position.
-- After events are accepted into the coalesced scope-job queue, the processor writes a checkpoint with `PUT /v1/admin/checkpoints/{workerId}`. The checkpoint value includes at least `lastEventCursor`, `updatedAt`, `runtimeId`, `runtimeVersion`, and the highest event timestamp observed. `{workerId}` is supplied by `cognition.worker.id` and identifies one logical processor instance, not one container replica.
+- A `GrpcAdminEventClient` consumes `EventStreamService.SubscribeEvents` with admin scope, exponential backoff, and resume-from-cursor semantics.
+- The processor must use gRPC checkpoint APIs from [101](101-grpc-api-parity-for-cognition.md) to persist its event progress. On startup it calls `AdminCheckpointService.GetCheckpoint` and, when a checkpoint exists, subscribes with `after_cursor=<lastEventCursor>` so restart catch-up begins near the last processed event instead of replaying the full retained window. A missing checkpoint means first run; subscribe from the configured bootstrap position.
+- After events are accepted into the coalesced scope-job queue, the processor writes a checkpoint with `AdminCheckpointService.PutCheckpoint`. The checkpoint value includes at least `lastEventCursor`, `updatedAt`, `runtimeId`, `runtimeVersion`, and the highest event timestamp observed. `{workerId}` is supplied by `cognition.worker.id` and identifies one logical processor instance, not one container replica.
 - Checkpoint writes may be batched on a configurable cadence, but shutdown and idle transitions should flush the latest accepted cursor. The processor must not advance the checkpoint past an event that has not been reduced into a durable or retryable job, or restart could skip work.
 - Incoming events are reduced to `ScopeJob` records keyed by conversation ID and pushed onto a singleton task queue (`Map<UUID, ScopeJob>` guarded by a serializable `Mutiny` workflow). Duplicate events for the same conversation while a job is pending coalesce into the existing job.
-- Scope jobs are dispatched on virtual threads (`@RunOnVirtualThread`) so blocking REST calls do not consume reactive event-loop capacity.
+- Scope jobs are dispatched on virtual threads (`@RunOnVirtualThread`) so blocking gRPC calls do not consume reactive event-loop capacity.
 - `@Scheduled` triggers run optional periodic sweeps and rebuild requests.
 
 ### Evidence Pack Builder
@@ -118,18 +116,27 @@ Before any LLM call, the processor builds a bounded evidence pack. This is the c
 
 Evidence packs include:
 
-- a recent transcript window for the impacted conversation, loaded through `/v1/conversations/{id}/entries`
+- a stable, periodically compacted conversation evidence base when one exists
+- a small recent transcript delta for the impacted conversation, loaded through `EntriesService.ListEntries`
 - the latest per-conversation `context` checkpoint if present
-- relevant episodic memories under the same user scope, queried through `/v1/memories`
+- relevant episodic memories under the same user scope, queried through gRPC memory search
 - related derived memories already written by this runtime
 - optional knowledge-cluster signals from [090](090-adaptive-knowledge-clustering.md) when clustering is enabled
+
+Evidence packs are not just the last user prompt and not the full raw conversation history. The processor uses a three-layer prompt shape:
+
+1. **Stable stage prefix** — extractor/verifier instructions, JSON schema, output rules, and safety constraints.
+2. **Stable conversation evidence base** — a periodically compacted, cited summary of the conversation state that changes only when the transcript delta crosses configurable size or age thresholds.
+3. **Dynamic evidence delta** — the newest entries since the compacted base, retrieved memories, related cognition memories, and any per-job scoring hints.
+
+This preserves multi-turn evidence while keeping most repeated conversation context in a cache-friendly prefix. The dynamic delta should stay small enough that normal event-driven jobs do not resend the full conversation.
 
 Evidence packs are aggressively bounded:
 
 - deduplicate repeated content
 - drop low-signal assistant boilerplate
 - keep only cited tool outputs or excerpts, not full logs
-- cap transcript size before extraction
+- cap the compacted evidence base and recent transcript delta before extraction
 - include stable identifiers for every source item
 
 Before any heuristic stage, the bounded evidence text is normalized into prose:
@@ -138,26 +145,38 @@ Before any heuristic stage, the bounded evidence text is normalized into prose:
 - keep natural-language lines that mention commands as part of prose
 - avoid extracting durable memory directly from shell transcripts, stack traces, or source blocks unless a later model-assisted stage explicitly cites them
 
-Evidence pack assembly is exposed as a registry of CDI-managed `@ApplicationScoped` `EvidenceLoader` beans so additional sources can be plugged in without changing the runtime. The registry supports a `cognition.profile` selector so shadow/benchmark runs can swap loaders side by side.
+Evidence pack assembly is exposed as a registry of CDI-managed `@ApplicationScoped` `EvidenceLoader` beans so additional sources can be plugged in without changing the runtime. The registry supports a `cognition.profile` selector so replay and benchmark runs can swap loaders side by side.
 
-#### Evidence packs are ephemeral
+#### Compacted evidence bases
 
-Evidence packs themselves are **not persisted**. They are rebuilt from the substrate on every scope job and held only in memory while the extractor and verifier run. Persisting raw evidence would duplicate encrypted user data into a second store and add a new lifecycle to govern.
+Full evidence packs are rebuilt from the substrate on every scope job and held only in memory while the extractor and verifier run. The exception is the **compacted conversation evidence base**, a TTL-backed cognition cache entry that stores a concise, cited, normalized view of older conversation evidence so repeated extraction calls can reuse a stable prefix.
+
+The compacted evidence base is stored under `evidence-base:<conversation-id>` in the cognition cache namespace. It is not a raw transcript dump. It contains concise natural-language claims, source identifiers, token counts, and compaction metadata. It must omit fenced source blocks, full tool logs, provider prompts, and provider request/response payloads.
+
+The evidence base is refreshed when any of these conditions hold:
+
+- the uncached transcript delta exceeds `cognition.evidence.delta.max-entries` or `cognition.evidence.delta.max-tokens`
+- the evidence base is older than `cognition.evidence.compaction.max-age`
+- a replay or manual rebuild explicitly requests recompaction
+- relevant source entries or memories have been archived or materially updated
+
+After compaction, subsequent extractor/verifier calls include the stable stage prefix, the compacted evidence base, and only the small delta since the base cursor. This is intentionally cache-friendly for providers that support prompt-prefix caching, while still allowing correctness to depend on source citations rather than opaque cached content.
 
 What is persisted is the minimum needed to make extraction replayable and auditable:
 
 - a **`provenance.source_hash`** computed over the canonicalized evidence pack — written onto every durable cognition memory so consolidation can no-op on replay when the same evidence produces the same candidate
 - **citation identifiers** — `provenance.conversation_ids`, `provenance.entry_ids`, and `provenance.memory_ids` on every durable cognition memory, pointing back at the substrate rows the candidate was supported by
 - **runtime attribution** — `runtime.id` and `runtime.version` so a given memory can be traced to the processor build that produced it
+- **compaction attribution** — `provenance.evidence_base_id` and `provenance.evidence_base_hash` when a candidate used a compacted evidence base
 
-This is sufficient for replay (recompute the pack, hash, compare) and for audit (follow citations back to the substrate). It deliberately leaves out the raw assembled prose, the prose-normalization decisions, and the per-stage prompt that the model actually saw.
+This is sufficient for replay (recompute the pack, hash, compare) and for audit (follow citations back to the substrate). It deliberately leaves out raw full transcripts, the prose-normalization decisions, and the per-stage prompt that the model actually saw.
 
 If a deployment needs deeper post-hoc inspection, two opt-in extensions are available without changing the durable storage shape:
 
 - **debug evidence dumps** — gated by `cognition.debug.persist-evidence=true`, the runtime can write the assembled pack to the cognition cache namespace under `evidence:<conversation-id>:<source-hash>` with a short TTL. This is intended for troubleshooting bad extractions, not steady-state operation.
 - **evidence manifests** — an optional compact manifest (ordered source IDs, per-source token counts, normalization flags) embedded in `provenance` alongside `source_hash`. Small, replayable, and free of raw content.
 
-Both are explicit non-defaults so steady-state runs do not accumulate redundant copies of substrate data.
+Both are explicit non-defaults so steady-state runs do not accumulate raw redundant copies of substrate data.
 
 ### Model-Backed Extraction Pipeline
 
@@ -196,19 +215,19 @@ public interface TopicSummaryExtractor {
 }
 ```
 
-Prompt layout is token-aware:
+Prompt layout is token-aware and cache-friendly:
 
-- one batched durable-extraction prompt with a stable system prefix and shared evidence catalog
-- one batched durable-verification prompt with a stable system prefix and shared evidence catalog
+- one batched durable-extraction prompt with a stable system prefix, the stable compacted evidence base, then the small dynamic evidence delta
+- one batched durable-verification prompt with a stable system prefix, the same compacted evidence base, then candidates plus cited dynamic evidence
 - one separate `topic_summary` prompt because its output contract is different and its prompt prefix is stable on its own
 
-Each AiService can specify a stable per-stage cache identifier so provider adapters can opt in to native prompt-prefix caching:
+Each AiService can specify a stable per-stage and per-conversation evidence-base cache identifier so provider adapters can opt in to native prompt-prefix caching:
 
 - OpenAI prompt cache keys via `quarkus.langchain4j.openai.chat-model.user` plus `prompt-cache-key`
 - Anthropic cache breakpoints on static system blocks
 - Gemini cached system-instruction content
 
-> **Caching is opt-in and must be evaluated, not assumed.** Provider prompt caching only pays off when the static prefix is large relative to the dynamic evidence and when the same prefix is hit frequently enough to amortize the cache write cost. For this processor the dynamic part of every call is the evidence pack, which changes per scope job, and the durable extractor/verifier prompts are large but not extreme. Some providers also charge a write surcharge on cache misses, which can make caching net-negative under low hit rates.
+> **Caching is opt-in and must be evaluated, not assumed.** Provider prompt caching pays off when the stable stage prefix plus compacted evidence base is reused across enough extraction, verification, and topic-summary calls to amortize cache write cost. The processor therefore makes repeated conversation evidence cache-friendly by design, but keeps provider caching disabled by default until measured.
 >
 > The benchmark harness should record per-stage cache hit rate, cached vs. uncached token cost, and end-to-end latency so we can decide per stage and per provider whether caching is on. Default the `cognition.langchain4j.<stage>.prompt-cache.enabled` flags to `false` until the data shows a stage benefits.
 
@@ -221,7 +240,7 @@ Not all retrieval aids should become durable user memories. The processor suppor
 - **bridge notes** — explicit current-focus, goal, concern, and relevant background phrases extracted from user turns via lightweight heuristics; conversation-scoped; TTL-backed
 - **topic notes** — short TTL-backed retrieval aids built from stronger bridge/procedure-style cues and recent topical phrases
 
-Both live in the cognition cache namespace and are indexed for `/v1/memories/search` so query vocabulary can match short-lived working context.
+Both live in the cognition cache namespace and are indexed for memory search so query vocabulary can match short-lived working context.
 
 ### Memory Types
 
@@ -244,7 +263,7 @@ Graph memories, relationship graphs, and broad autonomous world models are expli
 
 The processor reuses the existing substrate instead of creating a separate derived-memory datastore.
 
-#### Durable outputs: `/v1/memories`
+#### Durable outputs: memory APIs
 
 Derived durable memories are stored under fixed user-owned namespaces so existing governance, namespace-depth limits, archive semantics, and vector indexing still apply:
 
@@ -299,7 +318,7 @@ This gives us encrypted durable values, existing namespace scoping and archive s
 
 #### Short-lived outputs: TTL-backed cognition cache
 
-Short-lived cognition cache entries hold rolling conversation summaries, retrieval hints, and per-conversation working notes that have not been promoted to durable memory (including cache-only bridge notes).
+Short-lived cognition cache entries hold compacted evidence bases, rolling conversation summaries, retrieval hints, and per-conversation working notes that have not been promoted to durable memory (including cache-only bridge notes).
 
 API-compatible cache namespace shape:
 
@@ -307,7 +326,7 @@ API-compatible cache namespace shape:
 ["user", <sub>, "cognition.v1", "cache"]
 ```
 
-Key prefixes are `summary:<conversation-id>`, `bridge:<conversation-id>`, `topic:<conversation-id>`, and `candidate:<conversation-id>`. The shared `["user", <sub>, "cognition.v1"]` prefix lets agents retrieve all cognition output with one `/v1/memories/search` request while keeping each memory kind in a distinct child namespace. The four-segment layout stays within the default `EpisodicMaxDepth=5`.
+Key prefixes are `evidence-base:<conversation-id>`, `summary:<conversation-id>`, `bridge:<conversation-id>`, `topic:<conversation-id>`, and `candidate:<conversation-id>`. The shared `["user", <sub>, "cognition.v1"]` prefix lets agents retrieve all cognition output with one memory search request while keeping each memory kind in a distinct child namespace. The four-segment layout stays within the default `EpisodicMaxDepth=5`.
 
 External Quarkus workers cannot generically write conversation `context` through today's agent APIs, because context reads/writes are authorized by the conversation's stored `clientId` and the service does not support admin impersonation. The Quarkus processor therefore does not mirror summaries into `context`.
 
@@ -317,6 +336,7 @@ The consolidator is idempotent and replay-safe:
 
 - each promoted memory gets a stable natural key derived from type, scope, and normalized subject/facet
 - each write carries a `source_hash` over the evidence pack so replays can no-op
+- memories derived from compacted evidence also carry the compacted evidence base ID/hash so later recompaction can explain changed outputs
 - contradictory memories archive or supersede prior rows instead of coexisting indefinitely
 - confidence and freshness update in place by rewriting the active memory row for the same natural key
 - low-confidence candidates never become durable memories; they may remain only as short-lived retrieval candidates
@@ -335,10 +355,9 @@ This avoids polluting one app/agent's memory with assumptions learned from anoth
 
 ### Quality Controls
 
-The runtime supports three operating modes:
+The runtime supports two operating modes:
 
 - **active** — writes durable and short-lived cognition memories
-- **shadow** — runs extraction and scoring but does not affect production cognition memories
 - **replay** — rebuilds memory state from a stored cursor or a time window
 
 Each candidate and each retrieval-ready memory exposes:
@@ -356,6 +375,7 @@ Quality is measured explicitly before broad rollout. A replay harness feeds the 
 - duplicate churn rate
 - retrieval hit rate on evaluation prompts
 - token cost
+- prompt-cache hit rate and cached-token cost when a provider reports them
 - latency per scope job
 
 The harness is exposed as a Quarkus CLI subcommand (`mvn quarkus:dev` plus `-Dcognition.benchmark.scenario=...`, or a packaged uber-jar entry point) so scenarios can be run against a local memory-service instance using dev services.
@@ -364,26 +384,14 @@ The current [090](090-adaptive-knowledge-clustering.md) implementation is treate
 
 ### API Surface
 
-The public surface is intentionally small at first.
+The processor surface is intentionally small at first.
 
-- no new user-facing CRUD API for cognition memories
-- inspect durable outputs through existing `/v1/memories` APIs under cognition namespaces
-- retrieve cognition-produced memories through the enhanced `/v1/memories/search` contract defined by [100](100-enhanced-memory-search.md)
-- admin/debug endpoints for runtime status and rebuilds at `/admin/v1/cognition/status`, `/admin/v1/cognition/rebuild`, and `/admin/v1/cognition/conversations/{conversationId}/retrieval`
+- no new Memory Service cognition-specific API
+- inspect durable outputs through existing memory APIs under cognition namespaces
+- retrieve cognition-produced memories through the enhanced memory search contract defined by [100](100-enhanced-memory-search.md)
+- operational status, rebuild triggers, and retrieval-debug output remain local Quarkus processor concerns, not Memory Service substrate APIs
 
 The search request/response shape, filter language, cursor semantics, and safe retrieval attributes are owned by [100](100-enhanced-memory-search.md). This processor writes memory values compatible with that generic retrieval API.
-
-#### Admin Debug Endpoints
-
-The admin endpoints are implementation/debug surfaces only:
-
-| Endpoint | Purpose |
-| --- | --- |
-| `GET /admin/v1/cognition/status` | Return runtime ID/version, mode, profile, last processed event cursor, queue depth, last successful job time, and error counts. |
-| `POST /admin/v1/cognition/rebuild` | Enqueue rebuild jobs for a `conversationId`, `userId`, namespace prefix, or cursor/time range. Returns accepted job IDs. |
-| `GET /admin/v1/cognition/conversations/{conversationId}/retrieval` | Return the exact `/v1/memories/search` request the processor expects an agent app to use for that conversation, plus debug-only scoring details. |
-
-The retrieval debug endpoint must not return raw evidence packs unless `cognition.debug.persist-evidence=true` and the caller is admin.
 
 ### Configuration
 
@@ -393,16 +401,18 @@ All configuration is exposed via Quarkus `@ConfigMapping` types under the `cogni
 # Identity / connectivity
 cognition.worker.id=cognition-worker-1
 cognition.runtime.id=quarkus-reference-v1
-cognition.memory-service.base-url=http://memory-service:8082
+cognition.memory-service.grpc-target=memory-service:9090
 cognition.memory-service.api-key=${COGNITION_API_KEY}
 
 # Operating mode
-cognition.mode=active                       # active | shadow | replay
+cognition.mode=active                       # active | replay
 cognition.profile=default                   # selects evidence/extractor/verifier registry filters
 
 # Pipeline shape
-cognition.evidence.transcript.max-entries=40
-cognition.evidence.transcript.max-tokens=4000
+cognition.evidence.base.max-tokens=6000
+cognition.evidence.compaction.max-age=PT2H
+cognition.evidence.delta.max-entries=12
+cognition.evidence.delta.max-tokens=1500
 cognition.evidence.episodic.max-memories=20
 cognition.consolidation.max-revision-retries=3
 
@@ -411,6 +421,7 @@ cognition.debug.persist-evidence=false
 cognition.debug.persist-evidence.ttl=PT1H
 
 # Cache TTLs
+cognition.cache.evidence-base.ttl=PT24H
 cognition.cache.summary.ttl=PT2H
 cognition.cache.candidate.ttl=PT15M
 cognition.cache.bridge.ttl=PT45M
@@ -423,15 +434,15 @@ quarkus.langchain4j.openai.topic-summary.api-key=${OPENAI_API_KEY}
 quarkus.langchain4j.openai.topic-summary.chat-model.model-name=gpt-4o-mini
 ```
 
-Worker mode is the default. Replay/shadow processing is enabled by mode; the user-facing retrieval path remains `/v1/memories/search`.
+Worker mode is the default. Replay processing is enabled by mode; the user-facing retrieval path remains memory search.
 
 ### Compose Integration
 
 The repo `compose.yaml` already runs a separate cognition processor service against the main `memory-service` container. The Quarkus processor publishes a Docker image (`Dockerfile` in the new module) and replaces the existing entry by:
 
-- consuming `/v1/admin/events` from the main `memory-service` container with the dedicated admin API key/client ID `cognition-processor`
+- consuming the gRPC admin event stream from the main `memory-service` container with the dedicated service principal `cognition-processor`
 - using `COGNITION_WORKER_ID` for checkpoint identity
-- writing cognition memories back through the public episodic memory APIs
+- writing cognition memories back through gRPC memory APIs
 
 The compose service depends on `memory-service` plus its vector backend (`qdrant`/`pgvector`) and uses TCP-based readiness probes that match the dev images already in use.
 
@@ -439,17 +450,17 @@ The compose service depends on `memory-service` plus its vector backend (`qdrant
 
 ### Standalone Quarkus Application, Not an Embedded Extension
 
-`docs/memory-cognition.md` is directionally clear: cognition should evolve faster than the substrate. Shipping the processor as a separate Quarkus application keeps that separation strict, makes shadow benchmarking trivial, and avoids forcing memory-service deployments to take cognition release cadence.
+`docs/memory-cognition.md` is directionally clear: cognition should evolve faster than the substrate. Shipping the processor as a separate Quarkus application keeps that separation strict, makes replay benchmarking straightforward, and avoids forcing memory-service deployments to take cognition release cadence.
 
 ### LangChain4j as the Model Layer
 
 LangChain4j gives us declarative AiService interfaces, structured output, prompt caching, and a pluggable provider model that already aligns with how `chat-quarkus` integrates models. Reusing it avoids building a second model abstraction inside this repo and keeps the cognition stack consistent with the demo agent.
 
-### Reuse `/v1/memories` Instead of a New Derived Store
+### Reuse Memory APIs Instead of a New Derived Store
 
 This keeps governance, indexing, archive semantics, and encryption aligned with the rest of the system. Adding substrate extensions is deferred until the current memory primitives prove too weak.
 
-### Reuse Enhanced `/v1/memories/search`
+### Reuse Enhanced Memory Search
 
 The proposed cognition outputs are already stored as memory items. This processor depends on [100](100-enhanced-memory-search.md) so cognition-produced facts, preferences, procedures, summaries, bridge notes, and topic notes can be retrieved through the same governed surface as any other memory.
 
@@ -461,7 +472,7 @@ The extractor alone should never be trusted to create durable memory. Requiring 
 
 ### Use Existing Replay Surfaces in Phase 1
 
-The existing replayable admin SSE stream is sufficient as long as cognition jobs are driven by conversation and entry activity plus manual or periodic rebuilds. A dedicated cognition replay feed should not be added until the current surfaces prove too coarse or until memory-lifecycle-triggered reprocessing becomes a measured bottleneck.
+The gRPC admin event stream from [101](101-grpc-api-parity-for-cognition.md) is sufficient as long as cognition jobs are driven by conversation and entry activity plus manual or periodic rebuilds. A dedicated cognition replay feed should not be added until the generic event stream proves too coarse or until memory-lifecycle-triggered reprocessing becomes a measured bottleneck.
 
 ### Use Fixed Versioned Cognition Namespaces
 
@@ -469,7 +480,7 @@ The default episodic API validates namespaces against `EpisodicMaxDepth=5`. Usin
 
 ### Service Principal With Custom Episodic Policy
 
-The default episodic policy only allows `["user", <subject>, ...]` access for the authenticated subject. The Quarkus processor authenticates as a dedicated `cognition-processor` admin API key/client and ships with a custom episodic-memory policy that allows writes only under the configured cognition namespaces. This is a Phase 1 prerequisite, not optional later hardening.
+The default episodic policy only allows `["user", <subject>, ...]` access for the authenticated subject. The Quarkus processor authenticates as a dedicated `cognition-processor` service principal and uses the on-behalf-of gRPC policy support from [101](101-grpc-api-parity-for-cognition.md) to write only under the configured cognition namespaces. This is a Phase 1 prerequisite, not optional later hardening.
 
 ## Testing
 
@@ -498,9 +509,16 @@ Feature: Quarkus cognition processor
   Scenario: Memory search prefers relevant durable cognition memory over cache notes
     Given durable cognition memories exist for deployment troubleshooting
     And short-lived cognition cache memories exist for "conv-3"
-    When POST /v1/memories/search is called with query "deployment fix" across the cognition namespaces
-    Then the response status should be 200
-    And the response body field "items[0].value.kind" should equal "procedure"
+    When memory search is called with query "deployment fix" across the cognition namespaces
+    Then the response contains at least one item
+    And the first item value field "kind" should equal "procedure"
+
+  Scenario: Compacted evidence base keeps extraction cache-friendly
+    Given conversation "conv-4" has more transcript entries than the configured delta limit
+    And a compacted evidence base exists for "conv-4"
+    When the processor handles one new entry for "conv-4"
+    Then the durable extractor request includes the compacted evidence base before the new-entry delta
+    And the durable extractor request does not include the full raw transcript
 
   Scenario: Cognition writes are scoped to the configured namespaces
     Given the cognition service principal is configured for namespaces under ["user", "*", "cognition.v1"]
@@ -513,9 +531,10 @@ Feature: Quarkus cognition processor
 - `DurableMemoryExtractor` AiService is exercised against a recorded transcript fixture and a stubbed model that returns canned structured output, asserting that all durable kinds round-trip through the candidate schema.
 - `DurableMemoryVerifier` rejects candidates whose cited evidence does not appear in the bounded evidence pack.
 - `EvidencePackBuilder` deduplicates repeated content, drops fenced code blocks during the prose normalization step, and never exceeds the configured token cap.
+- `EvidenceCompactor` creates a cited `evidence-base:<conversation-id>` cache entry, advances the base cursor, and keeps later extraction requests to the configured delta bounds.
 - `Consolidator` merges duplicates by stable natural key, supersedes contradicted memories, and produces no-op writes on identical `source_hash` replays.
 - Cache-only `bridge` and `topic` notes are written under the cognition cache namespace with the configured TTLs and surface in memory search.
-- The admin SSE consumer loads its checkpoint with `GET /v1/admin/checkpoints/{workerId}`, resumes `/v1/admin/events` after the saved `lastEventCursor`, persists progress with `PUT /v1/admin/checkpoints/{workerId}`, coalesces bursts into singleton scope jobs, and does not lose events across reconnect.
+- The gRPC event consumer loads its checkpoint with `AdminCheckpointService.GetCheckpoint`, resumes `EventStreamService.SubscribeEvents` after the saved `lastEventCursor`, persists progress with `AdminCheckpointService.PutCheckpoint`, coalesces bursts into singleton scope jobs, and does not lose events across reconnect.
 - A Quarkus dev-services-backed integration test boots the full stack (memory-service container plus the processor) and verifies an end-to-end extraction-to-search flow against a `TestChatModel` that mimics the LangChain4j contract used in `chat-quarkus`.
 
 ## Tasks
@@ -523,9 +542,10 @@ Feature: Quarkus cognition processor
 - [ ] Create the `java/quarkus/cognition-processor-quarkus` Maven module with parent wiring, packaging, and Dockerfile.
 - [ ] Define the `CognitionProcessor` contract and `ScopeJob` types.
 - [ ] Wire the LangChain4j dependency and add named model configurations for durable extraction, verification, and topic summarization.
-- [ ] Implement the admin SSE consumer with checkpointed replay against `/v1/admin/events` using `GET`/`PUT /v1/admin/checkpoints/{workerId}` for the last accepted event cursor.
+- [ ] Implement the gRPC event consumer with checkpointed replay against `EventStreamService.SubscribeEvents` and `AdminCheckpointService` from [101](101-grpc-api-parity-for-cognition.md).
 - [ ] Implement the singleton-per-conversation scope-job queue running on virtual threads.
 - [ ] Implement the evidence pack builder registry over transcript, `context`, episodic memory, and optional knowledge-cluster sources.
+- [ ] Implement the compacted conversation evidence base with TTL-backed cache storage, source citations, base cursor tracking, and recompaction triggers.
 - [ ] Implement the `DurableMemoryExtractor` AiService with strict structured output for fact, preference, procedure, problem_solution, and decision candidates.
 - [ ] Implement the `DurableMemoryVerifier` AiService with batched citation checking and normalization.
 - [ ] Implement the `TopicSummaryExtractor` AiService and TTL-backed topic-summary cache writes.
@@ -534,11 +554,10 @@ Feature: Quarkus cognition processor
 - [ ] Implement TTL-backed rolling summary and retrieval candidate cache entries.
 - [ ] Use the enhanced memory search contract from [100](100-enhanced-memory-search.md) for retrieval examples and integration tests.
 - [ ] Update the cognition memory policy so cognition memories expose safe filter attributes.
-- [ ] Implement admin status / rebuild / retrieval-debug endpoints.
 - [ ] Add the configurable `cognition.profile` selector for evidence/extractor/verifier registry filtering.
-- [ ] Add the replay/shadow benchmark harness and scenario format.
+- [ ] Add the replay benchmark harness and scenario format.
 - [ ] Add Cucumber-driven BDD coverage that drives the processor against a memory-service container with a stubbed LangChain4j model.
-- [ ] Provide the dedicated `cognition-processor` admin API key and a custom episodic policy that scopes writes to the configured cognition namespaces.
+- [ ] Provide the dedicated `cognition-processor` service principal and a custom episodic policy that scopes on-behalf-of writes to the configured cognition namespaces.
 - [ ] Update `compose.yaml` to run the Quarkus processor image as the cognition service.
 - [ ] Update `docs/memory-cognition.md`'s "Relationship to Existing Enhancement Work" list to point at this enhancement.
 
@@ -548,22 +567,20 @@ Feature: Quarkus cognition processor
 | --- | --- |
 | `docs/enhancements/099-quarkus-cognition-processor.md` | This enhancement doc |
 | `docs/memory-cognition.md` | Add a pointer to this enhancement under "Relationship to Existing Enhancement Work" |
-| `contracts/openapi/openapi-admin.yml` | Add `/admin/v1/cognition/status`, `/admin/v1/cognition/rebuild`, and `/admin/v1/cognition/conversations/{conversationId}/retrieval` |
 | `internal/episodic/policy.go` and configured `attributes.rego` examples | Extract safe cognition attributes from cognition memory values/index payloads |
 | `java/pom.xml` | Register the new Quarkus cognition module in the reactor |
 | `java/quarkus/pom.xml` | Add the cognition processor module to the Quarkus reactor |
 | `java/quarkus/cognition-processor-quarkus/pom.xml` | New module with Quarkus + LangChain4j + memory-service-contracts dependencies |
 | `java/quarkus/cognition-processor-quarkus/Dockerfile` | Container image used by `compose.yaml` |
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../runtime/*.java` | Processor implementation, scope job dispatch, scheduler |
-| `java/quarkus/cognition-processor-quarkus/src/main/java/.../evidence/*.java` | Evidence loader registry plus transcript/context/episodic/cluster loaders |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../evidence/*.java` | Evidence loader registry, compactor, base-cursor tracking, and transcript/context/episodic/cluster loaders |
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../extractor/*.java` | LangChain4j durable extractor and topic-summary AiServices, plus heuristic bridge/topic extractors |
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../verifier/*.java` | LangChain4j verifier AiService and normalization helpers |
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../consolidator/*.java` | Idempotent consolidation, supersede, and natural-key logic |
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../retrieval/*.java` | Search payload shaping and retrieval metadata |
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../cache/*.java` | Cognition cache namespace helpers and TTL writes |
-| `java/quarkus/cognition-processor-quarkus/src/main/java/.../remote/*.java` | Admin SSE client, episodic memory client, conversation/entry loader |
-| `java/quarkus/cognition-processor-quarkus/src/main/java/.../remote/AdminCheckpointClient.java` | Client wrapper for `GET`/`PUT /v1/admin/checkpoints/{workerId}` |
-| `java/quarkus/cognition-processor-quarkus/src/main/java/.../admin/CognitionAdminResource.java` | Admin status/rebuild/retrieval-debug endpoints |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../remote/*.java` | gRPC event, checkpoint, memory, conversation, and entry clients |
+| `java/quarkus/cognition-processor-quarkus/src/main/java/.../remote/AdminCheckpointClient.java` | Client wrapper for gRPC checkpoint operations |
 | `java/quarkus/cognition-processor-quarkus/src/main/java/.../config/CognitionConfig.java` | `@ConfigMapping` types for the `cognition.*` prefix |
 | `java/quarkus/cognition-processor-quarkus/src/main/resources/application.properties` | Default config and named LangChain4j model bindings |
 | `java/quarkus/cognition-processor-quarkus/src/main/resources/prompts/*.md` | Stable system/user prompt templates loaded by AiServices |
@@ -596,15 +613,16 @@ docker compose up cognition-processor
 - exposing raw cluster centroids or embedding-derived internals to non-admin callers
 - promoting low-confidence or uncited candidate memories just to improve recall numbers
 - sharing process space with the memory-service Go server
+- adding cognition-specific status, rebuild, or retrieval-debug APIs to Memory Service
 
 ## Security Considerations
 
 - derived memories must remain under the same effective user scope as their evidence
 - durable writes must preserve provenance so incorrect memories can be audited and rebuilt
-- the Quarkus processor requires a dedicated `cognition-processor` admin API key and a tightly-scoped episodic-memory policy that only allows writes under the configured cognition namespaces; the built-in default policy is not sufficient
+- the Quarkus processor requires a dedicated `cognition-processor` service principal and a tightly-scoped episodic-memory policy that only allows writes under the configured cognition namespaces; the built-in default policy is not sufficient
 - cognition memory values and extracted attributes must not include internal `clientId` metadata, raw evidence dumps, provider prompts, or provider cache keys
-- admin/debug cognition endpoints must remain admin-only because they expose runtime internals and evidence traces
-- LangChain4j prompt cache identifiers must be derived from stable, non-sensitive inputs so cache keys do not leak per-user evidence into provider logs
+- compacted evidence bases must be concise cited summaries, not raw transcript mirrors, and must use the same effective user scope as their source evidence
+- LangChain4j prompt cache identifiers must be derived from stable, non-sensitive inputs such as runtime ID, stage, conversation ID, and evidence-base hash so cache keys do not leak user evidence into provider logs
 
 ## Deferred Evaluation
 

--- a/docs/enhancements/100-enhanced-memory-search.md
+++ b/docs/enhancements/100-enhanced-memory-search.md
@@ -8,7 +8,7 @@ status: proposed
 
 ## Summary
 
-Enhance `POST /v1/memories/search` so clients can filter by safe policy attributes with a small operator language and page deterministically with opaque cursors. This gives cognition processors and agent applications a governed retrieval surface for durable and TTL-backed memory items under a shared namespace prefix.
+Enhance memory search in both REST and gRPC so clients can filter by safe policy attributes with a small operator language and page deterministically with opaque cursors. This gives cognition processors and agent applications a governed retrieval surface for durable and TTL-backed memory items under a shared namespace prefix.
 
 ## Motivation
 
@@ -21,7 +21,7 @@ The current episodic memory search API is optimized for simple namespace-prefix 
 
 Without these improvements, applications either over-fetch broad search results and filter them client-side, or a separate cognition-specific retrieval API has to wrap memory search. The better substrate boundary is to make `/v1/memories/search` expressive enough for these retrieval patterns while keeping memory data under the existing governance, archive, indexing, and encryption model.
 
-[099](099-quarkus-cognition-processor.md) depends on this substrate enhancement for cognition-memory retrieval, but the API remains generic and is not coupled to that processor.
+[099](099-quarkus-cognition-processor.md) depends on this substrate enhancement for cognition-memory retrieval, and [101](101-grpc-api-parity-for-cognition.md) depends on this document for the memory-search portion of gRPC parity. The API remains generic and is not coupled to either processor.
 
 ## Design
 
@@ -91,7 +91,7 @@ Example response:
 
 ### gRPC Contract
 
-The gRPC `SearchMemoriesRequest` must stay semantically aligned with REST:
+The gRPC `SearchMemoriesRequest` must stay semantically aligned with REST. The same validation, defaults, OPA filter injection, safe attributes, ordering, cursor binding, archive filtering, TTL visibility, and usage metadata behavior apply to both transports:
 
 ```protobuf
 message SearchMemoriesRequest {
@@ -142,7 +142,7 @@ The default and example memory policies should document how cognition deployment
 | Attribute | Source | Purpose |
 | --- | --- | --- |
 | `memoryKind` | `value.kind` | Filter facts, preferences, procedures, decisions, summaries, bridge notes, and topic notes. |
-| `runtimeId` | `value.runtime.id` | Isolate active, shadow, or benchmark processor outputs. |
+| `runtimeId` | `value.runtime.id` | Isolate active, replay, or benchmark processor outputs. |
 | `runtimeVersion` | `value.runtime.version` | Debug and benchmark processor versions. |
 | `confidence` | `value.confidence` | Filter weak or medium-confidence candidates. |
 | `freshness` | `value.freshness` | Exclude stale or contradicted memories from retrieval. |
@@ -164,6 +164,18 @@ The route executes a search under one authorized namespace prefix:
 6. Return up to `limit` rows plus `afterCursor` when more rows are available.
 
 Cursor state should include the request hash and enough ordering keys to resume deterministically under the same effective prefix.
+
+### Archive, TTL, and Usage Parity
+
+Memory search behavior must be identical for REST and gRPC:
+
+- omitted `archived` defaults to `exclude`
+- `archived=exclude|include|only` maps to the same `ArchiveFilter` behavior in both transports
+- TTL-backed memories are searchable before expiry and excluded after expiry
+- TTL-backed memories expose `expires_at` in search results before expiry
+- OPA attributes are extracted from TTL-backed memory values/index payloads the same way as durable memories
+- `include_usage=true` returns usage metadata but does not increment usage counters
+- search never exposes raw encrypted memory values outside the existing response shape or any policy-disallowed internal metadata
 
 ## Design Decisions
 
@@ -213,6 +225,18 @@ Feature: Enhanced episodic memory search
   Scenario: Unsupported filter operators are rejected
     When POST /v1/memories/search filters memoryKind with {"$regex":"proc.*"}
     Then the response status should be 400
+
+  Scenario: gRPC search matches REST archive filtering
+    Given a memory is archived
+    When SearchMemories is called over gRPC with archived ONLY
+    Then the archived memory is returned
+    When SearchMemories is called over gRPC with archived EXCLUDE
+    Then the archived memory is not returned
+
+  Scenario: TTL-backed memories are searchable before expiry
+    Given a memory is written with ttl_seconds 3600 and index text "deployment cache"
+    When SearchMemories is called over REST and gRPC with query "deployment cache"
+    Then both responses include the memory with expires_at set
 ```
 
 ### Unit / Integration Tests
@@ -222,13 +246,14 @@ Feature: Enhanced episodic memory search
 - Search returns deterministic order across repeated calls.
 - OPA filter injection runs for the requested prefix and does not leak inaccessible rows.
 - `include_usage` enriches results without incrementing usage counters.
-- REST and gRPC request/response shapes remain semantically aligned.
+- REST and gRPC request/response shapes remain semantically aligned, including archive filters and TTL-backed memory visibility.
 
 ## Tasks
 
 - [ ] Add memory search filter operators `$eq`, `$ne`, `$in`, `$nin`, `$exists`, `$gte`, and `$lte`.
 - [ ] Add deterministic result ordering and opaque `after_cursor` pagination.
 - [ ] Align gRPC `SearchMemoriesRequest` and `SearchMemoriesResponse` with the REST contract.
+- [ ] Verify REST and gRPC search share archive-filter defaults, TTL visibility, safe attributes, and usage metadata behavior.
 - [ ] Update memory policy docs/examples so cognition memories can expose safe filter attributes.
 - [ ] Regenerate REST and gRPC clients.
 - [ ] Add BDD and store/route tests for authorization, operators, deterministic ordering, and cursor binding.
@@ -259,6 +284,9 @@ task generate:go
 
 # Regenerate Java REST clients after OpenAPI changes
 ./java/mvnw -f java/pom.xml -pl quarkus/memory-service-rest-quarkus -am clean compile
+
+# Compile Java gRPC stubs after protobuf changes
+./java/mvnw -f java/pom.xml -pl quarkus/memory-service-proto-quarkus -am compile
 
 # Build affected Go packages after search changes
 go build ./internal/registry/episodic ./internal/plugin/route/memories ./internal/plugin/store/postgres ./internal/plugin/store/sqlite ./internal/plugin/store/mongo ./internal/cmd/serve

--- a/docs/enhancements/101-grpc-api-parity-for-cognition.md
+++ b/docs/enhancements/101-grpc-api-parity-for-cognition.md
@@ -1,0 +1,289 @@
+---
+status: proposed
+---
+
+# Enhancement 101: gRPC API Parity for Cognition
+
+> **Status**: Proposed.
+
+## Summary
+
+Add the gRPC API parity needed for external cognition processors to use Memory Service without HTTP or SSE dependencies. The gRPC surface must match the behavior of the REST counterparts for event replay, worker checkpoints, archive handling, conditional memory updates, service-principal authorization, and TTL-backed indexed memory writes. Memory-search parity is handled by [100](100-enhanced-memory-search.md).
+
+## Motivation
+
+[099](099-quarkus-cognition-processor.md) should be able to run as a standalone Quarkus worker using only generated gRPC clients. Today the proto has useful conversation, entry, memory, search, and event-stream services, but the full cognition workflow still depends on REST-only or under-specified behavior:
+
+- replayable event consumption exists in REST admin APIs, while `EventStreamService.SubscribeEvents` is documented as membership-scoped
+- admin checkpoints exist only in `contracts/openapi/openapi-admin.yml`
+- [100](100-enhanced-memory-search.md) owns memory-search parity, including gRPC cursor/filter/order behavior
+- cognition consolidation needs revision-aware compare-and-set semantics
+- memory archive filters, TTL writes, indexing, and safe attributes must behave the same through gRPC as through REST
+- a service principal must be able to write scoped cognition memories on behalf of conversation owners without leaking cross-user access
+
+The goal is not to add cognition-specific admin/debug APIs. The goal is to make the generic substrate gRPC APIs complete enough that cognition can stay outside the Go server and still use the same governed behavior as REST clients.
+
+## Design
+
+### Event Stream Admin Parity
+
+`EventStreamService.SubscribeEvents` remains the general event streaming RPC, but it must support an admin/service-principal mode equivalent to REST admin event replay.
+
+```protobuf
+message SubscribeEventsRequest {
+  repeated bytes conversation_ids = 1;
+  repeated string kinds = 2;
+  optional string after_cursor = 3;
+  optional string detail = 4; // "summary" or "full"
+  optional EventScope scope = 5;
+}
+
+enum EventScope {
+  EVENT_SCOPE_UNSPECIFIED = 0; // existing user/member-scoped behavior
+  EVENT_SCOPE_AUTHORIZED = 1;  // user/member-scoped behavior
+  EVENT_SCOPE_ADMIN = 2;       // admin/service-principal event stream
+}
+```
+
+`EVENT_SCOPE_ADMIN` requires admin authorization and returns the same event set, cursor behavior, replay semantics, and archive visibility as REST `/v1/admin/events`. Non-admin callers requesting admin scope receive `403`. `conversation_ids` and `kinds` are filters, not authorization grants.
+
+`EventNotification` should remain cursor-bearing. The cursor must be durable enough for restart catch-up and must match the REST admin event cursor semantics.
+
+### Worker Checkpoints
+
+Add a gRPC checkpoint service equivalent to `GET/PUT /v1/admin/checkpoints/{clientId}`.
+
+```protobuf
+service AdminCheckpointService {
+  rpc GetCheckpoint(GetCheckpointRequest) returns (AdminCheckpoint);
+  rpc PutCheckpoint(PutCheckpointRequest) returns (AdminCheckpoint);
+}
+
+message GetCheckpointRequest {
+  string client_id = 1;
+}
+
+message PutCheckpointRequest {
+  string client_id = 1;
+  google.protobuf.Struct checkpoint = 2;
+}
+
+message AdminCheckpoint {
+  string client_id = 1;
+  google.protobuf.Struct checkpoint = 2;
+  google.protobuf.Timestamp updated_at = 3;
+}
+```
+
+Behavior must match REST:
+
+- checkpoints are encrypted at rest
+- authenticated client ID, when present, must match `client_id`
+- admin role is required unless an existing policy explicitly grants the operation
+- missing checkpoints return gRPC `NOT_FOUND`
+- malformed requests return `INVALID_ARGUMENT`
+
+### Revision-Aware Memory Writes
+
+Expose memory revisions so processors can consolidate idempotently without overwriting concurrent updates.
+
+```protobuf
+message MemoryItem {
+  bytes id = 1;
+  repeated string namespace = 2;
+  string key = 3;
+  google.protobuf.Struct value = 4;
+  optional google.protobuf.Struct attributes = 5;
+  optional double score = 6;
+  string created_at = 7;
+  optional string expires_at = 8;
+  optional MemoryUsage usage = 9;
+  bool archived = 10;
+  int64 revision = 11;
+}
+
+message PutMemoryRequest {
+  repeated string namespace = 1;
+  string key = 2;
+  google.protobuf.Struct value = 3;
+  int32 ttl_seconds = 4;
+  map<string, string> index = 5;
+  optional int64 expected_revision = 6;
+}
+
+message UpdateMemoryRequest {
+  repeated string namespace = 1;
+  string key = 2;
+  optional bool archived = 3;
+  optional int64 expected_revision = 4;
+}
+```
+
+When `expected_revision` is set, the write must only succeed if the active row for `(namespace, key)` has that revision. A mismatch returns gRPC `ABORTED` or `FAILED_PRECONDITION` consistently across datastores. `MemoryWriteResult` should include the resulting revision.
+
+### Archive Semantics
+
+All gRPC memory APIs must match REST archive behavior:
+
+- `ArchiveFilter` values map to REST `exclude|include|only`
+- omitted archive filters default to `exclude`
+- archived memories remain readable with `include` and `only`
+- search archive behavior is defined by [100](100-enhanced-memory-search.md)
+- get and namespace listing apply the same archive filter as REST
+- `UpdateMemory(archived=true)` archives the memory item instead of hard-deleting it
+- TTL expiration and eviction behavior must not be confused with archive state
+
+### Service Principal and On-Behalf-Of Scope
+
+Add explicit gRPC request context for service-principal writes that need to operate under a user-owned namespace. The server still enforces the same episodic-memory policy used by REST.
+
+```protobuf
+message RequestActor {
+  optional string on_behalf_of_user_id = 1;
+}
+```
+
+Memory write, update, get, search, and namespace-list requests may carry `RequestActor` where needed. Search-specific behavior is finalized in [100](100-enhanced-memory-search.md). Normal user callers omit it. Service principals can set it only when policy allows that principal to act for the target user and only within authorized namespace prefixes such as `["user", <sub>, "cognition.v1", ...]`.
+
+This must not expose internal `clientId` metadata in user-facing memory payloads. Admin APIs may still see internal metadata where existing REST admin APIs allow it.
+
+### TTL and Index Parity
+
+`PutMemoryRequest.ttl_seconds` already exists in protobuf, but gRPC behavior must be verified and tested to match REST:
+
+- TTL-backed memories receive `expires_at`
+- expired memories are not returned by get/search/list after expiry
+- TTL-backed memories are indexed before expiry; search visibility is specified in [100](100-enhanced-memory-search.md)
+- OPA attributes are extracted from TTL-backed memory values/index payloads the same way as durable memories
+- search usage behavior is specified in [100](100-enhanced-memory-search.md)
+- direct `GetMemory` increments usage counters exactly as REST direct fetches do
+
+## Design Decisions
+
+### Keep Cognition APIs Out Of The Substrate
+
+No `CognitionAdminService` is added here. Runtime status, rebuild triggers, and retrieval-debug output belong to the standalone processor, not Memory Service. Memory Service only needs generic substrate APIs that are complete and governed.
+
+### Match REST Exactly
+
+For every feature listed here, REST remains the behavior oracle unless a later enhancement intentionally changes both contracts. gRPC errors should use idiomatic status codes while preserving the same authorization, validation, and data-visibility semantics.
+
+### Prefer Generic Admin Checkpoints
+
+Checkpoints are not cognition-specific. Keeping them as generic admin client checkpoints lets event processors, indexers, and other background clients reuse the same durable cursor storage.
+
+## Testing
+
+### Cucumber Scenarios
+
+```gherkin
+Feature: gRPC parity for cognition processors
+  Scenario: Admin service principal replays events over gRPC
+    Given an admin service principal is authenticated over gRPC
+    When it subscribes to events with scope ADMIN and after_cursor "start"
+    Then it receives conversation and entry events with durable cursors
+
+  Scenario: Non-admin callers cannot request admin event scope
+    Given Alice is authenticated over gRPC without admin privileges
+    When Alice subscribes to events with scope ADMIN
+    Then the gRPC status should be PERMISSION_DENIED
+
+  Scenario: gRPC checkpoints match REST checkpoint behavior
+    Given an admin service principal stores checkpoint {"lastEventCursor":"cursor-1"} for "cognition-worker-1" over gRPC
+    When it reads checkpoint "cognition-worker-1" over gRPC
+    Then the checkpoint contains "lastEventCursor" equal to "cursor-1"
+
+  Scenario: gRPC conditional memory write detects conflicts
+    Given a memory has revision 3
+    When PutMemory is called over gRPC with expected_revision 2
+    Then the gRPC status should be ABORTED or FAILED_PRECONDITION
+
+  Scenario: gRPC archive filters match REST
+    Given a memory is archived
+    When GetMemory is called over gRPC with archived ONLY
+    Then the archived memory is returned
+    When GetMemory is called over gRPC with archived EXCLUDE
+    Then the archived memory is not returned
+
+  Scenario: Service principal writes only authorized cognition namespaces
+    Given the cognition service principal can write ["user","alice","cognition.v1"]
+    When it writes ["user","alice","cognition.v1","facts"] on behalf of "alice" over gRPC
+    Then the write succeeds
+    When it writes ["user","alice","private"] on behalf of "alice" over gRPC
+    Then the gRPC status should be PERMISSION_DENIED
+
+  Scenario: TTL-backed gRPC memories are indexed before expiry
+    Given a memory is written over gRPC with ttl_seconds 3600 and index text "deployment cache"
+    When the write response is returned
+    Then it includes expires_at
+    And the memory is queued for indexing before expiry
+```
+
+### Unit / Integration Tests
+
+- Proto validation tests cover required checkpoint client IDs, namespace prefixes, request actor fields, and invalid archive filters.
+- Memory-search parity tests live in [100](100-enhanced-memory-search.md).
+- Store-level tests verify revision increments and conditional write conflicts for PostgreSQL, SQLite, and MongoDB.
+- Event stream tests verify admin scope, user scope, `kinds`, `conversation_ids`, `after_cursor`, and reconnect behavior.
+- Policy tests verify service-principal `on_behalf_of_user_id` writes are constrained to allowed user namespaces.
+- TTL/index tests verify gRPC writes are indexed before expiry and disappear after expiry.
+
+## Tasks
+
+- [ ] Update `contracts/protobuf/memory/v1/memory_service.proto` with admin event scope, checkpoint RPCs, memory revisions, conditional write fields, and request actor fields.
+- [ ] Regenerate Go, Java, and Python gRPC stubs.
+- [ ] Implement gRPC admin event scope using the same store/outbox path as REST admin events.
+- [ ] Implement gRPC admin checkpoint service backed by the existing admin checkpoint store.
+- [ ] Add revision fields to episodic memory store models and expose conditional write/update behavior through gRPC.
+- [ ] Apply REST-equivalent memory archive semantics to gRPC memory get/list/update paths; search behavior is owned by [100](100-enhanced-memory-search.md).
+- [ ] Implement service-principal `on_behalf_of_user_id` authorization for gRPC memory operations without exposing internal `clientId` in user-facing payloads.
+- [ ] Verify gRPC TTL-backed memory writes are indexed, expire correctly, and expose write/get metadata consistently with REST.
+- [ ] Add BDD and integration coverage for the scenarios above.
+- [ ] Update [099](099-quarkus-cognition-processor.md) to depend on these gRPC substrate APIs for its Memory Service integration.
+
+## Files to Modify
+
+| File | Change |
+| --- | --- |
+| `docs/enhancements/101-grpc-api-parity-for-cognition.md` | This enhancement doc |
+| `docs/enhancements/099-quarkus-cognition-processor.md` | Reference this enhancement for gRPC-only substrate prerequisites |
+| `docs/enhancements/100-enhanced-memory-search.md` | Keep gRPC search contract aligned if field names or behavior change during implementation |
+| `contracts/protobuf/memory/v1/memory_service.proto` | Add/adjust gRPC messages and services |
+| `internal/generated/` | Regenerated Go protobuf code |
+| `java/quarkus/memory-service-proto-quarkus/` | Regenerated Java/Quarkus protobuf stubs |
+| `python/` | Regenerated Python gRPC stubs if protobuf artifacts are impacted |
+| `internal/service/` | gRPC handlers for events, checkpoints, memories, and write/get/list parity |
+| `internal/plugin/store/*` | Store support for memory revisions, conditional writes, archive filters, checkpoints, TTL/index parity |
+| `internal/episodic/` | Policy and request-context handling for service-principal on-behalf-of memory access |
+| `internal/bdd/testdata/features/` | gRPC parity BDD scenarios |
+| `internal/FACTS.md` | Record implementation gotchas discovered while adding gRPC parity |
+
+## Verification
+
+```bash
+# Regenerate Go protobuf clients/stubs
+task generate:go
+
+# Regenerate Python gRPC stubs if protobuf package artifacts are impacted
+task generate:python
+
+# Run Go tests for affected services and stores
+go test ./internal/... > test.log 2>&1
+# Search for failures using Grep tool on test.log
+
+# Compile Java modules that consume generated gRPC stubs
+./java/mvnw -f java/pom.xml -pl quarkus/memory-service-proto-quarkus -am compile
+```
+
+## Non-Goals
+
+- adding cognition-specific status, rebuild, or retrieval-debug RPCs to Memory Service
+- replacing REST APIs
+- changing archive semantics beyond matching the current REST behavior
+- exposing raw evidence, provider prompts, internal `clientId`, or provider cache keys through gRPC memory payloads
+
+## Security Considerations
+
+- Admin event scope and checkpoints require admin authorization or an explicitly equivalent service-principal policy.
+- `on_behalf_of_user_id` must never let a service principal broaden access beyond configured namespace policies.
+- gRPC safe attributes must match REST policy extraction and must not include encrypted memory values, raw evidence text, internal client metadata, provider prompts, or provider cache keys.


### PR DESCRIPTION
## Summary
Define the gRPC substrate parity needed for the Quarkus cognition processor and align the related enhancement docs.

## Changes
- Add Enhancement 101 for gRPC admin event scope, checkpoints, revision-aware memory writes, service-principal delegation, and TTL/index parity.
- Update Enhancement 099 to use gRPC-only Memory Service integration and remove cognition-specific Memory Service admin/debug endpoints.
- Update Enhancement 100 so enhanced memory search explicitly covers REST and gRPC parity for archive, TTL, usage, cursor, and safe-attribute behavior.
