### PR TITLE
refactor: defer attachment file conversion and ensure cleanup on termination

### DIFF
--- a/java/quarkus/examples/chat-quarkus/pom.xml
+++ b/java/quarkus/examples/chat-quarkus/pom.xml
@@ -118,6 +118,12 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <fork>true</fork>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
         <version>0.10.0</version>

--- a/java/quarkus/examples/chat-quarkus/src/main/java/org/acme/ChatResource.java
+++ b/java/quarkus/examples/chat-quarkus/src/main/java/org/acme/ChatResource.java
@@ -55,15 +55,23 @@ public class ChatResource {
 
         Attachments attachments = attachmentResolver.resolve(toRefs(request.getAttachments()));
 
-        Multi<ChatEvent> events =
-                agent.chat(
-                        conversationId,
-                        request.getMessage(),
-                        attachments,
-                        request.getForkedAtConversationId(),
-                        request.getForkedAtEntryId());
+        Multi<ChatEvent> events;
+        try {
+            events =
+                    agent.chat(
+                            conversationId,
+                            request.getMessage(),
+                            attachments,
+                            request.getForkedAtConversationId(),
+                            request.getForkedAtEntryId());
+        } catch (RuntimeException e) {
+            attachments.close();
+            throw e;
+        }
 
         return events.map(this::encode)
+                .onTermination()
+                .invoke(attachments::close)
                 .onFailure()
                 .invoke(
                         failure ->

--- a/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/AttachmentDescriptor.java
+++ b/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/AttachmentDescriptor.java
@@ -1,0 +1,55 @@
+package io.github.chirino.memory.history.runtime;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import dev.langchain4j.data.message.Content;
+import java.nio.file.Path;
+
+/**
+ * Describes an attachment for history recording and optional lazy LLM content delivery.
+ *
+ * @param attachmentId the attachment ID (UUID string)
+ * @param contentType the MIME type (e.g. "image/png", "audio/mp3"), may be null
+ * @param name the original filename, may be null
+ * @param href the download URL or reference, may be null
+ * @param filePath local temporary file path for lazy content conversion, not serialized
+ * @param contentUrl signed remote URL for lazy content conversion, not serialized
+ */
+public record AttachmentDescriptor(
+        String attachmentId,
+        String contentType,
+        String name,
+        String href,
+        @JsonIgnore Path filePath,
+        @JsonIgnore String contentUrl) {
+
+    public AttachmentDescriptor(String attachmentId, String contentType, String name, String href) {
+        this(attachmentId, contentType, name, href, null, null);
+    }
+
+    /** Creates a descriptor from an {@link AttachmentRef}. */
+    public static AttachmentDescriptor fromRef(AttachmentRef ref) {
+        return new AttachmentDescriptor(ref.id(), ref.contentType(), ref.name(), ref.href());
+    }
+
+    AttachmentDescriptor withFilePath(String resolvedContentType, Path filePath) {
+        return new AttachmentDescriptor(
+                attachmentId, resolvedContentType, name, href, filePath, null);
+    }
+
+    AttachmentDescriptor withContentUrl(String contentUrl) {
+        return new AttachmentDescriptor(attachmentId, contentType, name, href, null, contentUrl);
+    }
+
+    /**
+     * Resolves this descriptor into LangChain4j content for LLM delivery.
+     */
+    public Content content() {
+        if (contentUrl != null) {
+            return AttachmentResolver.toContentFromUrl(contentType, contentUrl);
+        }
+        if (filePath != null) {
+            return AttachmentResolver.toContentFromPath(contentType, filePath);
+        }
+        return null;
+    }
+}

--- a/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/AttachmentResolver.java
+++ b/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/AttachmentResolver.java
@@ -23,10 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Base64;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
@@ -58,43 +55,28 @@ public class AttachmentResolver {
             return Attachments.empty();
         }
 
-        List<Map<String, Object>> metadata = new ArrayList<>();
-        List<Content> contents = new ArrayList<>();
+        List<AttachmentDescriptor> descriptors = new ArrayList<>();
 
         for (AttachmentRef ref : refs) {
             if (ref.id() == null || ref.id().isBlank()) {
                 continue;
             }
 
-            // Build metadata for history recording
-            Map<String, Object> meta = new LinkedHashMap<>();
-            meta.put("attachmentId", ref.id());
-            if (ref.contentType() != null && !ref.contentType().isBlank()) {
-                meta.put("contentType", ref.contentType());
-            }
-            if (ref.name() != null && !ref.name().isBlank()) {
-                meta.put("name", ref.name());
-            }
-            if (ref.href() != null && !ref.href().isBlank()) {
-                meta.put("href", ref.href());
-            }
-            metadata.add(meta);
+            AttachmentDescriptor item = AttachmentDescriptor.fromRef(ref);
 
-            // Download and convert to LangChain4j Content
+            // Download to a local source for lazy LangChain4j Content conversion.
             try {
-                Content content = downloadAndConvert(ref);
-                if (content != null) {
-                    contents.add(content);
-                }
+                item = download(item);
             } catch (Exception e) {
                 LOG.warnf(e, "Failed to resolve attachment %s, skipping", ref.id());
             }
+            descriptors.add(item);
         }
 
-        return new Attachments(metadata, contents);
+        return Attachments.fromDescriptors(descriptors);
     }
 
-    private Content downloadAndConvert(AttachmentRef ref) throws IOException {
+    private AttachmentDescriptor download(AttachmentDescriptor item) throws IOException {
         String bearer = bearerToken(securityIdentity);
         if (memoryServiceApiBuilder.usesUnixSocket()) {
             UnixSocketHttpClient client =
@@ -104,27 +86,29 @@ public class AttachmentResolver {
                             memoryServiceApiBuilder.getApiKey(),
                             bearer);
             UnixSocketHttpClient.HttpResponseData response =
-                    client.exchange("GET", "/v1/attachments/" + ref.id(), null, (Object) null);
+                    client.exchange(
+                            "GET", "/v1/attachments/" + item.attachmentId(), null, (Object) null);
             if (response.statusCode() == 302) {
-                return toContentFromUrl(ref.contentType(), response.header("location"));
+                return urlSource(item, response.header("location"));
             }
             if (response.statusCode() == 200) {
                 String contentType = response.header("content-type");
                 if (contentType == null) {
-                    contentType = ref.contentType();
+                    contentType = item.contentType();
                 }
                 if (contentType == null) {
                     contentType = "application/octet-stream";
                 }
-                return streamToTempFileAndConvert(
-                        new ByteArrayInputStream(response.body()), contentType);
+                return streamToTempFile(
+                        item, new ByteArrayInputStream(response.body()), contentType);
             }
             LOG.warnf(
                     "Unexpected status %d downloading attachment %s",
-                    response.statusCode(), ref.id());
-            return null;
+                    response.statusCode(), item.attachmentId());
+            return item;
         }
-        String url = memoryServiceApiBuilder.getBaseUrl() + "/v1/attachments/" + ref.id();
+        String url =
+                memoryServiceApiBuilder.getBaseUrl() + "/v1/attachments/" + item.attachmentId();
         Client client = ClientBuilder.newClient();
         try {
             var req = client.target(url).request();
@@ -135,46 +119,60 @@ public class AttachmentResolver {
             if (response.getStatus() == 302) {
                 // S3 redirect — use the signed URL directly
                 String signedUrl = response.getHeaderString("Location");
-                return toContentFromUrl(ref.contentType(), signedUrl);
+                return urlSource(item, signedUrl);
             }
             if (response.getStatus() == 200) {
                 String contentType = response.getHeaderString("Content-Type");
                 if (contentType == null) {
-                    contentType = ref.contentType();
+                    contentType = item.contentType();
                 }
                 if (contentType == null) {
                     contentType = "application/octet-stream";
                 }
-                return streamToTempFileAndConvert(
-                        response.readEntity(InputStream.class), contentType);
+                return streamToTempFile(item, response.readEntity(InputStream.class), contentType);
             }
             LOG.warnf(
                     "Unexpected status %d downloading attachment %s",
-                    response.getStatus(), ref.id());
+                    response.getStatus(), item.attachmentId());
         } finally {
             client.close();
         }
-        return null;
+        return item;
     }
 
     /**
-     * Streams response body to a temp file, then base64-encodes from the file. This avoids
-     * buffering the entire attachment in memory.
+     * Streams response body to a temp file. LangChain4j Content conversion is deferred until the
+     * returned Attachments object's contents() method is called.
      */
-    private Content streamToTempFileAndConvert(InputStream body, String contentType)
-            throws IOException {
+    private AttachmentDescriptor streamToTempFile(
+            AttachmentDescriptor item, InputStream body, String contentType) throws IOException {
+        if (!isSupportedContentType(contentType)) {
+            LOG.debugf("Unsupported content type for LLM: %s", contentType);
+            return item;
+        }
         Path dir = resolveTempDir();
         Path tempFile = Files.createTempFile(dir, "attachment-", ".tmp");
         try {
             try (OutputStream out = Files.newOutputStream(tempFile)) {
                 body.transferTo(out);
             }
-            byte[] bytes = Files.readAllBytes(tempFile);
-            String base64 = Base64.getEncoder().encodeToString(bytes);
-            return toContentFromBase64(contentType, base64);
-        } finally {
+            return item.withFilePath(contentType, tempFile);
+        } catch (IOException | RuntimeException e) {
             Files.deleteIfExists(tempFile);
+            throw e;
         }
+    }
+
+    private AttachmentDescriptor urlSource(AttachmentDescriptor item, String url) {
+        if (url == null || url.isBlank()) {
+            return item;
+        }
+        String contentType = item.contentType();
+        if (contentType != null && !isSupportedContentType(contentType)) {
+            LOG.debugf("Unsupported content type for LLM via URL: %s", contentType);
+            return item;
+        }
+        return item.withContentUrl(url);
     }
 
     private Path resolveTempDir() {
@@ -225,18 +223,18 @@ public class AttachmentResolver {
         return null;
     }
 
-    static Content toContentFromBase64(String contentType, String base64) {
+    static Content toContentFromPath(String contentType, Path filePath) {
         if (contentType.startsWith("image/")) {
-            return ImageContent.from(base64, contentType);
+            return ImageContent.from(filePath, contentType);
         }
         if (contentType.startsWith("audio/")) {
-            return AudioContent.from(base64, contentType);
+            return AudioContent.from(filePath, contentType);
         }
         if (contentType.startsWith("video/")) {
-            return VideoContent.from(base64, contentType);
+            return VideoContent.from(filePath, contentType);
         }
         if (contentType.equals("application/pdf")) {
-            return PdfFileContent.from(base64, contentType);
+            return PdfFileContent.from(filePath, contentType);
         }
         LOG.debugf("Unsupported content type for LLM: %s", contentType);
         return null;

--- a/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/Attachments.java
+++ b/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/Attachments.java
@@ -1,45 +1,91 @@
 package io.github.chirino.memory.history.runtime;
 
 import dev.langchain4j.data.message.Content;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
+import org.jboss.logging.Logger;
 
 /**
- * Holds both the attachment metadata (for history recording) and the resolved LangChain4j Content
+ * Holds both attachment descriptors (for history recording) and resolved LangChain4j Content
  * objects (for LLM delivery). Created by {@link AttachmentResolver}.
  *
  * <p>When passed as a parameter to a {@link
  * io.github.chirino.memory.history.annotations.RecordConversation @RecordConversation} method, the
- * {@link ConversationInterceptor} automatically extracts {@link #metadata()} for conversation
+ * {@link ConversationInterceptor} automatically extracts {@link #descriptors()} for conversation
  * history storage.
+ *
+ * <p>This class owns temporary files created during attachment resolution. Call {@link #close()}
+ * after the model request completes.
  */
-public class Attachments {
+public class Attachments implements AutoCloseable {
 
+    private static final Logger LOG = Logger.getLogger(Attachments.class);
     private static final Attachments EMPTY = new Attachments(List.of(), List.of());
 
-    private final List<Map<String, Object>> metadata;
-    private final List<Content> contents;
+    private final List<AttachmentDescriptor> descriptors;
+    private volatile List<Content> contents;
 
-    public Attachments(List<Map<String, Object>> metadata, List<Content> contents) {
-        this.metadata = metadata;
+    public Attachments(List<AttachmentDescriptor> descriptors, List<Content> contents) {
+        this.descriptors = descriptors;
         this.contents = contents;
     }
 
-    /** Attachment metadata for history recording (attachmentId, contentType, name). */
-    public List<Map<String, Object>> metadata() {
-        return metadata;
+    static Attachments fromDescriptors(List<AttachmentDescriptor> descriptors) {
+        return new Attachments(descriptors, null);
     }
 
-    /** Resolved LangChain4j Content objects for LLM delivery. */
+    /** Attachment descriptors for history recording (attachmentId, contentType, name, href). */
+    public List<AttachmentDescriptor> descriptors() {
+        return descriptors;
+    }
+
+    /** Resolved LangChain4j Content objects for LLM delivery. Built lazily on first access. */
     public List<Content> contents() {
-        return contents;
+        List<Content> resolved = contents;
+        if (resolved == null) {
+            synchronized (this) {
+                resolved = contents;
+                if (resolved == null) {
+                    resolved =
+                            descriptors.stream()
+                                    .map(AttachmentDescriptor::content)
+                                    .filter(content -> content != null)
+                                    .toList();
+                    contents = resolved;
+                }
+            }
+        }
+        return resolved;
     }
 
     public boolean isEmpty() {
-        return contents.isEmpty() && metadata.isEmpty();
+        List<Content> resolved = contents;
+        return descriptors.isEmpty() && (resolved == null || resolved.isEmpty());
     }
 
     public static Attachments empty() {
         return EMPTY;
+    }
+
+    @Override
+    public void close() {
+        for (AttachmentDescriptor item : descriptors) {
+            close(item);
+        }
+    }
+
+    private static void close(AttachmentDescriptor item) {
+        Path filePath = item.filePath();
+        if (filePath == null) {
+            return;
+        }
+        try {
+            Files.deleteIfExists(filePath);
+            LOG.debugf("Deleted temporary attachment file: %s", filePath);
+        } catch (IOException e) {
+            LOG.warnf(e, "Failed to delete temporary attachment file: %s", filePath);
+        }
     }
 }

--- a/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ConversationEventStreamAdapter.java
+++ b/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ConversationEventStreamAdapter.java
@@ -97,7 +97,7 @@ public final class ConversationEventStreamAdapter {
                         : recordingManager.recorder(conversationId, bearerToken);
 
         EventCoalescer coalescer = new EventCoalescer(objectMapper);
-        List<Map<String, Object>> collectedAttachments = new CopyOnWriteArrayList<>();
+        List<AttachmentDescriptor> collectedAttachments = new CopyOnWriteArrayList<>();
 
         Multi<ResponseCancelSignal> cancelStream =
                 recorder.cancelStream().emitOn(Infrastructure.getDefaultExecutor());
@@ -137,7 +137,7 @@ public final class ConversationEventStreamAdapter {
             String bearerToken,
             String agentId,
             ToolAttachmentExtractor toolAttachmentExtractor,
-            List<Map<String, Object>> collectedAttachments) {
+            List<AttachmentDescriptor> collectedAttachments) {
 
         AtomicBoolean canceled = new AtomicBoolean(false);
         AtomicBoolean completed = new AtomicBoolean(false);
@@ -258,7 +258,7 @@ public final class ConversationEventStreamAdapter {
             MultiEmitter<? super ChatEvent> emitter,
             ChatEvent event,
             ToolAttachmentExtractor toolAttachmentExtractor,
-            List<Map<String, Object>> collectedAttachments) {
+            List<AttachmentDescriptor> collectedAttachments) {
 
         if (event == null) {
             return;
@@ -279,7 +279,7 @@ public final class ConversationEventStreamAdapter {
                                 "ToolExecutedEvent: tool=%s, outputLength=%d",
                                 toolName, output != null ? output.length() : -1);
                         if (toolName != null && output != null) {
-                            List<Map<String, Object>> extracted =
+                            List<AttachmentDescriptor> extracted =
                                     toolAttachmentExtractor.extract(toolName, output);
                             LOG.debugf(
                                     "ToolAttachmentExtractor returned %d attachments for tool=%s",
@@ -460,7 +460,7 @@ public final class ConversationEventStreamAdapter {
             MultiEmitter<? super ChatEvent> emitter,
             String bearerToken,
             String agentId,
-            List<Map<String, Object>> collectedAttachments) {
+            List<AttachmentDescriptor> collectedAttachments) {
 
         try {
             storeCoalescedEvents(
@@ -484,7 +484,7 @@ public final class ConversationEventStreamAdapter {
             Throwable failure,
             String bearerToken,
             String agentId,
-            List<Map<String, Object>> collectedAttachments) {
+            List<AttachmentDescriptor> collectedAttachments) {
 
         // Store partial events on failure
         List<JsonNode> events = coalescer.finish();
@@ -515,7 +515,7 @@ public final class ConversationEventStreamAdapter {
             ResponseRecordingManager.RecordingSession recorder,
             String bearerToken,
             String agentId,
-            List<Map<String, Object>> collectedAttachments) {
+            List<AttachmentDescriptor> collectedAttachments) {
 
         try {
             storeCoalescedEvents(
@@ -533,7 +533,7 @@ public final class ConversationEventStreamAdapter {
             EventCoalescer coalescer,
             String bearerToken,
             String agentId,
-            List<Map<String, Object>> collectedAttachments) {
+            List<AttachmentDescriptor> collectedAttachments) {
 
         List<JsonNode> events = coalescer.finish();
         String finalText = coalescer.getFinalText();

--- a/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ConversationInterceptor.java
+++ b/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ConversationInterceptor.java
@@ -21,9 +21,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import org.jboss.logging.Logger;
 
 @RecordConversation
@@ -105,7 +103,7 @@ public class ConversationInterceptor {
         String conversationId = null;
         String userMessage = null;
         Attachments attachmentsObj = null;
-        List<Map<String, Object>> imageUrlAttachments = new ArrayList<>();
+        List<AttachmentDescriptor> imageUrlAttachments = new ArrayList<>();
         String agentId = null;
         String forkedAtConversationId = null;
         String forkedAtEntryId = null;
@@ -141,10 +139,9 @@ public class ConversationInterceptor {
                     startedByEntryId = (String) args[i];
                 }
                 if (a instanceof ImageUrl && args[i] != null) {
-                    Map<String, Object> att = new LinkedHashMap<>();
-                    att.put("href", String.valueOf(args[i]));
-                    att.put("contentType", "image/*");
-                    imageUrlAttachments.add(att);
+                    imageUrlAttachments.add(
+                            new AttachmentDescriptor(
+                                    null, "image/*", null, String.valueOf(args[i])));
                 }
             }
         }
@@ -154,9 +151,9 @@ public class ConversationInterceptor {
                     "Missing @ConversationId or @UserMessage on intercepted method");
         }
 
-        // Prefer Attachments object metadata over @ImageUrl-derived attachments
-        List<Map<String, Object>> attachments =
-                attachmentsObj != null ? attachmentsObj.metadata() : imageUrlAttachments;
+        // Prefer Attachments object descriptors over @ImageUrl-derived attachments
+        List<AttachmentDescriptor> attachments =
+                attachmentsObj != null ? attachmentsObj.descriptors() : imageUrlAttachments;
 
         return new ConversationInvocation(
                 conversationId,

--- a/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ConversationInvocation.java
+++ b/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ConversationInvocation.java
@@ -1,12 +1,11 @@
 package io.github.chirino.memory.history.runtime;
 
 import java.util.List;
-import java.util.Map;
 
 public record ConversationInvocation(
         String conversationId,
         String userMessage,
-        List<Map<String, Object>> attachments,
+        List<AttachmentDescriptor> attachments,
         String agentId,
         String forkedAtConversationId,
         String forkedAtEntryId,

--- a/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ConversationStore.java
+++ b/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ConversationStore.java
@@ -82,14 +82,14 @@ public class ConversationStore {
     }
 
     public void appendUserMessage(
-            String conversationId, String content, List<Map<String, Object>> attachments) {
+            String conversationId, String content, List<AttachmentDescriptor> attachments) {
         appendUserMessage(conversationId, content, attachments, null, null, null, null, null);
     }
 
     public void appendUserMessage(
             String conversationId,
             String content,
-            List<Map<String, Object>> attachments,
+            List<AttachmentDescriptor> attachments,
             String agentId,
             String forkedAtConversationId,
             String forkedAtEntryId,
@@ -255,7 +255,7 @@ public class ConversationStore {
             String conversationId,
             String finalText,
             List<JsonNode> events,
-            List<Map<String, Object>> attachments,
+            List<AttachmentDescriptor> attachments,
             String bearerToken) {
         appendAgentMessageWithEvents(
                 conversationId, finalText, events, attachments, null, bearerToken);
@@ -265,7 +265,7 @@ public class ConversationStore {
             String conversationId,
             String finalText,
             List<JsonNode> events,
-            List<Map<String, Object>> attachments,
+            List<AttachmentDescriptor> attachments,
             String agentId,
             String bearerToken) {
         CreateEntryRequest request = new CreateEntryRequest();

--- a/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/DefaultToolAttachmentExtractor.java
+++ b/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/DefaultToolAttachmentExtractor.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import org.jboss.logging.Logger;
 
 /**
@@ -20,12 +18,12 @@ public class DefaultToolAttachmentExtractor implements ToolAttachmentExtractor {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @Override
-    public List<Map<String, Object>> extract(String toolName, String result) {
+    public List<AttachmentDescriptor> extract(String toolName, String result) {
         if (result == null || result.isBlank()) {
             return List.of();
         }
 
-        List<Map<String, Object>> attachments = new ArrayList<>();
+        List<AttachmentDescriptor> attachments = new ArrayList<>();
         try {
             JsonNode root = MAPPER.readTree(result);
             LOG.debugf(
@@ -41,7 +39,7 @@ public class DefaultToolAttachmentExtractor implements ToolAttachmentExtractor {
         return attachments;
     }
 
-    private void extractFromNode(JsonNode node, List<Map<String, Object>> attachments) {
+    private void extractFromNode(JsonNode node, List<AttachmentDescriptor> attachments) {
         if (node == null) {
             return;
         }
@@ -71,19 +69,13 @@ public class DefaultToolAttachmentExtractor implements ToolAttachmentExtractor {
             JsonNode attachmentId = node.get("attachmentId");
             if (attachmentId != null && attachmentId.isTextual()) {
                 String id = attachmentId.asText();
-                Map<String, Object> att = new LinkedHashMap<>();
-                att.put("attachmentId", id);
-                if (node.has("contentType")) {
-                    att.put("contentType", node.get("contentType").asText());
-                }
-                if (node.has("name")) {
-                    att.put("name", node.get("name").asText());
-                }
+                String contentType =
+                        node.has("contentType") ? node.get("contentType").asText() : null;
+                String name = node.has("name") ? node.get("name").asText() : null;
                 // Use explicit href if provided, otherwise derive from attachmentId
-                att.put(
-                        "href",
-                        node.has("href") ? node.get("href").asText() : "/v1/attachments/" + id);
-                attachments.add(att);
+                String href =
+                        node.has("href") ? node.get("href").asText() : "/v1/attachments/" + id;
+                attachments.add(new AttachmentDescriptor(id, contentType, name, href));
             }
         }
     }

--- a/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ToolAttachmentExtractor.java
+++ b/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/history/runtime/ToolAttachmentExtractor.java
@@ -1,7 +1,6 @@
 package io.github.chirino.memory.history.runtime;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Extracts attachment references from tool execution results. Implementations parse the tool output
@@ -14,7 +13,7 @@ public interface ToolAttachmentExtractor {
      *
      * @param toolName the name of the tool that was executed
      * @param result the tool execution output (typically JSON)
-     * @return list of attachment metadata maps (each containing at least "attachmentId")
+     * @return list of attachment metadata (each containing at least attachmentId)
      */
-    List<Map<String, Object>> extract(String toolName, String result);
+    List<AttachmentDescriptor> extract(String toolName, String result);
 }

--- a/java/quarkus/memory-service-extension/runtime/src/test/java/io/github/chirino/memory/history/runtime/AttachmentResolverTest.java
+++ b/java/quarkus/memory-service-extension/runtime/src/test/java/io/github/chirino/memory/history/runtime/AttachmentResolverTest.java
@@ -1,0 +1,97 @@
+package io.github.chirino.memory.history.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.langchain4j.data.message.Content;
+import dev.langchain4j.data.message.ImageContent;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AttachmentResolverTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void pathConversionCreatesInlineImageContent() throws Exception {
+        Path image = tempDir.resolve("image.png");
+        Files.write(image, new byte[] {1, 2, 3});
+
+        Content content = AttachmentResolver.toContentFromPath("image/png", image);
+
+        assertThat(content).isInstanceOf(ImageContent.class);
+        ImageContent imageContent = (ImageContent) content;
+        assertThat(imageContent.image().url()).isNull();
+        assertThat(imageContent.image().base64Data()).isEqualTo("AQID");
+        assertThat(imageContent.image().mimeType()).isEqualTo("image/png");
+    }
+
+    @Test
+    void attachmentsConvertPathContentLazily() throws Exception {
+        Path image = tempDir.resolve("lazy-image.png");
+        Files.write(image, new byte[] {1, 2, 3});
+
+        Attachments attachments =
+                Attachments.fromDescriptors(
+                        List.of(
+                                new AttachmentDescriptor(
+                                        null, "image/png", null, null, image, null)));
+
+        Files.delete(image);
+
+        assertThatThrownBy(attachments::contents).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void descriptorContentCreatesInlineImageContent() throws Exception {
+        Path image = tempDir.resolve("descriptor-image.png");
+        Files.write(image, new byte[] {1, 2, 3});
+        AttachmentDescriptor descriptor =
+                new AttachmentDescriptor(null, "image/png", null, null, image, null);
+
+        Content content = descriptor.content();
+
+        assertThat(content).isInstanceOf(ImageContent.class);
+        ImageContent imageContent = (ImageContent) content;
+        assertThat(imageContent.image().url()).isNull();
+        assertThat(imageContent.image().base64Data()).isEqualTo("AQID");
+        assertThat(imageContent.image().mimeType()).isEqualTo("image/png");
+    }
+
+    @Test
+    void closeDeletesTemporaryAttachmentFiles() throws Exception {
+        Path image = tempDir.resolve("close-image.png");
+        Files.write(image, new byte[] {1, 2, 3});
+        Attachments attachments =
+                Attachments.fromDescriptors(
+                        List.of(
+                                new AttachmentDescriptor(
+                                        null, "image/png", null, null, image, null)));
+
+        attachments.close();
+
+        assertThat(Files.exists(image)).isFalse();
+    }
+
+    @Test
+    void descriptorSerializationOmitsLazySourceFields() throws Exception {
+        Path image = tempDir.resolve("metadata-image.png");
+        AttachmentDescriptor descriptor =
+                new AttachmentDescriptor(
+                        "attachment-1",
+                        "image/png",
+                        "image.png",
+                        "/v1/attachments/attachment-1",
+                        image,
+                        "https://example.test/signed");
+
+        String json = new ObjectMapper().writeValueAsString(descriptor);
+
+        assertThat(json).contains("attachmentId", "contentType", "name", "href");
+        assertThat(json).doesNotContain("filePath", "contentUrl", image.toString());
+    }
+}

--- a/java/quarkus/memory-service-extension/runtime/src/test/java/io/github/chirino/memory/subagent/runtime/SubAgentTaskManagerTest.java
+++ b/java/quarkus/memory-service-extension/runtime/src/test/java/io/github/chirino/memory/subagent/runtime/SubAgentTaskManagerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.chirino.memory.client.model.Conversation;
+import io.github.chirino.memory.history.runtime.AttachmentDescriptor;
 import io.github.chirino.memory.history.runtime.ConversationStore;
 import io.quarkiverse.langchain4j.runtime.aiservice.ChatEvent;
 import io.smallrye.mutiny.Multi;
@@ -500,7 +501,7 @@ class SubAgentTaskManagerTest {
         public void appendUserMessage(
                 String conversationId,
                 String content,
-                List<Map<String, Object>> attachments,
+                List<AttachmentDescriptor> attachments,
                 String agentId,
                 String forkedAtConversationId,
                 String forkedAtEntryId,

--- a/java/quarkus/memory-service-rest-quarkus/pom.xml
+++ b/java/quarkus/memory-service-rest-quarkus/pom.xml
@@ -109,6 +109,13 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <fork>true</fork>
+          <useIncrementalCompilation>false</useIncrementalCompilation>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>3.6.1</version>

--- a/java/spring/examples/chat-spring/src/main/java/org/acme/ChatController.java
+++ b/java/spring/examples/chat-spring/src/main/java/org/acme/ChatController.java
@@ -115,40 +115,51 @@ class ChatController {
 
         Attachments attachments = attachmentResolver.resolve(toRefs(request.getAttachments()));
 
-        ChatClient.ChatClientRequestSpec requestSpec =
-                chatClient
-                        .prompt()
-                        .advisors(
-                                advisor -> {
-                                    advisor.param(ChatMemory.CONVERSATION_ID, conversationId);
-                                    if (!attachments.isEmpty()) {
-                                        advisor.param(
-                                                ConversationHistoryStreamAdvisor.ATTACHMENTS_KEY,
-                                                attachments);
-                                    }
-                                    if (StringUtils.hasText(request.getForkedAtConversationId())) {
-                                        advisor.param(
-                                                ConversationHistoryStreamAdvisor
-                                                        .FORKED_AT_CONVERSATION_ID_KEY,
-                                                request.getForkedAtConversationId());
-                                    }
-                                    if (StringUtils.hasText(request.getForkedAtEntryId())) {
-                                        advisor.param(
-                                                ConversationHistoryStreamAdvisor
-                                                        .FORKED_AT_ENTRY_ID_KEY,
-                                                request.getForkedAtEntryId());
-                                    }
-                                })
-                        .user(
-                                spec -> {
-                                    spec.text(request.getMessage());
-                                    if (!attachments.media().isEmpty()) {
-                                        spec.media(attachments.media().toArray(new Media[0]));
-                                    }
-                                });
+        Flux<String> responseFlux;
+        try {
+            ChatClient.ChatClientRequestSpec requestSpec =
+                    chatClient
+                            .prompt()
+                            .advisors(
+                                    advisor -> {
+                                        advisor.param(ChatMemory.CONVERSATION_ID, conversationId);
+                                        if (!attachments.isEmpty()) {
+                                            advisor.param(
+                                                    ConversationHistoryStreamAdvisor
+                                                            .ATTACHMENTS_KEY,
+                                                    attachments);
+                                        }
+                                        if (StringUtils.hasText(
+                                                request.getForkedAtConversationId())) {
+                                            advisor.param(
+                                                    ConversationHistoryStreamAdvisor
+                                                            .FORKED_AT_CONVERSATION_ID_KEY,
+                                                    request.getForkedAtConversationId());
+                                        }
+                                        if (StringUtils.hasText(request.getForkedAtEntryId())) {
+                                            advisor.param(
+                                                    ConversationHistoryStreamAdvisor
+                                                            .FORKED_AT_ENTRY_ID_KEY,
+                                                    request.getForkedAtEntryId());
+                                        }
+                                    })
+                            .user(
+                                    spec -> {
+                                        spec.text(request.getMessage());
+                                        if (!attachments.media().isEmpty()) {
+                                            spec.media(attachments.media().toArray(new Media[0]));
+                                        }
+                                    });
 
-        Flux<String> responseFlux =
-                requestSpec.stream().chatClientResponse().map(this::extractContent);
+            responseFlux =
+                    requestSpec.stream()
+                            .chatClientResponse()
+                            .map(this::extractContent)
+                            .doFinally(signal -> attachments.close());
+        } catch (RuntimeException e) {
+            attachments.close();
+            throw e;
+        }
 
         SseEmitter emitter = new SseEmitter(0L);
         Disposable subscription =

--- a/java/spring/memory-service-rest-spring/pom.xml
+++ b/java/spring/memory-service-rest-spring/pom.xml
@@ -94,6 +94,12 @@
         </executions>
       </plugin>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <fork>true</fork>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>3.6.1</version>

--- a/java/spring/memory-service-spring-boot-autoconfigure/pom.xml
+++ b/java/spring/memory-service-spring-boot-autoconfigure/pom.xml
@@ -71,4 +71,15 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <fork>true</fork>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/AttachmentDescriptor.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/AttachmentDescriptor.java
@@ -1,0 +1,74 @@
+package io.github.chirino.memoryservice.history;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.springframework.ai.content.Media;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.lang.Nullable;
+
+/**
+ * Describes an attachment for history recording and optional lazy Spring AI media delivery.
+ */
+public record AttachmentDescriptor(
+        @Nullable String attachmentId,
+        @Nullable String contentType,
+        @Nullable String name,
+        @Nullable String href,
+        @JsonIgnore @Nullable Path filePath,
+        @JsonIgnore @Nullable String contentUrl) {
+
+    public AttachmentDescriptor(
+            @Nullable String attachmentId,
+            @Nullable String contentType,
+            @Nullable String name,
+            @Nullable String href) {
+        this(attachmentId, contentType, name, href, null, null);
+    }
+
+    public static AttachmentDescriptor fromRef(AttachmentRef ref) {
+        return new AttachmentDescriptor(ref.id(), ref.contentType(), ref.name(), ref.href());
+    }
+
+    AttachmentDescriptor withFilePath(String resolvedContentType, Path filePath) {
+        return new AttachmentDescriptor(
+                attachmentId, resolvedContentType, name, href, filePath, null);
+    }
+
+    AttachmentDescriptor withContentUrl(String contentUrl) {
+        return new AttachmentDescriptor(attachmentId, contentType, name, href, null, contentUrl);
+    }
+
+    /**
+     * Resolves this descriptor into Spring AI media for LLM delivery.
+     */
+    @Nullable
+    public Media media() {
+        if (contentUrl != null) {
+            return AttachmentResolver.toMediaFromUrl(contentType, contentUrl);
+        }
+        if (filePath != null) {
+            return AttachmentResolver.toMediaFromResource(
+                    contentType, new FileSystemResource(filePath));
+        }
+        return null;
+    }
+
+    Map<String, Object> toHistoryMap() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        if (attachmentId != null && !attachmentId.isBlank()) {
+            map.put("attachmentId", attachmentId);
+        }
+        if (href != null && !href.isBlank()) {
+            map.put("href", href);
+        }
+        if (contentType != null && !contentType.isBlank()) {
+            map.put("contentType", contentType);
+        }
+        if (name != null && !name.isBlank()) {
+            map.put("name", name);
+        }
+        return map;
+    }
+}

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/AttachmentResolver.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/AttachmentResolver.java
@@ -9,13 +9,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Base64;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.ai.content.Media;
+import org.springframework.core.io.Resource;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
@@ -55,62 +53,43 @@ public class AttachmentResolver {
 
     /**
      * Resolves a list of attachment references into an {@link Attachments} object containing both
-     * metadata and Media objects.
+     * descriptors and lazy Media sources.
      */
     public Attachments resolve(List<AttachmentRef> refs) {
         if (refs == null || refs.isEmpty()) {
             return Attachments.empty();
         }
 
-        List<Map<String, Object>> metadata = new ArrayList<>();
-        List<Media> media = new ArrayList<>();
+        List<AttachmentDescriptor> descriptors = new ArrayList<>();
 
         for (AttachmentRef ref : refs) {
             if (!StringUtils.hasText(ref.id()) && !StringUtils.hasText(ref.href())) {
                 continue;
             }
 
-            // Build metadata for history recording
-            if (StringUtils.hasText(ref.id())) {
-                Map<String, Object> meta = new LinkedHashMap<>();
-                meta.put("attachmentId", ref.id());
-                if (StringUtils.hasText(ref.contentType())) {
-                    meta.put("contentType", ref.contentType());
-                }
-                if (StringUtils.hasText(ref.name())) {
-                    meta.put("name", ref.name());
-                }
-                metadata.add(meta);
-            }
+            AttachmentDescriptor descriptor = AttachmentDescriptor.fromRef(ref);
 
-            // Download and convert to Media for LLM delivery
+            // Download to a local source for lazy Spring AI Media conversion.
             try {
-                Media m = downloadAndConvert(ref);
-                if (m != null) {
-                    media.add(m);
-                }
+                descriptor = download(descriptor);
             } catch (Exception e) {
                 LOG.warn("Failed to resolve attachment {}, skipping", ref.id(), e);
             }
+            descriptors.add(descriptor);
         }
 
-        return new Attachments(metadata, media);
+        return Attachments.fromDescriptors(descriptors);
     }
 
-    @Nullable
-    private Media downloadAndConvert(AttachmentRef ref) {
+    private AttachmentDescriptor download(AttachmentDescriptor descriptor) {
         // If an explicit href is provided (full URL), use it directly
-        if (StringUtils.hasText(ref.href())) {
-            MimeType mimeType =
-                    StringUtils.hasText(ref.contentType())
-                            ? MimeTypeUtils.parseMimeType(ref.contentType())
-                            : MimeTypeUtils.APPLICATION_OCTET_STREAM;
-            return new Media(mimeType, URI.create(ref.href()));
+        if (StringUtils.hasText(descriptor.href())) {
+            return descriptor.withContentUrl(descriptor.href());
         }
 
         // Download from memory service
         String baseUrl = MemoryServiceClients.resolveBaseUrl(properties);
-        String url = baseUrl + "/v1/attachments/" + ref.id();
+        String url = baseUrl + "/v1/attachments/" + descriptor.attachmentId();
         String bearer = SecurityHelper.bearerToken(authorizedClientService);
 
         var requestSpec = webClient.get().uri(url);
@@ -133,51 +112,61 @@ public class AttachmentResolver {
                                                 .findFirst()
                                                 .orElse(null);
                                 return response.releaseBody()
-                                        .thenReturn(toMediaFromUrl(ref.contentType(), signedUrl));
+                                        .thenReturn(urlSource(descriptor, signedUrl));
                             }
 
                             if (status == HttpStatus.OK) {
                                 String contentType =
                                         response.headers().header(HttpHeaders.CONTENT_TYPE).stream()
                                                 .findFirst()
-                                                .orElse(ref.contentType());
-                                return streamToTempFileAndConvert(
-                                        response.bodyToFlux(DataBuffer.class), contentType);
+                                                .orElse(descriptor.contentType());
+                                return streamToTempFile(
+                                        descriptor,
+                                        response.bodyToFlux(DataBuffer.class),
+                                        contentType);
                             }
 
                             LOG.warn(
                                     "Unexpected status {} downloading attachment {}",
                                     response.statusCode().value(),
-                                    ref.id());
-                            return response.releaseBody().then(Mono.empty());
+                                    descriptor.attachmentId());
+                            return response.releaseBody().thenReturn(descriptor);
                         })
                 .block();
     }
 
     /**
-     * Streams response data buffers to a temp file, then base64-encodes from the file. This avoids
-     * buffering the entire attachment in WebClient memory.
+     * Streams response data buffers to a temp file. Spring AI Media conversion is deferred until
+     * the returned Attachments object's media() method is called.
      */
-    private Mono<Media> streamToTempFileAndConvert(
-            Flux<DataBuffer> body, @Nullable String contentType) {
+    private Mono<AttachmentDescriptor> streamToTempFile(
+            AttachmentDescriptor descriptor, Flux<DataBuffer> body, @Nullable String contentType) {
+        String resolvedContentType =
+                StringUtils.hasText(contentType) ? contentType : "application/octet-stream";
         try {
             Path tempFile = Files.createTempFile(tempDir, "attachment-", ".tmp");
             return DataBufferUtils.write(body, tempFile)
                     .then(
                             Mono.fromCallable(
-                                    () -> {
-                                        try {
-                                            byte[] bytes = Files.readAllBytes(tempFile);
-                                            String base64 =
-                                                    Base64.getEncoder().encodeToString(bytes);
-                                            return toMediaFromBase64(contentType, base64);
-                                        } finally {
-                                            Files.deleteIfExists(tempFile);
-                                        }
-                                    }));
+                                    () -> descriptor.withFilePath(resolvedContentType, tempFile)))
+                    .onErrorResume(
+                            error ->
+                                    Mono.fromCallable(
+                                                    () -> {
+                                                        Files.deleteIfExists(tempFile);
+                                                        return descriptor;
+                                                    })
+                                            .then(Mono.error(error)));
         } catch (IOException e) {
             return Mono.error(e);
         }
+    }
+
+    private AttachmentDescriptor urlSource(AttachmentDescriptor descriptor, @Nullable String url) {
+        if (!StringUtils.hasText(url)) {
+            return descriptor;
+        }
+        return descriptor.withContentUrl(url);
     }
 
     private static Path resolveTempDir(@Nullable String configured) {
@@ -201,12 +190,11 @@ public class AttachmentResolver {
     }
 
     @Nullable
-    static Media toMediaFromBase64(@Nullable String contentType, String base64) {
+    static Media toMediaFromResource(@Nullable String contentType, Resource resource) {
         if (contentType == null) {
             contentType = "application/octet-stream";
         }
         MimeType mimeType = MimeTypeUtils.parseMimeType(contentType);
-        String dataUri = "data:" + contentType + ";base64," + base64;
-        return new Media(mimeType, URI.create(dataUri));
+        return new Media(mimeType, resource);
     }
 }

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/Attachments.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/Attachments.java
@@ -1,44 +1,90 @@
 package io.github.chirino.memoryservice.history;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.ai.content.Media;
 
 /**
- * Holds both the attachment metadata (for history recording) and the resolved Spring AI {@link
- * Media} objects (for LLM delivery). Created by {@link AttachmentResolver}.
+ * Holds both attachment descriptors (for history recording) and resolved Spring AI {@link Media}
+ * objects (for LLM delivery). Created by {@link AttachmentResolver}.
  *
  * <p>When passed via the advisor context using {@link
  * ConversationHistoryStreamAdvisor#ATTACHMENTS_KEY}, the advisor automatically extracts {@link
- * #metadata()} for conversation history storage.
+ * #descriptors()} for conversation history storage.
  */
-public class Attachments {
+public class Attachments implements AutoCloseable {
 
+    private static final Logger LOG = LoggerFactory.getLogger(Attachments.class);
     private static final Attachments EMPTY = new Attachments(List.of(), List.of());
 
-    private final List<Map<String, Object>> metadata;
-    private final List<Media> media;
+    private final List<AttachmentDescriptor> descriptors;
+    private volatile List<Media> media;
 
-    public Attachments(List<Map<String, Object>> metadata, List<Media> media) {
-        this.metadata = metadata;
+    public Attachments(List<AttachmentDescriptor> descriptors, List<Media> media) {
+        this.descriptors = descriptors;
         this.media = media;
     }
 
-    /** Attachment metadata for history recording (attachmentId, contentType, name). */
-    public List<Map<String, Object>> metadata() {
-        return metadata;
+    static Attachments fromDescriptors(List<AttachmentDescriptor> descriptors) {
+        return new Attachments(descriptors, null);
     }
 
-    /** Resolved Spring AI Media objects for LLM delivery. */
+    /** Attachment descriptors for history recording (attachmentId, contentType, name, href). */
+    public List<AttachmentDescriptor> descriptors() {
+        return descriptors;
+    }
+
+    /** Attachment metadata maps for existing history storage APIs. */
+    public List<Map<String, Object>> toHistoryMaps() {
+        return descriptors.stream().map(AttachmentDescriptor::toHistoryMap).toList();
+    }
+
+    /** Resolved Spring AI Media objects for LLM delivery. Built lazily on first access. */
     public List<Media> media() {
-        return media;
+        List<Media> resolved = media;
+        if (resolved == null) {
+            synchronized (this) {
+                resolved = media;
+                if (resolved == null) {
+                    resolved =
+                            descriptors.stream()
+                                    .map(AttachmentDescriptor::media)
+                                    .filter(item -> item != null)
+                                    .toList();
+                    media = resolved;
+                }
+            }
+        }
+        return resolved;
     }
 
     public boolean isEmpty() {
-        return media.isEmpty() && metadata.isEmpty();
+        List<Media> resolved = media;
+        return descriptors.isEmpty() && (resolved == null || resolved.isEmpty());
     }
 
     public static Attachments empty() {
         return EMPTY;
+    }
+
+    @Override
+    public void close() {
+        for (AttachmentDescriptor descriptor : descriptors) {
+            Path filePath = descriptor.filePath();
+            if (filePath == null) {
+                continue;
+            }
+            try {
+                Files.deleteIfExists(filePath);
+                LOG.debug("Deleted temporary attachment file: {}", filePath);
+            } catch (IOException e) {
+                LOG.warn("Failed to delete temporary attachment file: {}", filePath, e);
+            }
+        }
     }
 }

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationHistoryCallAdvisor.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationHistoryCallAdvisor.java
@@ -131,9 +131,11 @@ public class ConversationHistoryCallAdvisor implements CallAdvisor {
 
     @SuppressWarnings("unchecked")
     private List<Map<String, Object>> extractAttachments(ChatClientRequest request) {
-        // Prefer explicit attachment metadata from the request context
-        Object explicit =
-                request.context().get(ConversationHistoryStreamAdvisor.ATTACHMENT_METADATA_KEY);
+        // Prefer explicit attachments from the request context.
+        Object explicit = request.context().get(ConversationHistoryStreamAdvisor.ATTACHMENTS_KEY);
+        if (explicit instanceof Attachments attachmentsObj) {
+            return attachmentsObj.toHistoryMaps();
+        }
         if (explicit instanceof List<?> list && !list.isEmpty()) {
             return (List<Map<String, Object>>) list;
         }

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationHistoryStreamAdvisor.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationHistoryStreamAdvisor.java
@@ -341,14 +341,9 @@ public class ConversationHistoryStreamAdvisor implements CallAdvisor, StreamAdvi
 
     /**
      * Key for storing an {@link Attachments} object in the advisor context. When present, the
-     * advisor extracts {@link Attachments#metadata()} for history recording.
+     * advisor extracts {@link Attachments#descriptors()} for history recording.
      */
     public static final String ATTACHMENTS_KEY = "conversation.attachments";
-
-    /**
-     * @deprecated Use {@link #ATTACHMENTS_KEY} with an {@link Attachments} object instead.
-     */
-    @Deprecated public static final String ATTACHMENT_METADATA_KEY = ATTACHMENTS_KEY;
 
     /** Key for storing fork metadata in the advisor context. */
     public static final String FORKED_AT_CONVERSATION_ID_KEY = "forkedAtConversationId";
@@ -361,10 +356,10 @@ public class ConversationHistoryStreamAdvisor implements CallAdvisor, StreamAdvi
 
         // Prefer Attachments object (new API)
         if (contextValue instanceof Attachments attachmentsObj) {
-            return attachmentsObj.metadata();
+            return attachmentsObj.toHistoryMaps();
         }
 
-        // Support legacy List<Map<String, Object>> metadata
+        // Support explicit history maps for callers that construct them directly.
         if (contextValue instanceof List<?> list && !list.isEmpty()) {
             return (List<Map<String, Object>>) contextValue;
         }

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/test/java/io/github/chirino/memoryservice/history/AttachmentResolverTest.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/test/java/io/github/chirino/memoryservice/history/AttachmentResolverTest.java
@@ -1,0 +1,93 @@
+package io.github.chirino.memoryservice.history;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.ai.content.Media;
+import org.springframework.core.io.FileSystemResource;
+
+class AttachmentResolverTest {
+
+    @TempDir Path tempDir;
+
+    @Test
+    void pathConversionCreatesMediaFromPathBytes() throws Exception {
+        Path image = tempDir.resolve("image.png");
+        Files.write(image, new byte[] {1, 2, 3});
+
+        Media media =
+                AttachmentResolver.toMediaFromResource("image/png", new FileSystemResource(image));
+
+        assertThat(media).isNotNull();
+        assertThat(media.getMimeType().toString()).isEqualTo("image/png");
+        assertThat(media.getData()).isEqualTo(new byte[] {1, 2, 3});
+    }
+
+    @Test
+    void attachmentsConvertPathMediaLazily() throws Exception {
+        Path image = tempDir.resolve("lazy-image.png");
+        Files.write(image, new byte[] {1, 2, 3});
+        Attachments attachments =
+                Attachments.fromDescriptors(
+                        List.of(
+                                new AttachmentDescriptor(
+                                        null, "image/png", null, null, image, null)));
+
+        Files.delete(image);
+
+        assertThatThrownBy(attachments::media).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void descriptorMediaCreatesMediaFromPathBytes() throws Exception {
+        Path image = tempDir.resolve("descriptor-image.png");
+        Files.write(image, new byte[] {1, 2, 3});
+        AttachmentDescriptor descriptor =
+                new AttachmentDescriptor(null, "image/png", null, null, image, null);
+
+        Media media = descriptor.media();
+
+        assertThat(media).isNotNull();
+        assertThat(media.getMimeType().toString()).isEqualTo("image/png");
+        assertThat(media.getData()).isEqualTo(new byte[] {1, 2, 3});
+    }
+
+    @Test
+    void closeDeletesTemporaryAttachmentFiles() throws Exception {
+        Path image = tempDir.resolve("close-image.png");
+        Files.write(image, new byte[] {1, 2, 3});
+        Attachments attachments =
+                Attachments.fromDescriptors(
+                        List.of(
+                                new AttachmentDescriptor(
+                                        null, "image/png", null, null, image, null)));
+
+        attachments.close();
+
+        assertThat(Files.exists(image)).isFalse();
+    }
+
+    @Test
+    void descriptorSerializationOmitsLazySourceFields() throws Exception {
+        Path image = tempDir.resolve("metadata-image.png");
+        AttachmentDescriptor descriptor =
+                new AttachmentDescriptor(
+                        "attachment-1",
+                        "image/png",
+                        "image.png",
+                        "/v1/attachments/attachment-1",
+                        image,
+                        "https://example.test/signed");
+
+        String json = new ObjectMapper().writeValueAsString(descriptor);
+
+        assertThat(json).contains("attachmentId", "contentType", "name", "href");
+        assertThat(json).doesNotContain("filePath", "contentUrl", image.toString());
+    }
+}


### PR DESCRIPTION
## Summary
Defer attachment conversion until model content or media is requested, so downloaded files stay on disk instead of being eagerly loaded into memory. The change also centralizes attachment descriptor handling across Quarkus and Spring and ensures temporary files are cleaned up when attachment wrappers are closed.

## Changes
- Add attachment descriptors that retain metadata and lazily convert temp-file or URL sources for Quarkus and Spring.
- Update Quarkus and Spring chat attachment paths to use deferred content/media conversion.
- Add focused attachment resolver coverage and compiler isolation needed for clean reactor builds of the affected Java modules.
