### PR TITLE
ci: build arm64 and amd64 images on main

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -154,6 +154,10 @@ jobs:
           show-global-summary-report: true
           ignore-no-report-found: true
 
+      - name: Set up QEMU
+        if: startsWith(matrix.job, 'image-') && github.ref == 'refs/heads/main'
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         if: startsWith(matrix.job, 'image-')
         uses: docker/setup-buildx-action@v3
@@ -172,6 +176,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ghcr.io/${{ github.repository_owner }}/memory-service:latest
           cache-from: type=gha,scope=image-memory-service
@@ -183,6 +188,7 @@ jobs:
         with:
           context: .
           file: java/quarkus/examples/chat-quarkus/Dockerfile
+          platforms: ${{ github.ref == 'refs/heads/main' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.ref == 'refs/heads/main' }}
           tags: ghcr.io/${{ github.repository_owner }}/memory-service-chat-quarkus:latest
           cache-from: type=gha,scope=image-chat-quarkus


### PR DESCRIPTION
## Summary
Update CI Docker image jobs so pull requests validate only the linux/amd64 image build without publishing, while main branch builds publish multi-platform manifests.

## Changes
- Add QEMU setup for main-branch Docker image jobs.
- Configure image builds to use linux/amd64 on PRs and linux/amd64,linux/arm64 on main pushes.
