### PR TITLE
fix: preserve attachment ids in history entries

### DIFF
--- a/internal/bdd/testdata/features/attachments-rest.feature
+++ b/internal/bdd/testdata/features/attachments-rest.feature
@@ -61,6 +61,7 @@ Feature: Attachments REST API
     }
     """
     Then the response status should be 201
+    And the response body field "content[0].attachments[0].attachmentId" should be "${uploadedAttachmentId}"
     And the response body field "content[0].attachments[0].href" should contain "/v1/attachments/"
 
   Scenario: History channel rejects attachment missing both href and attachmentId

--- a/internal/bdd/testdata/features/forked-attachments-rest.feature
+++ b/internal/bdd/testdata/features/forked-attachments-rest.feature
@@ -27,6 +27,7 @@ Feature: Forked Attachments REST API
     }
     """
     Then the response status should be 201
+    And the response body field "content[0].attachments[0].attachmentId" should be "${originalAttachmentId}"
     And the response body field "content[0].attachments[0].href" should contain "/v1/attachments/"
     # Fork the conversation
     When I list entries for the conversation
@@ -50,6 +51,7 @@ Feature: Forked Attachments REST API
     }
     """
     Then the response status should be 201
+    And the response body field "content[0].attachments[0].attachmentId" should be "${originalAttachmentId}"
     And the response body field "content[0].attachments[0].href" should contain "/v1/attachments/"
     # The href should use a NEW attachment ID (shared reference, not the original)
     And set "newAttachmentHref" to the json response field "content[0].attachments[0].href"

--- a/internal/plugin/route/entries/entries.go
+++ b/internal/plugin/route/entries/entries.go
@@ -577,8 +577,6 @@ func resolveAttachmentRefs(ctx context.Context, store registrystore.MemoryStore,
 				att["name"] = *attachment.Filename
 			}
 
-			// Remove attachmentId from the response content.
-			delete(att, "attachmentId")
 			attachments[ai] = att
 			modified = true
 		}


### PR DESCRIPTION
## Summary
Preserve attachment identifiers in history entry content while still backfilling normalized attachment metadata.

## Changes
- Keep `attachmentId` when resolving history entry attachment references in the Go API layer.
- Add BDD assertions for direct and forked attachment entry creation responses.
