### PR TITLE
fix(deploy): update keycloak 26 configuration

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -117,8 +117,8 @@ services:
     image: quay.io/keycloak/keycloak:26.6.3
     command: ["start-dev", "--import-realm"]
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       KC_DB: postgres
       KC_DB_URL_HOST: postgres
       KC_DB_URL_DATABASE: keycloak
@@ -127,8 +127,7 @@ services:
       KC_HTTP_RELATIVE_PATH: /
       KC_HEALTH_ENABLED: "true"
       # External hostname for browser redirects (configurable via env var)
-      KC_HOSTNAME: ${KEYCLOAK_HOSTNAME:-localhost}
-      KC_HOSTNAME_PORT: ${KEYCLOAK_HOSTNAME_PORT:-8081}
+      KC_HOSTNAME: http://${KEYCLOAK_HOSTNAME:-localhost}:${KEYCLOAK_HOSTNAME_PORT:-8081}
       # Allow internal (Docker network) backchannel communication
       KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"
     volumes:
@@ -139,7 +138,7 @@ services:
     ports:
       - "8081:8080"
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && cat <&3 | grep -q 'UP'"]
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && printf 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && cat <&3 | grep -q 'UP'"]
       interval: 10s
       timeout: 5s
       retries: 15

--- a/compose.yaml
+++ b/compose.yaml
@@ -72,7 +72,7 @@ services:
       retries: 10
 
   qdrant:
-    image: qdrant/qdrant:v1.16.3
+    image: qdrant/qdrant:v1.18.2
     ports:
       - "6333:6333"   # HTTP/REST
       - "6334:6334"   # gRPC
@@ -87,7 +87,7 @@ services:
       retries: 10
 
   redis:
-    image: redis:7-alpine
+    image: redis:8-alpine
     ports:
       - "6379:6379"
     command: ["redis-server", "--save", "", "--appendonly", "no"]
@@ -101,7 +101,7 @@ services:
       retries: 10
 
   infinispan:
-    image: quay.io/infinispan/server:16.1
+    image: quay.io/infinispan/server:16.2.1
     ports:
       - "11222:11222"
     environment:
@@ -114,7 +114,7 @@ services:
       retries: 10
 
   keycloak:
-    image: quay.io/keycloak/keycloak:24.0.5
+    image: quay.io/keycloak/keycloak:26.6.3
     command: ["start-dev", "--import-realm"]
     environment:
       KEYCLOAK_ADMIN: admin
@@ -357,7 +357,7 @@ services:
         condition: service_healthy
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24.8
+    image: clickhouse/clickhouse-server:26.5.1.882
     environment:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: clickhouse

--- a/deploy/kustomize/components/auth/keycloak/deployment-keycloak.yaml
+++ b/deploy/kustomize/components/auth/keycloak/deployment-keycloak.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: keycloak
-          image: quay.io/keycloak/keycloak:24.0.5
+          image: quay.io/keycloak/keycloak:26.6.3
           args:
             - start-dev
             - --import-realm
@@ -26,17 +26,20 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: management
+              containerPort: 9000
+              protocol: TCP
           env:
-            - name: KEYCLOAK_ADMIN
+            - name: KC_BOOTSTRAP_ADMIN_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: keycloak-secret
-                  key: KEYCLOAK_ADMIN
-            - name: KEYCLOAK_ADMIN_PASSWORD
+                  key: KC_BOOTSTRAP_ADMIN_USERNAME
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: keycloak-secret
-                  key: KEYCLOAK_ADMIN_PASSWORD
+                  key: KC_BOOTSTRAP_ADMIN_PASSWORD
             - name: KC_DB
               value: "postgres"
             - name: KC_DB_URL_HOST
@@ -57,6 +60,11 @@ spec:
               value: "/"
             - name: KC_HEALTH_ENABLED
               value: "true"
+            - name: KC_HOSTNAME
+              valueFrom:
+                configMapKeyRef:
+                  name: memory-service-config
+                  key: KEYCLOAK_FRONTEND_URL
             - name: KC_HOSTNAME_BACKCHANNEL_DYNAMIC
               value: "true"
           volumeMounts:
@@ -66,7 +74,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /health/ready
-              port: http
+              port: management
             initialDelaySeconds: 30
             periodSeconds: 10
             timeoutSeconds: 5
@@ -74,7 +82,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /health/live
-              port: http
+              port: management
             initialDelaySeconds: 60
             periodSeconds: 15
             timeoutSeconds: 5

--- a/deploy/kustomize/components/auth/keycloak/kustomization.yaml
+++ b/deploy/kustomize/components/auth/keycloak/kustomization.yaml
@@ -29,8 +29,8 @@ configMapGenerator:
 secretGenerator:
   - name: keycloak-secret
     literals:
-      - KEYCLOAK_ADMIN=admin
-      - KEYCLOAK_ADMIN_PASSWORD=admin
+      - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+      - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
       - KEYCLOAK_CLIENT_SECRET=change-me
   - name: keycloak-db-secret
     literals:

--- a/java/spring/examples/chat-spring/compose.yaml
+++ b/java/spring/examples/chat-spring/compose.yaml
@@ -21,7 +21,7 @@ services:
       retries: 10
 
   redis:
-    image: redis:7-alpine
+    image: redis:8-alpine
     command: ["redis-server", "--save", "", "--appendonly", "no"]
     ports:
       - "56379:6379"
@@ -47,7 +47,7 @@ services:
       retries: 10
 
   keycloak:
-    image: quay.io/keycloak/keycloak:24.0.5
+    image: quay.io/keycloak/keycloak:26.6.3
     command: ["start-dev", "--import-realm"]
     environment:
       KEYCLOAK_ADMIN: admin

--- a/java/spring/examples/chat-spring/compose.yaml
+++ b/java/spring/examples/chat-spring/compose.yaml
@@ -50,8 +50,8 @@ services:
     image: quay.io/keycloak/keycloak:26.6.3
     command: ["start-dev", "--import-realm"]
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       KC_DB: postgres
       KC_DB_URL_HOST: postgres
       KC_DB_URL_DATABASE: keycloak
@@ -60,8 +60,7 @@ services:
       KC_HTTP_RELATIVE_PATH: /
       KC_HEALTH_ENABLED: "true"
       # External hostname for browser redirects (configurable via env var)
-      KC_HOSTNAME: ${KEYCLOAK_HOSTNAME:-localhost}
-      KC_HOSTNAME_PORT: ${KEYCLOAK_HOSTNAME_PORT:-8081}
+      KC_HOSTNAME: http://${KEYCLOAK_HOSTNAME:-localhost}:${KEYCLOAK_HOSTNAME_PORT:-8081}
       # Allow internal (Docker network) backchannel communication
       KC_HOSTNAME_BACKCHANNEL_DYNAMIC: "true"
     volumes:
@@ -72,7 +71,7 @@ services:
     ports:
       - "8081:8080"
     healthcheck:
-      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080 && echo -e 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && cat <&3 | grep -q 'UP'"]
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/9000 && printf 'GET /health/ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n' >&3 && cat <&3 | grep -q 'UP'"]
       interval: 10s
       timeout: 5s
       retries: 15


### PR DESCRIPTION
## Summary
Update the Compose dependency bump branch so Keycloak 26.6.3 starts cleanly across local Compose and kustomize deployments.

## Changes
- Bump the Compose-managed dependency images, including Keycloak 26.6.3.
- Update Keycloak admin bootstrap variables, full hostname configuration, and health checks for Keycloak 26 in Compose and kustomize manifests.
