### PR TITLE
chore(java): add mvn central publish workflows

### DIFF
--- a/.github/workflows/publish-java-snapshot.yml
+++ b/.github/workflows/publish-java-snapshot.yml
@@ -1,29 +1,14 @@
-name: Release packages
+name: Publish Java SNAPSHOT
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
-  publish-python:
+  publish-snapshot:
     runs-on: ubuntu-latest
     environment: release
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
-      - name: Build wheel
-        run: uv build
-        working-directory: python/langchain
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: python/dist/
-
-  publish-java:
-    runs-on: ubuntu-latest
-    environment: release
+    # Only allow SNAPSHOT publishing from main branch
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
 
@@ -45,11 +30,12 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Deploy to Maven Central
+      - name: Deploy SNAPSHOT to Maven Central
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          go run github.com/go-task/task/v3/cmd/task release:java VERSION="$VERSION"
+          go run github.com/go-task/task/v3/cmd/task release:java:snapshot
+
+# Made with Bob

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,6 +11,7 @@ vars:
   OVERLAY: '{{.OVERLAY | default "postgresql-infinispan"}}'
   PYTHON_DOCKER_IMAGE: astral/uv:python3.11-bookworm
   GRPC_TOOLS_VERSION: "1.74.0"
+  JAVA_PUBLISH_MODULES: ":memory-service-parent,:memory-service-contracts,:memory-service-quarkus-parent,:memory-service-rest-quarkus,:memory-service-proto-quarkus,:memory-service-extension-parent,:memory-service-extension,:memory-service-extension-deployment,:quarkus-data-encryption-parent,:quarkus-data-encryption,:quarkus-data-encryption-deployment,:quarkus-data-encryption-dek,:quarkus-data-encryption-vault,:memory-service-spring-parent,:memory-service-rest-spring,:memory-service-proto-spring,:memory-service-spring-boot-autoconfigure,:memory-service-spring-boot-starter,:memory-service-spring-boot-docker-compose-starter"
   
 
 tasks:
@@ -439,3 +440,67 @@ tasks:
         echo "  Grafana:        http://grafana.127.0.0.1.nip.io/grafana/   (admin/admin)"
         echo "  Prometheus:     http://prometheus.127.0.0.1.nip.io/prometheus/"
         echo "  MinIO Console:  http://minio.127.0.0.1.nip.io              (minioadmin/minioadmin)"
+
+  release:java:bundle:
+    desc: Build a signed Maven Central bundle for validation (without publishing)
+    cmds:
+      - |
+        if [ -z "{{.VERSION}}" ]; then
+          echo "Error: VERSION is required. Usage: task release:java:bundle VERSION=x.y.z"
+          exit 1
+        fi
+        case "{{.VERSION}}" in
+          *-SNAPSHOT)
+          echo "Error: Release version cannot contain -SNAPSHOT"
+          exit 1
+          ;;
+        esac
+      - ./java/mvnw -f java/pom.xml versions:set -DnewVersion={{.VERSION}} -DgenerateBackupPoms=false
+      - ./java/mvnw -T 1C -f java/pom.xml clean install -Pcentral-release -pl {{.JAVA_PUBLISH_MODULES}} -am -Dcentral.skipPublishing=true
+      - |
+        echo ""
+        echo "Bundle created successfully for version {{.VERSION}}"
+        echo "Inspect artifacts in java/*/target/ directories"
+        echo "Look for: .pom, .jar, -sources.jar, -javadoc.jar, .asc, and checksum files"
+
+  release:java:
+    desc: Publish a release version to Maven Central
+    cmds:
+      - |
+        if [ -z "{{.VERSION}}" ]; then
+          echo "Error: VERSION is required. Usage: task release:java VERSION=x.y.z"
+          exit 1
+        fi
+        case "{{.VERSION}}" in
+          *-SNAPSHOT)
+          echo "Error: Release version cannot contain -SNAPSHOT"
+          exit 1
+          ;;
+        esac
+      - ./java/mvnw -f java/pom.xml versions:set -DnewVersion={{.VERSION}} -DgenerateBackupPoms=false
+      - ./java/mvnw -T 1C -f java/pom.xml clean test -pl {{.JAVA_PUBLISH_MODULES}} -am
+      - ./java/mvnw -T 1C -f java/pom.xml deploy -Pcentral-release -pl {{.JAVA_PUBLISH_MODULES}} -am -DskipTests
+      - |
+        echo ""
+        echo "Release {{.VERSION}} published to Maven Central"
+        echo "Check Central Portal for validation status"
+
+  release:java:snapshot:
+    desc: Publish current SNAPSHOT version to Maven Central
+    cmds:
+      - |
+        VERSION=$(./java/mvnw -f java/pom.xml help:evaluate -Dexpression=project.version -q -DforceStdout)
+        case "$VERSION" in
+          *-SNAPSHOT)
+            ;;
+          *)
+          echo "Error: Current version ($VERSION) is not a SNAPSHOT version"
+          exit 1
+          ;;
+        esac
+        echo "Publishing SNAPSHOT version: $VERSION"
+      - ./java/mvnw -T 1C -f java/pom.xml clean test -pl {{.JAVA_PUBLISH_MODULES}} -am
+      - ./java/mvnw -T 1C -f java/pom.xml deploy -Pcentral-release -pl {{.JAVA_PUBLISH_MODULES}} -am -DskipTests
+      - |
+        echo ""
+        echo "SNAPSHOT published to Maven Central"

