### PR TITLE
test(quarkus): add in-memory ai service checkpoint

### DIFF
--- a/java/quarkus/FACTS.md
+++ b/java/quarkus/FACTS.md
@@ -1,5 +1,11 @@
 # Quarkus Module Facts
 
+**AI service direct-call test**: `examples/doc-checkpoints/02-with-memory` has an `@QuarkusTest` that injects the generated `@RegisterAiService` `Agent`, calls it directly with a memory id, and points the real LangChain4j OpenAI client at a local OpenAI-compatible mock endpoint.
+
+**Configurable chat memory store**: The Quarkus extension registers the Memory Service-backed LangChain4j `ChatMemoryStore` when `memory-service.chat-memory.kind=memory-service` or is unset. Set `memory-service.chat-memory.kind=in-memory` to skip that extension bean and let Quarkiverse LangChain4j use its local in-memory store, avoiding Memory Service Dev Services.
+
+**Standalone Keycloak tests**: Standalone Quarkus checkpoint tests that use `quarkus-test-keycloak-server` must set `keycloak.version` themselves; for Quarkus `3.35.4`, use Keycloak `26.5.7` from the Quarkus build parent. Older `24.0.5` starts but returns null admin/user tokens with the 3.35 test helper.
+
 **Conversation channel naming**: Quarkus integrations should use `Channel.CONTEXT` for agent-managed conversation state and reserve `Channel.HISTORY` for user-visible turns.
 
 **Frontend event proxy boundary**: Keep `MemoryServiceProxy.streamEvents(...)` generic. Frontend-facing example handlers such as `EventsResource` should enforce history-only entry visibility themselves by forwarding only `entry_channel=history` entry notifications.

--- a/java/quarkus/examples/doc-checkpoints/02-with-memory/pom.xml
+++ b/java/quarkus/examples/doc-checkpoints/02-with-memory/pom.xml
@@ -42,6 +42,11 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-rest</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/quarkus/examples/doc-checkpoints/02-with-memory/src/test/java/org/acme/AgentAiServiceTest.java
+++ b/java/quarkus/examples/doc-checkpoints/02-with-memory/src/test/java/org/acme/AgentAiServiceTest.java
@@ -1,0 +1,23 @@
+package org.acme;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@QuarkusTestResource(MockOpenAiTestResource.class)
+class AgentAiServiceTest {
+
+    @Inject Agent agent;
+
+    @Test
+    void testAgentRequest() {
+        String result = agent.chat(UUID.randomUUID().toString(), "hi");
+
+        assertEquals("test-response", result);
+    }
+}

