### PR TITLE
build(spring): upgrade to spring boot 4

### DIFF
--- a/internal/sitebdd/checkpoint.go
+++ b/internal/sitebdd/checkpoint.go
@@ -234,6 +234,7 @@ func (s *SiteScenario) startCheckpoint() error {
 	isNode := !isPython && fileExists(filepath.Join(s.CheckpointPath, "package.json"))
 	quarkusJar := filepath.Join(s.CheckpointPath, "target", "quarkus-app", "quarkus-run.jar")
 	isQuarkus := !isPython && !isNode && fileExists(quarkusJar)
+	isSpring := !isPython && !isNode && !isQuarkus
 
 	var cmd *exec.Cmd
 	memoryServiceURL := s.MemServiceURL
@@ -263,7 +264,7 @@ func (s *SiteScenario) startCheckpoint() error {
 			fmt.Sprintf("-Dquarkus.http.port=%d", s.CheckpointPort),
 			"-jar", quarkusJar)
 
-	default:
+	case isSpring:
 		// Spring Boot — find any JAR in target/
 		jar, err := findJar(filepath.Join(s.CheckpointPath, "target"))
 		if err != nil {
@@ -287,11 +288,16 @@ func (s *SiteScenario) startCheckpoint() error {
 		cmd = exec.Command("java", springArgs...)
 	}
 
+	openAIBaseURL := s.Mock.URL()
+	if isSpring {
+		openAIBaseURL += "/v1"
+	}
+
 	cmd.Dir = s.CheckpointPath
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	// Base env: OpenAI mock routing + memory service URL in all supported forms.
 	cmd.Env = append(os.Environ(),
-		"OPENAI_BASE_URL="+s.Mock.URL(),
+		"OPENAI_BASE_URL="+openAIBaseURL,
 		"OPENAI_API_KEY="+s.apiKey(),
 		"OPENAI_MODEL=mock-gpt-markdown",
 		"PORT="+fmt.Sprintf("%d", s.CheckpointPort),

--- a/java/spring/examples/chat-spring/pom.xml
+++ b/java/spring/examples/chat-spring/pom.xml
@@ -66,7 +66,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/spring/examples/chat-spring/src/main/resources/application.properties
+++ b/java/spring/examples/chat-spring/src/main/resources/application.properties
@@ -22,7 +22,7 @@ chat.frontend.keycloak-client-id=${KEYCLOAK_CLIENT_ID:frontend}
 # export OPENAI_API_KEY=sk-...
 
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
-spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com}
+spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 spring.ai.openai.chat.options.model=${OPENAI_MODEL:gpt-4o}
 spring.ai.openai.image.options.model=${OPENAI_IMAGE_MODEL:dall-e-3}
 spring.ai.openai.image.options.response-format=url

--- a/java/spring/examples/doc-checkpoints/01-basic-agent/pom.xml
+++ b/java/spring/examples/doc-checkpoints/01-basic-agent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>4.1.0</version>
     <relativePath/>
   </parent>
   <groupId>com.example</groupId>
@@ -14,7 +14,7 @@
   <description>Demo project for Spring Boot</description>
   <properties>
     <java.version>21</java.version>
-    <spring-ai.version>1.1.2</spring-ai.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/java/spring/examples/doc-checkpoints/01-basic-agent/src/main/resources/application.properties
+++ b/java/spring/examples/doc-checkpoints/01-basic-agent/src/main/resources/application.properties
@@ -1,4 +1,4 @@
 server.port=9090
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
-spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com}
+spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 spring.ai.openai.chat.options.model=${OPENAI_MODEL:gpt-4}

--- a/java/spring/examples/doc-checkpoints/02-with-memory/pom.xml
+++ b/java/spring/examples/doc-checkpoints/02-with-memory/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>4.1.0</version>
     <relativePath/>
   </parent>
   <groupId>com.example</groupId>
@@ -14,7 +14,7 @@
   <description>Demo project for Spring Boot</description>
   <properties>
     <java.version>21</java.version>
-    <spring-ai.version>1.1.2</spring-ai.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
     <memory-service.version>999-SNAPSHOT</memory-service.version>
   </properties>
   <dependencyManagement>

--- a/java/spring/examples/doc-checkpoints/02-with-memory/src/main/resources/application.properties
+++ b/java/spring/examples/doc-checkpoints/02-with-memory/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=9090
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
-spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com}
+spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 spring.ai.openai.chat.options.model=${OPENAI_MODEL:gpt-4}
 
 # Memory Service

