### PR TITLE
fix(dev): enable self-signed tls defaults

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -158,6 +158,7 @@ tasks:
     desc: Run the memory-service app in dev mode.
     env:
       MEMORY_SERVICE_PORT: 8082
+      MEMORY_SERVICE_TLS_SELF_SIGNED: "true"
       # ── Datastore ──────────────────────────────────────────────
       MEMORY_SERVICE_DB_URL: postgres://postgres:postgres@localhost:5432/memory_service?sslmode=disable
       MEMORY_SERVICE_DB_MIGRATE_AT_START: "true"
@@ -234,6 +235,7 @@ tasks:
     desc: Run the memory-service app in dev mode with pgvector (for knowledge clustering).
     env:
       MEMORY_SERVICE_PORT: 8082
+      MEMORY_SERVICE_TLS_SELF_SIGNED: "true"
       # ── Datastore ──────────────────────────────────────────────
       MEMORY_SERVICE_DB_URL: postgres://postgres:postgres@localhost:5432/memory_service?sslmode=disable
       MEMORY_SERVICE_DB_MIGRATE_AT_START: "true"

--- a/compose.yaml
+++ b/compose.yaml
@@ -174,6 +174,7 @@ services:
     environment:
 
       # ── Datastore ──────────────────────────────────────────────
+      MEMORY_SERVICE_TLS_SELF_SIGNED: "true"
       MEMORY_SERVICE_DB_URL: postgres://postgres:postgres@postgres:5432/memory_service?sslmode=disable
       MEMORY_SERVICE_DB_MIGRATE_AT_START: "true"
 

--- a/internal/FACTS.md
+++ b/internal/FACTS.md
@@ -32,6 +32,8 @@
 **Entries invalid-id parity**: Legacy `GET /v1/conversations/:conversationId/entries` returns `404 {"code":"not_found","error":"conversation not found"}` when `conversationId` is not a UUID. Wrapper binding emits 400 by default, so wrapper error handling must map this specific case back to legacy 404.
 **Unix-socket listener validation**: Listener selection conflicts must use explicit flag/env detection (`cmd.IsSet(...)`), not non-zero resolved port values, otherwise the default port `8080` falsely conflicts with `--unix-socket`. When a Unix-socket parent directory is missing, the serve layer creates it as `0700`; if it already exists and is group/world accessible, startup must fail fast instead of chmod-ing it.
 
+**TLS self-signed certificate opt-in**: Omitting `MEMORY_SERVICE_TLS_CERT_FILE` and `MEMORY_SERVICE_TLS_KEY_FILE` only generates an ephemeral self-signed certificate when `MEMORY_SERVICE_TLS_SELF_SIGNED=true` / `--tls-self-signed` is set. Dev launch surfaces that enable TLS without cert files must set this explicitly.
+
 **gRPC recorder disconnect cleanup**: In `ResponseRecorderServer.Record`, if the stream fails with gRPC/ctx `CANCELED` or `DEADLINE_EXCEEDED` after a recorder has been created, call `recorder.Complete()` before returning so the locator/cache registry entry for that conversation is removed.
 
 **gRPC cancel semantics**: `ResponseRecorderServer.Record` subscribes to `resumer.CancelStream(conversationID)` once the first chunk sets `conversation_id`; when cancel is requested it completes the recorder (removing locator/cache registry) and returns unary `RecordResponse{status=RECORD_STATUS_CANCELLED}`.

