### PR TITLE
chore(deps): merge javascript dependabot updates

### DIFF
--- a/frontends/chat-frontend/package-lock.json
+++ b/frontends/chat-frontend/package-lock.json
@@ -4786,9 +4786,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/frontends/chat-frontend/package-lock.json
+++ b/frontends/chat-frontend/package-lock.json
@@ -3029,13 +3029,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6725,9 +6725,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/typescript/examples/vecelai/doc-checkpoints/01-basic-chat/package-lock.json
+++ b/typescript/examples/vecelai/doc-checkpoints/01-basic-chat/package-lock.json
@@ -1295,9 +1295,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/prettier": {

--- a/typescript/examples/vecelai/doc-checkpoints/02-with-memory/package-lock.json
+++ b/typescript/examples/vecelai/doc-checkpoints/02-with-memory/package-lock.json
@@ -23,7 +23,7 @@
       "name": "@chirino/memory-service-vercelai",
       "version": "0.0.1",
       "dependencies": {
-        "undici": "^7.16.0"
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.0",

--- a/typescript/examples/vecelai/doc-checkpoints/03-with-history/package-lock.json
+++ b/typescript/examples/vecelai/doc-checkpoints/03-with-history/package-lock.json
@@ -23,7 +23,7 @@
       "name": "@chirino/memory-service-vercelai",
       "version": "0.0.1",
       "dependencies": {
-        "undici": "^7.16.0"
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.0",

--- a/typescript/examples/vecelai/doc-checkpoints/04-conversation-forking/package-lock.json
+++ b/typescript/examples/vecelai/doc-checkpoints/04-conversation-forking/package-lock.json
@@ -23,7 +23,7 @@
       "name": "@chirino/memory-service-vercelai",
       "version": "0.0.1",
       "dependencies": {
-        "undici": "^7.16.0"
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.0",

--- a/typescript/examples/vecelai/doc-checkpoints/05-response-resumption/package-lock.json
+++ b/typescript/examples/vecelai/doc-checkpoints/05-response-resumption/package-lock.json
@@ -1526,9 +1526,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/prettier": {

--- a/typescript/examples/vecelai/doc-checkpoints/05a-streaming/package-lock.json
+++ b/typescript/examples/vecelai/doc-checkpoints/05a-streaming/package-lock.json
@@ -23,7 +23,7 @@
       "name": "@chirino/memory-service-vercelai",
       "version": "0.0.1",
       "dependencies": {
-        "undici": "^7.16.0"
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.0",

--- a/typescript/examples/vecelai/doc-checkpoints/05b-response-resumption/package-lock.json
+++ b/typescript/examples/vecelai/doc-checkpoints/05b-response-resumption/package-lock.json
@@ -1526,9 +1526,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/prettier": {

--- a/typescript/examples/vecelai/doc-checkpoints/05b-response-resumption/package-lock.json
+++ b/typescript/examples/vecelai/doc-checkpoints/05b-response-resumption/package-lock.json
@@ -25,7 +25,7 @@
       "name": "@chirino/memory-service-vercelai",
       "version": "0.0.1",
       "dependencies": {
-        "undici": "^7.16.0"
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.0",

--- a/typescript/examples/vecelai/doc-checkpoints/06-sharing/package-lock.json
+++ b/typescript/examples/vecelai/doc-checkpoints/06-sharing/package-lock.json
@@ -23,7 +23,7 @@
       "name": "@chirino/memory-service-vercelai",
       "version": "0.0.1",
       "dependencies": {
-        "undici": "^7.16.0"
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.0",

--- a/typescript/examples/vecelai/doc-checkpoints/07-with-search/package-lock.json
+++ b/typescript/examples/vecelai/doc-checkpoints/07-with-search/package-lock.json
@@ -23,7 +23,7 @@
       "name": "@chirino/memory-service-vercelai",
       "version": "0.0.1",
       "dependencies": {
-        "undici": "^7.16.0"
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.0",

--- a/typescript/vercelai/package-lock.json
+++ b/typescript/vercelai/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@chirino/memory-service-vercelai",
       "version": "0.0.1",
       "dependencies": {
-        "undici": "^7.16.0"
+        "undici": "^7.28.0"
       },
       "devDependencies": {
         "@types/node": "^22.13.0",
@@ -183,9 +183,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.2.tgz",
-      "integrity": "sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/typescript/vercelai/package.json
+++ b/typescript/vercelai/package.json
@@ -21,7 +21,7 @@
     "prettier": "prettier -w \"src/**/*.{ts,tsx,js}\""
   },
   "dependencies": {
-    "undici": "^7.16.0"
+    "undici": "^7.28.0"
   },
   "peerDependencies": {
     "@grpc/grpc-js": "^1.14.0",


### PR DESCRIPTION
## Summary
Merge the JavaScript-labeled Dependabot updates that had passing build checks into one dependency update branch.

## Changes
- Merge Dependabot updates for frontend flatted/minimatch, Vercel AI undici, and path-to-regexp checkpoint lockfiles.
- Sync Vercel AI doc checkpoint lockfiles with the bumped local `@chirino/memory-service-vercelai` undici range.