--- a/java/spring/examples/doc-checkpoints/03-with-history/pom.xml
+++ b/java/spring/examples/doc-checkpoints/03-with-history/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>4.1.0</version>
     <relativePath/>
   </parent>
   <groupId>com.example</groupId>
@@ -14,7 +14,7 @@
   <description>Demo project for Spring Boot</description>
   <properties>
     <java.version>21</java.version>
-    <spring-ai.version>1.1.2</spring-ai.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
     <memory-service.version>999-SNAPSHOT</memory-service.version>
   </properties>
   <dependencyManagement>

--- a/java/spring/examples/doc-checkpoints/03-with-history/src/main/resources/application.properties
+++ b/java/spring/examples/doc-checkpoints/03-with-history/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=9090
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
-spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com}
+spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 
 # Memory Service
 memory-service.client.url=http://localhost:8082

--- a/java/spring/examples/doc-checkpoints/03b-with-events/pom.xml
+++ b/java/spring/examples/doc-checkpoints/03b-with-events/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>4.1.0</version>
     <relativePath/>
   </parent>
   <groupId>com.example</groupId>
@@ -14,7 +14,7 @@
   <description>Demo project for Spring Boot</description>
   <properties>
     <java.version>21</java.version>
-    <spring-ai.version>1.1.2</spring-ai.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
     <memory-service.version>999-SNAPSHOT</memory-service.version>
   </properties>
   <dependencyManagement>

--- a/java/spring/examples/doc-checkpoints/03b-with-events/src/main/resources/application.properties
+++ b/java/spring/examples/doc-checkpoints/03b-with-events/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=9090
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
-spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com}
+spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 
 # Memory Service
 memory-service.client.url=http://localhost:8082

--- a/java/spring/examples/doc-checkpoints/04-conversation-forking/pom.xml
+++ b/java/spring/examples/doc-checkpoints/04-conversation-forking/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>4.1.0</version>
     <relativePath/>
   </parent>
   <groupId>com.example</groupId>
@@ -14,7 +14,7 @@
   <description>Demo project for Spring Boot</description>
   <properties>
     <java.version>21</java.version>
-    <spring-ai.version>1.1.2</spring-ai.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
     <memory-service.version>999-SNAPSHOT</memory-service.version>
   </properties>
   <dependencyManagement>

--- a/java/spring/examples/doc-checkpoints/04-conversation-forking/src/main/resources/application.properties
+++ b/java/spring/examples/doc-checkpoints/04-conversation-forking/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=9090
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
-spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com}
+spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 
 # Memory Service
 memory-service.client.url=http://localhost:8082

--- a/java/spring/examples/doc-checkpoints/05-response-resumption/pom.xml
+++ b/java/spring/examples/doc-checkpoints/05-response-resumption/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>4.1.0</version>
     <relativePath/>
   </parent>
   <groupId>com.example</groupId>
@@ -14,7 +14,7 @@
   <description>Demo project for Spring Boot</description>
   <properties>
     <java.version>21</java.version>
-    <spring-ai.version>1.1.2</spring-ai.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
     <memory-service.version>999-SNAPSHOT</memory-service.version>
   </properties>
   <dependencyManagement>

--- a/java/spring/examples/doc-checkpoints/05-response-resumption/src/main/resources/application.properties
+++ b/java/spring/examples/doc-checkpoints/05-response-resumption/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=9090
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
-spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com}
+spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 
 # Memory Service
 memory-service.client.url=http://localhost:8082

