### PR TITLE
feat(auth): allow self-signed oidc issuer certs

### DIFF
--- a/internal/FACTS.md
+++ b/internal/FACTS.md
@@ -33,6 +33,7 @@
 **Unix-socket listener validation**: Listener selection conflicts must use explicit flag/env detection (`cmd.IsSet(...)`), not non-zero resolved port values, otherwise the default port `8080` falsely conflicts with `--unix-socket`. When a Unix-socket parent directory is missing, the serve layer creates it as `0700`; if it already exists and is group/world accessible, startup must fail fast instead of chmod-ing it.
 
 **TLS self-signed certificate opt-in**: Omitting `MEMORY_SERVICE_TLS_CERT_FILE` and `MEMORY_SERVICE_TLS_KEY_FILE` only generates an ephemeral self-signed certificate when `MEMORY_SERVICE_TLS_SELF_SIGNED=true` / `--tls-self-signed` is set. Dev launch surfaces that enable TLS without cert files must set this explicitly.
+**OIDC self-signed issuer opt-in**: `MEMORY_SERVICE_OIDC_TLS_INSECURE_SKIP_VERIFY=true` / `--oidc-tls-insecure-skip-verify` only affects outbound OIDC discovery and JWKS fetches in `internal/security/auth.go`; it does not change listener TLS or general HTTP client behavior.
 
 **gRPC recorder disconnect cleanup**: In `ResponseRecorderServer.Record`, if the stream fails with gRPC/ctx `CANCELED` or `DEADLINE_EXCEEDED` after a recorder has been created, call `recorder.Complete()` before returning so the locator/cache registry entry for that conversation is removed.
 

--- a/internal/cmd/serve/serve.go
+++ b/internal/cmd/serve/serve.go
@@ -550,6 +550,13 @@ func authorizationFlags(cfg *config.Config) []cli.Flag {
 			Destination: &cfg.OIDCDiscoveryURL,
 			Usage:       "OIDC discovery URL (internal URL when issuer is not directly reachable)",
 		},
