### PR TITLE
ci: add GitHub Container Registry publishing for Docker images

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -27,6 +27,7 @@ concurrency:
 permissions:
   contents: read
   checks: write
+  packages: write
 
 jobs:
   build:
@@ -157,14 +158,22 @@ jobs:
         if: startsWith(matrix.job, 'image-')
         uses: docker/setup-buildx-action@v3
 
+      - name: Log in to GitHub Container Registry
+        if: startsWith(matrix.job, 'image-') && github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build Docker image (memory-service)
         if: matrix.job == 'image-memory-service'
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
-          push: false
-          tags: ghcr.io/chirino/memory-service:latest
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ghcr.io/${{ github.repository_owner }}/memory-service:latest
           cache-from: type=gha,scope=image-memory-service
           cache-to: type=gha,mode=max,scope=image-memory-service
 
@@ -174,7 +183,7 @@ jobs:
         with:
           context: .
           file: java/quarkus/examples/chat-quarkus/Dockerfile
-          push: false
-          tags: ghcr.io/chirino/memory-service-chat-quarkus:latest
+          push: ${{ github.ref == 'refs/heads/main' }}
+          tags: ghcr.io/${{ github.repository_owner }}/memory-service-chat-quarkus:latest
           cache-from: type=gha,scope=image-chat-quarkus
           cache-to: type=gha,mode=max,scope=image-chat-quarkus


### PR DESCRIPTION
# Summary

This pull request updates the CI workflow to automatically push Docker images to GitHub Container Registry (GHCR) when changes are merged to the main branch. Previously, Docker images were only built but not pushed to any registry.

## Changes

- **Added `packages: write` permission** - Required for pushing images to ghcr.io
- **Added GHCR login step** - Authenticates with GitHub Container Registry using `GITHUB_TOKEN`, only runs on main branch builds
- **Updated image build steps** to conditionally push:
  - `memory-service` image: pushes to `ghcr.io/${{ github.repository_owner }}/memory-service:latest` on main
  - `chat-quarkus` image: pushes to `ghcr.io/${{ github.repository_owner }}/memory-service-chat-quarkus:latest` on main

## Behavior

- **PR builds**: Images are built but NOT pushed (validates build works)
- **Main branch builds**: Images are built AND pushed to ghcr.io automatically
- Uses `${{ github.repository_owner }}` for dynamic repository owner resolution
- Leverages existing GitHub Actions cache for faster builds

## Files Changed

📄 `.github/workflows/pr-check.yml` - Updated PR check workflow to enable Docker image publishing