--- a/java/spring/examples/doc-checkpoints/06-sharing/pom.xml
+++ b/java/spring/examples/doc-checkpoints/06-sharing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>4.1.0</version>
     <relativePath/>
   </parent>
   <groupId>com.example</groupId>
@@ -14,7 +14,7 @@
   <description>Demo project for Spring Boot</description>
   <properties>
     <java.version>21</java.version>
-    <spring-ai.version>1.1.2</spring-ai.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
     <memory-service.version>999-SNAPSHOT</memory-service.version>
   </properties>
   <dependencyManagement>

--- a/java/spring/examples/doc-checkpoints/06-sharing/src/main/resources/application.properties
+++ b/java/spring/examples/doc-checkpoints/06-sharing/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=9090
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
-spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com}
+spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 
 # Memory Service
 memory-service.client.url=http://localhost:8082

--- a/java/spring/examples/doc-checkpoints/07-with-search/pom.xml
+++ b/java/spring/examples/doc-checkpoints/07-with-search/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>4.1.0</version>
     <relativePath/>
   </parent>
   <groupId>com.example</groupId>
@@ -14,7 +14,7 @@
   <description>Demo project for Spring Boot</description>
   <properties>
     <java.version>21</java.version>
-    <spring-ai.version>1.1.2</spring-ai.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
     <memory-service.version>999-SNAPSHOT</memory-service.version>
   </properties>
   <dependencyManagement>

--- a/java/spring/examples/doc-checkpoints/07-with-search/src/main/resources/application.properties
+++ b/java/spring/examples/doc-checkpoints/07-with-search/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=9090
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
-spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com}
+spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 
 # Memory Service
 memory-service.client.url=http://localhost:8082

--- a/java/spring/examples/doc-checkpoints/08-with-attachments/pom.xml
+++ b/java/spring/examples/doc-checkpoints/08-with-attachments/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>4.1.0</version>
     <relativePath/>
   </parent>
   <groupId>com.example</groupId>
@@ -14,7 +14,7 @@
   <description>Demo project for Spring Boot</description>
   <properties>
     <java.version>21</java.version>
-    <spring-ai.version>1.1.2</spring-ai.version>
+    <spring-ai.version>2.0.0</spring-ai.version>
     <memory-service.version>999-SNAPSHOT</memory-service.version>
   </properties>
   <dependencyManagement>

--- a/java/spring/examples/doc-checkpoints/08-with-attachments/src/main/resources/application.properties
+++ b/java/spring/examples/doc-checkpoints/08-with-attachments/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 server.port=9090
 spring.ai.openai.api-key=${OPENAI_API_KEY:}
-spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com}
+spring.ai.openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 
 # Memory Service
 memory-service.client.url=http://localhost:8082

--- a/java/spring/memory-service-rest-spring/pom.xml
+++ b/java/spring/memory-service-rest-spring/pom.xml
@@ -22,6 +22,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.github.chirino.memory-service</groupId>
       <artifactId>memory-service-contracts</artifactId>
       <version>${project.version}</version>

