### PR TITLE
ci: group dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
       timezone: "America/New_York"
     cooldown:
       default-days: 7
+    groups:
+      github-actions-dependencies:
+        patterns: ["*"]
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -75,7 +78,6 @@ updates:
     groups:
       npm-dependencies:
         patterns: ["*"]
-        group-by: "dependency-name"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -113,7 +115,6 @@ updates:
     groups:
       python-dependencies:
         patterns: ["*"]
-        group-by: "dependency-name"
     commit-message:
       prefix: "chore"
       include: "scope"
@@ -165,6 +166,9 @@ updates:
       timezone: "America/New_York"
     cooldown:
       default-days: 7
+    groups:
+      devcontainer-dependencies:
+        patterns: ["*"]
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Summary
Configure Dependabot to batch version updates more aggressively across the repository's configured ecosystems.

## Changes
- Add wildcard version update groups for GitHub Actions and devcontainer updates
- Collapse npm and uv version updates into ecosystem-level groups instead of per-dependency groups