--- a/java/chat-frontend/pom.xml
+++ b/java/chat-frontend/pom.xml
@@ -14,6 +14,8 @@
   <name>Memory Service - Demo Chat App - Frontend</name>
 
   <properties>
+    <!-- Skip Maven Central publishing for demo frontend -->
+    <maven.deploy.skip>true</maven.deploy.skip>
     <frontend.dir>${maven.multiModuleProjectDirectory}/../frontends/chat-frontend</frontend.dir>
     <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
     <node.docker.image>node:22.19.0-alpine</node.docker.image>
@@ -68,6 +70,15 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.10.0</version>
+        <configuration>
+          <skip>true</skip>
+          <skipPublishing>true</skipPublishing>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -6,6 +6,25 @@
   <version>999-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Memory Service - Parent</name>
+  <description>Memory service for AI agents that stores messages exchanged with LLMs and users, supporting conversation replay and forking</description>
+  <url>https://github.com/chirino/memory-service</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <id>chirino</id>
+      <name>Hiram Chirino</name>
+      <email>hiram@hiramchirino.com</email>
+      <url>https://github.com/chirino</url>
+    </developer>
+  </developers>
 
   <modules>
     <module>chat-frontend</module>
@@ -13,6 +32,13 @@
     <module>quarkus</module>
     <module>spring</module>
   </modules>
+
+  <scm>
+    <connection>scm:git:git://github.com/chirino/memory-service.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/chirino/memory-service.git</developerConnection>
+    <tag>HEAD</tag>
+    <url>https://github.com/chirino/memory-service</url>
+  </scm>
 
   <properties>
     <compiler-plugin.version>3.14.1</compiler-plugin.version>
@@ -203,6 +229,86 @@
         <skipITs>false</skipITs>
         <quarkus.native.enabled>true</quarkus.native.enabled>
       </properties>
+    </profile>
+
+    <profile>
+      <id>central-release</id>
+      <build>
+        <plugins>
+
+          <!-- Sign artifacts with GPG -->
+          <plugin>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.7</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <phase>verify</phase>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Attach javadocs -->
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>3.11.2</version>
+            <configuration>
+              <doclint>none</doclint>
+              <quiet>true</quiet>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <!-- Attach sources -->
+          <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>3.3.1</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+
+          <!-- Publish to Central Portal -->
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.10.0</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+              <excludeArtifacts>
+                <excludeArtifact>chat-frontend</excludeArtifact>
+                <excludeArtifact>memory-service-quarkus-examples-parent</excludeArtifact>
+                <excludeArtifact>chat-quarkus</excludeArtifact>
+                <excludeArtifact>memory-service-spring-examples-parent</excludeArtifact>
+                <excludeArtifact>chat-spring</excludeArtifact>
+              </excludeArtifacts>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/java/quarkus/examples/chat-quarkus/pom.xml
+++ b/java/quarkus/examples/chat-quarkus/pom.xml
@@ -13,6 +13,11 @@
   <packaging>jar</packaging>
   <name>Memory Service - Demo Chat App - Quarkus</name>
 
+  <properties>
+    <!-- Skip Maven Central publishing for demo app -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <dependencies>
 
     <!-- Memory Service Extension (provides Dev Services) -->
@@ -119,6 +124,20 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.10.0</version>
+        <configuration>
+          <skip>true</skip>
+          <skipPublishing>true</skipPublishing>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <profiles>
     <!--

--- a/java/quarkus/examples/pom.xml
+++ b/java/quarkus/examples/pom.xml
@@ -17,4 +17,23 @@
     <module>chat-quarkus</module>
   </modules>
 
+  <properties>
+    <!-- Skip Maven Central publishing for examples parent -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.10.0</version>
+        <configuration>
+          <skip>true</skip>
+          <skipPublishing>true</skipPublishing>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/java/spring/examples/chat-spring/pom.xml
+++ b/java/spring/examples/chat-spring/pom.xml
@@ -13,6 +13,11 @@
   <packaging>jar</packaging>
   <name>Memory Service - Demo Chat App - Spring</name>
 
+  <properties>
+    <!-- Skip Maven Central publishing for demo app -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.github.chirino.memory-service</groupId>
@@ -68,6 +73,15 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.10.0</version>
+        <configuration>
+          <skip>true</skip>
+          <skipPublishing>true</skipPublishing>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>

--- a/java/spring/examples/pom.xml
+++ b/java/spring/examples/pom.xml
@@ -17,4 +17,23 @@
     <module>chat-spring</module>
   </modules>
 
+  <properties>
+    <!-- Skip Maven Central publishing for examples parent -->
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.10.0</version>
+        <configuration>
+          <skip>true</skip>
+          <skipPublishing>true</skipPublishing>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
## Summary
Add Maven Central publishing support for Java artifacts through shared Taskfile targets and GitHub Actions workflows.

## Changes
- Add release and SNAPSHOT Java publishing workflows backed by Taskfile targets.
- Configure Maven Central metadata, signing, source, javadoc, and Central Portal publishing profile.
- Exclude demo/example modules from Java publishing and document the setup.