### PR TITLE
chore(deps): update python dependencies

### DIFF
--- a/python/examples/langchain/doc-checkpoints/03b-with-events/pyproject.toml
+++ b/python/examples/langchain/doc-checkpoints/03b-with-events/pyproject.toml
@@ -5,7 +5,7 @@ description = "Memory Service Python docs checkpoint app - events"
 requires-python = ">=3.10"
 dependencies = [
   "fastapi>=0.136.3,<1.0.0",
-  "langchain>=1.0.0,<2.0.0",
+  "langchain>=1.3.7,<2.0.0",
   "langchain-openai>=1.0.0,<2.0.0",
   "memory-service-langchain",
   "httpx>=0.28.1,<1.0.0",

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
+    { name = "fastapi", specifier = ">=0.136.3,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "langchain", specifier = ">=1.0.0,<2.0.0" },
     { name = "langchain-openai", specifier = ">=1.0.0,<2.0.0" },
@@ -180,7 +180,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
+    { name = "fastapi", specifier = ">=0.136.3,<1.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "langchain-openai", specifier = ">=1.0.0,<2.0.0" },
     { name = "langgraph", specifier = ">=1.0.0,<2.0.0" },
@@ -627,7 +627,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
+    { name = "fastapi", specifier = ">=0.136.3,<1.0.0" },
     { name = "grpcio", specifier = ">=1.74.0,<2.0.0" },
     { name = "httpx", specifier = ">=0.28.0,<1.0.0" },
     { name = "langchain", specifier = ">=1.0.0,<2.0.0" },


### PR DESCRIPTION
## Summary
Update Python dependency pins from the merged Dependabot branches for FastAPI and LangChain.

## Changes
- Bump FastAPI constraints in the Python package lock state.
- Bump LangChain for the LangChain docs checkpoint example.