### PR TITLE
fix(auth): restore admin api key in dev config

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -170,9 +170,10 @@ tasks:
       MEMORY_SERVICE_OIDC_DISCOVERY_URL: http://localhost:8081/realms/memory-service
       MEMORY_SERVICE_ROLES_ADMIN_OIDC_ROLE: admin
       MEMORY_SERVICE_ROLES_AUDITOR_OIDC_ROLE: auditor
-      MEMORY_SERVICE_ROLES_ADMIN_CLIENTS: turn_traces_processor
+      MEMORY_SERVICE_ROLES_ADMIN_CLIENTS: admin,turn_traces_processor
       MEMORY_SERVICE_ROLES_INDEXER_CLIENTS: agent
       MEMORY_SERVICE_API_KEYS_AGENT: agent-api-key-1
+      MEMORY_SERVICE_API_KEYS_ADMIN: admin-api-key-1
       MEMORY_SERVICE_API_KEYS_TURN_TRACES_PROCESSOR: turn-traces-processor-key
       # ── CORS ───────────────────────────────────────────────────
       MEMORY_SERVICE_CORS_ENABLED: "true"

--- a/compose.yaml
+++ b/compose.yaml
@@ -187,9 +187,10 @@ services:
       MEMORY_SERVICE_OIDC_DISCOVERY_URL: http://keycloak:8080/realms/memory-service
       MEMORY_SERVICE_ROLES_ADMIN_OIDC_ROLE: admin
       MEMORY_SERVICE_ROLES_AUDITOR_OIDC_ROLE: auditor
-      MEMORY_SERVICE_ROLES_ADMIN_CLIENTS: turn_traces_processor
+      MEMORY_SERVICE_ROLES_ADMIN_CLIENTS: admin,turn_traces_processor
       MEMORY_SERVICE_ROLES_INDEXER_CLIENTS: agent
       MEMORY_SERVICE_API_KEYS_AGENT: agent-api-key-1,agent-api-key-2
+      MEMORY_SERVICE_API_KEYS_ADMIN: admin-api-key-1
       MEMORY_SERVICE_API_KEYS_TURN_TRACES_PROCESSOR: turn-traces-processor-key
 
       # ── CORS ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Restore the legacy `admin-api-key-1` local development credential so external cognition processors using the existing defaults can authenticate against memory-service admin APIs.

## Changes
- Grant the `admin` API client admin access in Docker Compose and Taskfile dev config.
- Define `MEMORY_SERVICE_API_KEYS_ADMIN=admin-api-key-1` alongside the existing turn trace processor key.