--- a/internal/cmd/serve/management.go
+++ b/internal/cmd/serve/management.go
@@ -60,7 +60,7 @@ func startManagementServer(cfg config.ListenerConfig, handler http.Handler) (net
 
 	var tlsServer *http.Server
 	if cfg.EnableTLS {
-		cert, err := loadServerCertificate(cfg.TLSCertFile, cfg.TLSKeyFile)
+		cert, err := loadServerCertificate(cfg.TLSCertFile, cfg.TLSKeyFile, cfg.TLSSelfSigned)
 		if err != nil {
 			_ = baseLis.Close()
 			_ = prepared.Cleanup()

--- a/internal/cmd/serve/serve.go
+++ b/internal/cmd/serve/serve.go
@@ -186,6 +186,13 @@ func serverFlags(cfg *config.Config, state *FlagState) []cli.Flag {
 			Destination: &cfg.Listener.TLSKeyFile,
 			Usage:       "TLS private key file for listener TLS mode",
 		},
+		&cli.BoolFlag{
+			Name:        "tls-self-signed",
+			Category:    "Server:",
+			Sources:     cli.EnvVars("MEMORY_SERVICE_TLS_SELF_SIGNED"),
+			Destination: &cfg.Listener.TLSSelfSigned,
+			Usage:       "Generate an ephemeral self-signed certificate when TLS is enabled and cert/key files are not provided",
+		},
 		&cli.StringFlag{
 			Name:        "advertised-address",
 			Category:    "Server:",

--- a/internal/cmd/serve/serve_test.go
+++ b/internal/cmd/serve/serve_test.go
@@ -68,3 +68,19 @@ func readBodyLengthHandler(c *gin.Context) {
 	}
 	c.String(http.StatusOK, "%d", n)
 }
+
+func TestLoadServerCertificate_RequiresExplicitFiles(t *testing.T) {
+	_, err := loadServerCertificate("", "", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "automatic self-signed certificates are disabled")
+
+	_, err = loadServerCertificate("cert.pem", "", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "requires both certificate and key files")
+}
+
+func TestLoadServerCertificate_SelfSigned(t *testing.T) {
+	cert, err := loadServerCertificate("", "", true)
+	require.NoError(t, err)
+	require.NotEmpty(t, cert.Certificate)
+}

--- a/internal/cmd/serve/server.go
+++ b/internal/cmd/serve/server.go
@@ -418,6 +418,7 @@ func startManagementRoutes(cfg *config.Config) (func(context.Context) error, err
 	mgmtCfg := cfg.ManagementListener
 	mgmtCfg.TLSCertFile = cfg.Listener.TLSCertFile
 	mgmtCfg.TLSKeyFile = cfg.Listener.TLSKeyFile
+	mgmtCfg.TLSSelfSigned = cfg.Listener.TLSSelfSigned
 	_, closeManagement, err := startManagementServer(mgmtCfg, mgmtRouter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start management server: %w", err)

--- a/internal/cmd/serve/singleport.go
+++ b/internal/cmd/serve/singleport.go
@@ -70,7 +70,7 @@ func StartSinglePortHTTPAndGRPC(
 
 	var tlsServer *http.Server
 	if cfg.EnableTLS {
-		cert, err := loadServerCertificate(cfg.TLSCertFile, cfg.TLSKeyFile)
+		cert, err := loadServerCertificate(cfg.TLSCertFile, cfg.TLSKeyFile, cfg.TLSSelfSigned)
 		if err != nil {
 			_ = baseLis.Close()
 			_ = prepared.Cleanup()
@@ -161,15 +161,24 @@ func grpcOrHTTPHandler(grpcServer *grpc.Server, httpHandler http.Handler) http.H
 	})
 }
 
-func loadServerCertificate(certFile, keyFile string) (tls.Certificate, error) {
-	if strings.TrimSpace(certFile) != "" && strings.TrimSpace(keyFile) != "" {
+func loadServerCertificate(certFile, keyFile string, selfSigned bool) (tls.Certificate, error) {
+	certFile = strings.TrimSpace(certFile)
+	keyFile = strings.TrimSpace(keyFile)
+	switch {
+	case certFile == "" && keyFile == "":
+		if selfSigned {
+			return generateSelfSignedCertificate()
+		}
+		return tls.Certificate{}, fmt.Errorf("tls requires both certificate and key files; automatic self-signed certificates are disabled")
+	case certFile == "" || keyFile == "":
+		return tls.Certificate{}, fmt.Errorf("tls requires both certificate and key files")
+	default:
 		cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 		if err != nil {
 			return tls.Certificate{}, fmt.Errorf("failed to load tls certificate: %w", err)
 		}
 		return cert, nil
 	}
-	return generateSelfSignedCertificate()
 }
 
 func generateSelfSignedCertificate() (tls.Certificate, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type ListenerConfig struct {
 	EnableTLS         bool
 	TLSCertFile       string
 	TLSKeyFile        string
+	TLSSelfSigned     bool
 	ReadHeaderTimeout time.Duration
 }
 

--- a/internal/plugin/route/attachments/attachments.go
+++ b/internal/plugin/route/attachments/attachments.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -502,7 +503,8 @@ func completeSourceURLAttachment(store registrystore.MemoryStore, attachStore re
 		return
 	}
 	client := &http.Client{
-		Timeout: 3 * time.Minute,
+		Timeout:   3 * time.Minute,
+		Transport: newSourceURLTransport(cfg.AllowPrivateSourceURLs),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 10 {
 				return fmt.Errorf("too many redirects")
@@ -628,6 +630,102 @@ func validateSourceURL(raw string, allowPrivate bool) error {
 		}
 	}
 	return nil
+}
+
+func newSourceURLTransport(allowPrivate bool) http.RoundTripper {
+	base := http.DefaultTransport.(*http.Transport).Clone()
+	if allowPrivate {
+		return base
+	}
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	base.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			host = address
+		}
+		if err := validateResolvedHost(host); err != nil {
+			return nil, err
+		}
+		conn, err := dialer.DialContext(ctx, network, address)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateRemoteAddr(conn.RemoteAddr()); err != nil {
+			_ = conn.Close()
+			return nil, err
+		}
+		return conn, nil
+	}
+	return base
+}
+
+func validateResolvedHost(host string) error {
+	if ip := net.ParseIP(strings.TrimSpace(host)); ip != nil {
+		return validateSourceIP(ip)
+	}
+	return nil
+}
+
+func validateRemoteAddr(addr net.Addr) error {
+	switch v := addr.(type) {
+	case *net.TCPAddr:
+		return validateSourceIP(v.IP)
+	case *net.UDPAddr:
+		return validateSourceIP(v.IP)
+	case *net.IPAddr:
+		return validateSourceIP(v.IP)
+	default:
+		host, _, err := net.SplitHostPort(addr.String())
+		if err != nil {
+			host = addr.String()
+		}
+		if ip := net.ParseIP(strings.TrimSpace(host)); ip != nil {
+			return validateSourceIP(ip)
+		}
+		return nil
+	}
+}
+
+func validateSourceIP(ip net.IP) error {
+	if ip == nil {
+		return fmt.Errorf("cannot resolve sourceUrl host")
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+		return fmt.Errorf("URLs targeting localhost or private networks are not allowed")
+	}
+	if len(ip) == net.IPv6len {
+		if ip.IsMulticast() || ip.IsInterfaceLocalMulticast() {
+			return fmt.Errorf("URLs targeting localhost or private networks are not allowed")
+		}
+		if ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() {
+			return fmt.Errorf("URLs targeting localhost or private networks are not allowed")
+		}
+		if ip[0]&0xfe == 0xfc {
+			return fmt.Errorf("URLs targeting localhost or private networks are not allowed")
+		}
+	}
+	return nil
+}
+
+func isPrivateNetworkError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if strings.Contains(err.Error(), "URLs targeting localhost or private networks are not allowed") {
+		return true
+	}
+	return errors.Is(err, syscall.EPERM)
+}
+
+func NewSourceURLTransportForTest(allowPrivate bool) http.RoundTripper {
+	return newSourceURLTransport(allowPrivate)
+}
+
+func ValidateSourceURLForTest(raw string, allowPrivate bool) error {
+	return validateSourceURL(raw, allowPrivate)
 }
 
 func handleError(c *gin.Context, err error) {

--- a/internal/plugin/route/attachments/attachments_test.go
+++ b/internal/plugin/route/attachments/attachments_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"mime/multipart"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -242,4 +243,23 @@ func TestAttachmentTokenDownloadAndDelete(t *testing.T) {
 	getResp := httptest.NewRecorder()
 	router.ServeHTTP(getResp, getReq)
 	require.Equal(t, http.StatusNotFound, getResp.Code)
+}
+
+func TestSourceURLTransport_BlocksPrivateLiteralIPs(t *testing.T) {
+	transport := attachments.NewSourceURLTransportForTest(false)
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/resource", nil)
+	_, err := transport.RoundTrip(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "private networks are not allowed")
+}
+
+func TestValidateSourceURL_BlocksPrivateResolvedIPs(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	err = attachments.ValidateSourceURLForTest("http://"+listener.Addr().String()+"/resource", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "private networks are not allowed")
 }

--- a/java/quarkus/memory-service-extension/deployment/src/main/java/io/github/chirino/memory/deployment/MemoryServiceDevServicesProcessor.java
+++ b/java/quarkus/memory-service-extension/deployment/src/main/java/io/github/chirino/memory/deployment/MemoryServiceDevServicesProcessor.java
@@ -210,6 +210,7 @@ public class MemoryServiceDevServicesProcessor {
                                                 .withEnv(
                                                         "MEMORY_SERVICE_API_KEYS_AGENT",
                                                         effectiveApiKey)
+                                                .withEnv("MEMORY_SERVICE_TLS_SELF_SIGNED", "true")
                                                 .withEnv("MEMORY_SERVICE_DB_KIND", "sqlite")
                                                 .withEnv(
                                                         "MEMORY_SERVICE_DB_URL",

--- a/java/spring/examples/chat-spring/compose.yaml
+++ b/java/spring/examples/chat-spring/compose.yaml
@@ -114,6 +114,7 @@ services:
     environment:
       # Trusted agent API keys (first value is surfaced to the Spring app via the service connection)
       MEMORY_SERVICE_API_KEYS_AGENT: agent-api-key-1,agent-api-key-2
+      MEMORY_SERVICE_TLS_SELF_SIGNED: "true"
 
       MEMORY_SERVICE_DB_KIND: postgres
       MEMORY_SERVICE_DB_URL: postgresql://postgres:postgres@postgres:5432/memory_service

--- a/site/src/pages/docs/configuration.mdx
+++ b/site/src/pages/docs/configuration.mdx
@@ -16,15 +16,16 @@ Memory Service is configured through CLI flags or environment variables. Use the
 
 ## Server Configuration
 
-| Flag                                                                                     | Values                                    | Default         | Description                                                    |
-| ---------------------------------------------------------------------------------------- | ----------------------------------------- | --------------- | -------------------------------------------------------------- |
-| <Cfg p="--tls-cert-file" e="MEMORY_SERVICE_TLS_CERT_FILE" />                             | path                                      | _(none)_        | TLS certificate file (self-signed if omitted)                  |
-| <Cfg p="--tls-key-file" e="MEMORY_SERVICE_TLS_KEY_FILE" />                               | path                                      | _(none)_        | TLS private key file (self-signed if omitted)                  |
-| <Cfg p="--advertised-address" e="MEMORY_SERVICE_ADVERTISED_ADDRESS" />                   | `host:port`                               | auto-detected   | Advertised address for client redirects                        |
-| <Cfg p="--read-header-timeout-seconds" e="MEMORY_SERVICE_READ_HEADER_TIMEOUT_SECONDS" /> | integer                                   | `5`             | HTTP read header timeout in seconds                            |
-| <Cfg p="--temp-dir" e="MEMORY_SERVICE_TEMP_DIR" />                                       | path                                      | system temp dir | Directory for temporary files                                  |
-| <Cfg p="--management-access-log" e="MEMORY_SERVICE_MANAGEMENT_ACCESS_LOG" />             | `true`, `false`                           | `false`         | Enable HTTP access logging for `/health`, `/ready`, `/metrics` |
-| `MEMORY_SERVICE_LOG_LEVEL`                                                               | `debug`, `info`, `warn`, `error`, `fatal` | `info`          | Server log level                                               |
+| Flag                                                                                     | Values                                    | Default         | Description                                                                   |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------- | --------------- | ----------------------------------------------------------------------------- |
+| <Cfg p="--tls-cert-file" e="MEMORY_SERVICE_TLS_CERT_FILE" />                             | path                                      | _(none)_        | TLS certificate file                                                          |
+| <Cfg p="--tls-key-file" e="MEMORY_SERVICE_TLS_KEY_FILE" />                               | path                                      | _(none)_        | TLS private key file                                                          |
+| <Cfg p="--tls-self-signed" e="MEMORY_SERVICE_TLS_SELF_SIGNED" />                         | `true`, `false`                           | `false`         | Generate an ephemeral self-signed certificate when cert/key files are omitted |
+| <Cfg p="--advertised-address" e="MEMORY_SERVICE_ADVERTISED_ADDRESS" />                   | `host:port`                               | auto-detected   | Advertised address for client redirects                                       |
+| <Cfg p="--read-header-timeout-seconds" e="MEMORY_SERVICE_READ_HEADER_TIMEOUT_SECONDS" /> | integer                                   | `5`             | HTTP read header timeout in seconds                                           |
+| <Cfg p="--temp-dir" e="MEMORY_SERVICE_TEMP_DIR" />                                       | path                                      | system temp dir | Directory for temporary files                                                 |
+| <Cfg p="--management-access-log" e="MEMORY_SERVICE_MANAGEMENT_ACCESS_LOG" />             | `true`, `false`                           | `false`         | Enable HTTP access logging for `/health`, `/ready`, `/metrics`                |
+| `MEMORY_SERVICE_LOG_LEVEL`                                                               | `debug`, `info`, `warn`, `error`, `fatal` | `info`          | Server log level                                                              |
 
 ### Network Listener
 

--- a/site/src/pages/docs/quarkus/dev-services.mdx
+++ b/site/src/pages/docs/quarkus/dev-services.mdx
@@ -41,6 +41,7 @@ The memory-service container is configured by default with:
   code={`MEMORY_SERVICE_DB_KIND=sqlite
 MEMORY_SERVICE_DB_URL=file:/tmp/memory-service-dev/memory-service.db
 MEMORY_SERVICE_DB_MIGRATE_AT_START=true
+MEMORY_SERVICE_TLS_SELF_SIGNED=true
 MEMORY_SERVICE_CACHE_KIND=local
 MEMORY_SERVICE_VECTOR_KIND=sqlite
 MEMORY_SERVICE_EMBEDDING_KIND=local

--- a/site/src/pages/docs/spring/docker-compose.mdx
+++ b/site/src/pages/docs/spring/docker-compose.mdx
@@ -88,6 +88,7 @@ services:
     environment:
       # Trusted agent API keys (first value is surfaced to the Spring app via the service connection)
       MEMORY_SERVICE_API_KEYS_AGENT: agent-api-key-1,agent-api-key-2
+      MEMORY_SERVICE_TLS_SELF_SIGNED: "true"
       MEMORY_SERVICE_DB_URL: postgresql://postgres:postgres@postgres:5432/memory_service
       MEMORY_SERVICE_DB_MIGRATE_AT_START: "true"
       MEMORY_SERVICE_OIDC_ISSUER: http://localhost:8081/realms/memory-service


### PR DESCRIPTION
## Summary
Enable explicit self-signed TLS generation for dev launch surfaces and document the new opt-in flag. Also harden attachment source URL fetching by blocking localhost and private network targets unless private source URLs are explicitly allowed.

## Changes
- Add `MEMORY_SERVICE_TLS_SELF_SIGNED=true` to backend dev tasks, root compose, Spring compose, and Quarkus Dev Services.
- Add `--tls-self-signed` / `MEMORY_SERVICE_TLS_SELF_SIGNED` server configuration and tests.
- Document the self-signed TLS flag in configuration, Quarkus Dev Services, and Spring Docker Compose docs.
- Validate attachment source URL fetch targets before and after dialing to block private network access by default.