--- a/java/spring/memory-service-rest-spring/src/main/java/io/github/chirino/memoryservice/client/MemoryServiceClients.java
+++ b/java/spring/memory-service-rest-spring/src/main/java/io/github/chirino/memoryservice/client/MemoryServiceClients.java
@@ -173,8 +173,9 @@ public final class MemoryServiceClients {
             if (StringUtils.hasText(baseUrl) && !url.startsWith(baseUrl)) {
                 return next.exchange(request);
             }
-            boolean hasAuthorization = request.headers().containsKey(HttpHeaders.AUTHORIZATION);
-            boolean hasApiKey = request.headers().containsKey("X-API-Key");
+            boolean hasAuthorization =
+                    request.headers().getFirst(HttpHeaders.AUTHORIZATION) != null;
+            boolean hasApiKey = request.headers().getFirst("X-API-Key") != null;
             LOGGER.info(
                     "memory-service client request: {} {}, sent Authorization header: {}, sent"
                             + " X-API-Key header: {}",

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationHistoryAutoConfiguration.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationHistoryAutoConfiguration.java
@@ -57,6 +57,12 @@ public class ConversationHistoryAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    @Bean
     @ConditionalOnBean({MemoryServiceGrpcClients.MemoryServiceStubs.class, ManagedChannel.class})
     public ResponseRecordingManager grpcResponseRecordingManager(
             MemoryServiceClientProperties clientProperties,

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationHistoryCallAdvisor.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationHistoryCallAdvisor.java
@@ -170,7 +170,7 @@ public class ConversationHistoryCallAdvisor implements CallAdvisor {
         if (potential instanceof String value && StringUtils.hasText(value)) {
             return value;
         }
-        return ChatMemory.DEFAULT_CONVERSATION_ID;
+        return ConversationHistoryStreamAdvisor.DEFAULT_CONVERSATION_ID;
     }
 
     private @Nullable String resolveUserMessage(ChatClientRequest request) {

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationHistoryStreamAdvisor.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/history/ConversationHistoryStreamAdvisor.java
@@ -44,6 +44,7 @@ public class ConversationHistoryStreamAdvisor implements CallAdvisor, StreamAdvi
 
     private static final Logger LOG =
             LoggerFactory.getLogger(ConversationHistoryStreamAdvisor.class);
+    static final String DEFAULT_CONVERSATION_ID = "default";
 
     private final ConversationStore conversationStore;
     private final ResponseRecordingManager recordingManager;
@@ -394,7 +395,7 @@ public class ConversationHistoryStreamAdvisor implements CallAdvisor, StreamAdvi
         if (potential instanceof String value && StringUtils.hasText(value)) {
             return value;
         }
-        return ChatMemory.DEFAULT_CONVERSATION_ID;
+        return DEFAULT_CONVERSATION_ID;
     }
 
     private @Nullable String resolveUserMessage(ChatClientRequest request) {

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/memory/MemoryServiceChatMemoryRepository.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/main/java/io/github/chirino/memoryservice/memory/MemoryServiceChatMemoryRepository.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
@@ -249,10 +250,8 @@ public class MemoryServiceChatMemoryRepository implements ChatMemoryRepository {
 
     @Nullable
     private Message createMessage(String role, String text) {
-        MessageType messageType;
-        try {
-            messageType = MessageType.fromValue(role.toLowerCase());
-        } catch (IllegalArgumentException e) {
+        MessageType messageType = messageType(role);
+        if (messageType == null) {
             LOG.warn("Unknown message role: {}", role);
             return null;
         }
@@ -267,5 +266,16 @@ public class MemoryServiceChatMemoryRepository implements ChatMemoryRepository {
                 yield null;
             }
         };
+    }
+
+    @Nullable
+    private MessageType messageType(String role) {
+        String normalized = role.toLowerCase(Locale.ROOT);
+        for (MessageType candidate : MessageType.values()) {
+            if (candidate.getValue().equals(normalized)) {
+                return candidate;
+            }
+        }
+        return null;
     }
 }

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/test/java/io/github/chirino/memoryservice/spring/autoconfigure/MemoryServiceAutoConfigurationComposeTest.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/test/java/io/github/chirino/memoryservice/spring/autoconfigure/MemoryServiceAutoConfigurationComposeTest.java
@@ -8,19 +8,17 @@ import io.github.chirino.memoryservice.spring.autoconfigure.serviceconnection.Me
 import java.net.URI;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
 
 class MemoryServiceAutoConfigurationComposeTest {
 
     private final ApplicationContextRunner contextRunner =
             new ApplicationContextRunner()
-                    .withConfiguration(
-                            AutoConfigurations.of(
-                                    WebClientAutoConfiguration.class,
-                                    MemoryServiceAutoConfiguration.class));
+                    .withConfiguration(AutoConfigurations.of(MemoryServiceAutoConfiguration.class))
+                    .withBean(WebClient.Builder.class, WebClient::builder);
 
     @Test
     void apiKeyDefaultsFromServiceConnectionWhenPropertyMissing() {

--- a/java/spring/memory-service-spring-boot-autoconfigure/src/test/java/io/github/chirino/memoryservice/spring/boot/MemoryServiceAutoConfigurationTest.java
+++ b/java/spring/memory-service-spring-boot-autoconfigure/src/test/java/io/github/chirino/memoryservice/spring/boot/MemoryServiceAutoConfigurationTest.java
@@ -7,19 +7,17 @@ import io.github.chirino.memoryservice.grpc.MemoryServiceGrpcClients;
 import io.grpc.ManagedChannel;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
 
 class MemoryServiceAutoConfigurationTest {
 
     private final ApplicationContextRunner contextRunner =
             new ApplicationContextRunner()
-                    .withConfiguration(
-                            AutoConfigurations.of(
-                                    WebClientAutoConfiguration.class,
-                                    MemoryServiceAutoConfiguration.class));
+                    .withConfiguration(AutoConfigurations.of(MemoryServiceAutoConfiguration.class))
+                    .withBean(WebClient.Builder.class, WebClient::builder);
 
     @Test
     void createsApiClientWithApiKey() {

--- a/java/spring/memory-service-spring-boot-starter/pom.xml
+++ b/java/spring/memory-service-spring-boot-starter/pom.xml
@@ -23,5 +23,9 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webclient</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/java/spring/pom.xml
+++ b/java/spring/pom.xml
@@ -23,12 +23,12 @@
   </modules>
 
   <properties>
-    <spring.boot.version>3.5.10</spring.boot.version>
-    <spring.ai.version>1.1.2</spring.ai.version>
+    <spring.boot.version>4.1.0</spring.boot.version>
+    <spring.ai.version>2.0.0</spring.ai.version>
     <openapi.generator.version>7.23.0</openapi.generator.version>
     <protobuf.maven.plugin.version>0.6.1</protobuf.maven.plugin.version>
     <grpc.version>1.67.1</grpc.version>
-    <protobuf.version>4.35.0</protobuf.version>
+    <protobuf.version>4.34.2</protobuf.version>
   </properties>
 
   <dependencyManagement>

--- a/site/src/pages/docs/spring/getting-started.mdx
+++ b/site/src/pages/docs/spring/getting-started.mdx
@@ -18,8 +18,8 @@ Make sure you've completed the [prerequisites](/docs/spring/) before starting th
 
 **Starting checkpoint**: View the complete code at [java/spring/examples/doc-checkpoints/01-basic-agent](https://github.com/chirino/memory-service/tree/main/java/spring/examples/doc-checkpoints/01-basic-agent)
 
-First, let's create a new Spring Boot application. Use [Spring Initializr](https://start.spring.io/#!type=maven-project&language=java&platformVersion=3.5.10&packaging=jar&configurationFileFormat=properties&jvmVersion=21&groupId=com.example&artifactId=demo&name=demo&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.demo&dependencies=spring-ai-openai,web) to setup the project.
-Make sure to use Spring Boot 3.5 as that the latest version supported by Spring AI and add the OpenAI and Spring Web dependencies.
+First, let's create a new Spring Boot application. Use [Spring Initializr](https://start.spring.io/#!type=maven-project&language=java&platformVersion=4.1.0&packaging=jar&configurationFileFormat=properties&jvmVersion=21&groupId=com.example&artifactId=demo&name=demo&description=Demo%20project%20for%20Spring%20Boot&packageName=com.example.demo&dependencies=spring-ai-openai,web) to setup the project.
+Make sure to use Spring Boot 4.1 to match the Spring AI 2 examples, and add the OpenAI and Spring Web dependencies.
 
 Once you download the starter project extract it and open it in your favorite IDE.
 


### PR DESCRIPTION
## Summary
Upgrade the Spring modules and runnable docs checkpoints to Spring Boot 4.1 and Spring AI 2.0.

## Changes
- Update Spring dependency management, Testcontainers artifact names, and Spring AI API compatibility code.
- Align Spring docs checkpoints with Boot 4/Spring AI 2, including protobuf runtime and OpenAI base URL handling.
- Update the site test harness and Spring getting-started docs for the upgraded checkpoints.