+		&cli.BoolFlag{
+			Name:        "oidc-tls-insecure-skip-verify",
+			Category:    "Authorization:",
+			Sources:     cli.EnvVars("MEMORY_SERVICE_OIDC_TLS_INSECURE_SKIP_VERIFY"),
+			Destination: &cfg.OIDCTLSSkipCertificateVerify,
+			Usage:       "Skip TLS certificate verification for OIDC discovery and JWKS requests (unsafe; for self-signed development issuers)",
+		},
 		&cli.StringFlag{
 			Name:        "roles-admin-oidc-role",
 			Category:    "Authorization:",

--- a/internal/cmd/serve/serve_test.go
+++ b/internal/cmd/serve/serve_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chirino/memory-service/internal/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -83,4 +84,18 @@ func TestLoadServerCertificate_SelfSigned(t *testing.T) {
 	cert, err := loadServerCertificate("", "", true)
 	require.NoError(t, err)
 	require.NotEmpty(t, cert.Certificate)
+}
+
+func TestFlagsIncludeOIDCTLSSkipVerify(t *testing.T) {
+	cfg := config.DefaultConfig()
+	flags := Flags(&cfg, NewFlagState(&cfg))
+
+	flagNames := make(map[string]bool, len(flags))
+	for _, flag := range flags {
+		for _, name := range flag.Names() {
+			flagNames[name] = true
+		}
+	}
+
+	require.True(t, flagNames["oidc-tls-insecure-skip-verify"])
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,8 +137,9 @@ type Config struct {
 	SearchFulltextEnabled bool
 
 	// OIDC
-	OIDCIssuer       string
-	OIDCDiscoveryURL string // Internal URL for OIDC discovery (when issuer URL is not reachable)
+	OIDCIssuer                   string
+	OIDCDiscoveryURL             string // Internal URL for OIDC discovery (when issuer URL is not reachable)
+	OIDCTLSSkipCertificateVerify bool   // Allow self-signed/untrusted certificates for OIDC discovery and JWKS requests.
 
 	// Prometheus
 	PrometheusURL string

--- a/internal/security/auth.go
+++ b/internal/security/auth.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -74,6 +75,13 @@ func NewTokenResolver(cfg *config.Config) *TokenResolver {
 
 	if oidcIssuer != "" {
 		ctx := context.Background()
+		if cfg.OIDCTLSSkipCertificateVerify {
+			transport := http.DefaultTransport.(*http.Transport).Clone()
+			transport.TLSClientConfig = &tls.Config{
+				InsecureSkipVerify: true, // #nosec G402 - explicitly enabled by OIDC TLS skip-verify config.
+			}
+			ctx = oidc.ClientContext(ctx, &http.Client{Transport: transport})
+		}
 		expectedIssuer := oidcIssuer // preserve the configured issuer for token validation
 		discoveryURL := cfg.OIDCDiscoveryURL
 		if discoveryURL != "" && discoveryURL != oidcIssuer {

--- a/internal/security/auth_test.go
+++ b/internal/security/auth_test.go
@@ -1,0 +1,35 @@
+package security
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/chirino/memory-service/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTokenResolverOIDCSelfSignedIssuerRequiresExplicitTLSBypass(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/.well-known/openid-configuration", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"issuer":   "https://example.invalid",
+			"jwks_uri": "https://example.invalid/certs",
+		})
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := config.DefaultConfig()
+	cfg.OIDCIssuer = "https://example.invalid"
+	cfg.OIDCDiscoveryURL = server.URL
+
+	resolver := NewTokenResolver(&cfg)
+	require.Nil(t, resolver.verifier)
+
+	cfg.OIDCTLSSkipCertificateVerify = true
+	resolver = NewTokenResolver(&cfg)
+	require.NotNil(t, resolver.verifier)
+}

--- a/site/src/pages/docs/configuration.mdx
+++ b/site/src/pages/docs/configuration.mdx
@@ -720,11 +720,21 @@ Authenticated agent/app clients can call `GET /v1/capabilities` or gRPC `SystemS
 
 Memory Service supports OIDC authentication via Keycloak or any compliant provider.
 
+| Flag                                                                                         | Values          | Default  | Description                                                                                                  |
+| -------------------------------------------------------------------------------------------- | --------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| <Cfg p="--oidc-issuer" e="MEMORY_SERVICE_OIDC_ISSUER" />                                     | URL             | _(none)_ | OIDC issuer URL; enables OIDC auth                                                                           |
+| <Cfg p="--oidc-discovery-url" e="MEMORY_SERVICE_OIDC_DISCOVERY_URL" />                       | URL             | _(none)_ | Internal discovery URL when the issuer URL is not directly reachable                                         |
+| <Cfg p="--oidc-tls-insecure-skip-verify" e="MEMORY_SERVICE_OIDC_TLS_INSECURE_SKIP_VERIFY" /> | `true`, `false` | `false`  | Skip TLS certificate verification for OIDC discovery and JWKS requests; use only for self-signed dev issuers |
+
 <ConfigBlock
   property={`# OIDC configuration
---oidc-issuer=http://localhost:8180/realms/memory-service`}
+--oidc-issuer=http://localhost:8180/realms/memory-service
+# Development/self-signed issuers only:
+--oidc-tls-insecure-skip-verify`}
   env={`# OIDC configuration
-MEMORY_SERVICE_OIDC_ISSUER=http://localhost:8180/realms/memory-service`}
+MEMORY_SERVICE_OIDC_ISSUER=http://localhost:8180/realms/memory-service
+# Development/self-signed issuers only:
+MEMORY_SERVICE_OIDC_TLS_INSECURE_SKIP_VERIFY=true`}
 />
 
 ## Admin Access Configuration

--- a/site/src/pages/docs/deployment/docker.mdx
+++ b/site/src/pages/docs/deployment/docker.mdx
@@ -118,10 +118,11 @@ With this configuration, attachment bytes are stored under `/data/memory-service
 
 ### Authentication
 
-| Variable                           | Description                | Default |
-| ---------------------------------- | -------------------------- | ------- |
-| `MEMORY_SERVICE_OIDC_ISSUER`       | OIDC issuer URL            | -       |
-| `MEMORY_SERVICE_API_KEYS_<CLIENT>` | API key(s) for a client ID | -       |
+| Variable                                       | Description                                                                                                       | Default |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------- |
+| `MEMORY_SERVICE_OIDC_ISSUER`                   | OIDC issuer URL                                                                                                   | -       |
+| `MEMORY_SERVICE_OIDC_TLS_INSECURE_SKIP_VERIFY` | Skip TLS certificate verification for OIDC discovery/JWKS requests; use only with self-signed development issuers | `false` |
+| `MEMORY_SERVICE_API_KEYS_<CLIENT>`             | API key(s) for a client ID                                                                                        | -       |
 
 ## Health Checks
 


### PR DESCRIPTION
## Summary
Adds an explicit OIDC TLS opt-in for development issuers that use self-signed or otherwise untrusted certificates.

## Changes
- Add `MEMORY_SERVICE_OIDC_TLS_INSECURE_SKIP_VERIFY` / `--oidc-tls-insecure-skip-verify` for OIDC discovery and JWKS requests
- Cover the new behavior and flag registration with focused Go tests
- Document the new option in configuration and Docker deployment docs