--- a/java/quarkus/examples/doc-checkpoints/02-with-memory/src/test/java/org/acme/MockOpenAiTestResource.java
+++ b/java/quarkus/examples/doc-checkpoints/02-with-memory/src/test/java/org/acme/MockOpenAiTestResource.java
@@ -1,0 +1,71 @@
+package org.acme;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+public class MockOpenAiTestResource implements QuarkusTestResourceLifecycleManager {
+
+    private HttpServer server;
+
+    @Override
+    public Map<String, String> start() {
+        try {
+            server = HttpServer.create(new InetSocketAddress("localhost", 0), 0);
+            server.createContext("/v1/chat/completions", this::chatCompletions);
+            server.start();
+            return Map.of(
+                    "quarkus.langchain4j.openai.api-key",
+                    "test-openai-key",
+                    "quarkus.langchain4j.openai.base-url",
+                    "http://localhost:" + server.getAddress().getPort() + "/v1",
+                    "quarkus.langchain4j.openai.chat-model.model-name",
+                    "test-model");
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to start mock OpenAI endpoint", e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    private void chatCompletions(HttpExchange exchange) throws IOException {
+        byte[] response =
+                """
+                {
+                  "id": "chatcmpl-test",
+                  "object": "chat.completion",
+                  "created": 0,
+                  "model": "test-model",
+                  "choices": [
+                    {
+                      "index": 0,
+                      "message": {
+                        "role": "assistant",
+                        "content": "test-response"
+                      },
+                      "finish_reason": "stop"
+                    }
+                  ],
+                  "usage": {
+                    "prompt_tokens": 1,
+                    "completion_tokens": 1,
+                    "total_tokens": 2
+                  }
+                }
+                """
+                        .getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(200, response.length);
+        exchange.getResponseBody().write(response);
+        exchange.close();
+    }
+}

--- a/java/quarkus/examples/doc-checkpoints/02-with-memory/src/test/resources/application.properties
+++ b/java/quarkus/examples/doc-checkpoints/02-with-memory/src/test/resources/application.properties
@@ -1,0 +1,2 @@
+quarkus.langchain4j.openai.api-key=test-openai-key
+memory-service.chat-memory.kind=in-memory

--- a/java/quarkus/memory-service-extension/deployment/src/main/java/io/github/chirino/memory/deployment/ChatMemoryProcessor.java
+++ b/java/quarkus/memory-service-extension/deployment/src/main/java/io/github/chirino/memory/deployment/ChatMemoryProcessor.java
@@ -1,20 +1,54 @@
 package io.github.chirino.memory.deployment;
 
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import org.eclipse.microprofile.config.ConfigProvider;
 
 public class ChatMemoryProcessor {
 
+    private static final String CHAT_MEMORY_KIND = "memory-service.chat-memory.kind";
+    private static final String MEMORY_SERVICE_KIND = "memory-service";
+    private static final String IN_MEMORY_KIND = "in-memory";
+
     @BuildStep
-    AdditionalBeanBuildItem registerBeans() {
-        return AdditionalBeanBuildItem.builder()
-                .setUnremovable()
-                .addBeanClasses(
-                        // We can replace MemoryServiceChatMemoryProvider once langchain4j picks up:
-                        // https://github.com/langchain4j/langchain4j/pull/4416
-                        "io.github.chirino.memory.langchain4j.MemoryServiceChatMemoryStore"
-                        // "io.github.chirino.memory.langchain4j.MemoryServiceChatMemoryProvider"
-                        )
-                .build();
+    void registerBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        switch (chatMemoryKind()) {
+            case MEMORY_SERVICE_KIND ->
+                    additionalBeans.produce(
+                            AdditionalBeanBuildItem.builder()
+                                    .setUnremovable()
+                                    .addBeanClasses(
+                                            // We can replace MemoryServiceChatMemoryProvider once
+                                            // langchain4j picks up:
+                                            // https://github.com/langchain4j/langchain4j/pull/4416
+                                            "io.github.chirino.memory.langchain4j.MemoryServiceChatMemoryStore"
+                                            // "io.github.chirino.memory.langchain4j.MemoryServiceChatMemoryProvider"
+                                            )
+                                    .build());
+            case IN_MEMORY_KIND -> {
+                // Quarkiverse LangChain4j provides the in-memory ChatMemoryStore.
+            }
+            default ->
+                    throw new IllegalArgumentException(
+                            CHAT_MEMORY_KIND
+                                    + " must be either '"
+                                    + MEMORY_SERVICE_KIND
+                                    + "' or '"
+                                    + IN_MEMORY_KIND
+                                    + "'");
+        }
+    }
+
+    private static String chatMemoryKind() {
+        try {
+            return ConfigProvider.getConfig()
+                    .getOptionalValue(CHAT_MEMORY_KIND, String.class)
+                    .map(value -> value.trim().toLowerCase())
+                    .filter(value -> !value.isEmpty())
+                    .orElse(MEMORY_SERVICE_KIND);
+        } catch (IllegalStateException e) {
+            return MEMORY_SERVICE_KIND;
+        }
     }
 }


### PR DESCRIPTION
## Summary
Add a Quarkus checkpoint test that exercises the generated LangChain4j AI service with an in-memory chat-memory configuration and a local OpenAI-compatible mock endpoint.

## Changes
- Add `memory-service.chat-memory.kind=in-memory` handling to skip the Memory Service-backed chat-memory bean.
- Add a `02-with-memory` Quarkus test that calls the generated agent with a memory id.
- Add a local mock OpenAI chat-completions endpoint for the test.