### PR TITLE
feat(compose): add cognition-processor component and clean up configuration

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -357,6 +357,58 @@ services:
       - "8080:8080"
 
   # ============================================================================
+  # Cognition Processor (optional). Run with:
+  #    docker compose --profile cognition up -d
+  # ============================================================================
+
+  cognition-processor:
+    profiles: ["cognition"]
+    image: quay.io/rigazilla/cognitive-memory:cd-latest
+    ports:
+      - "8090:8090"
+    environment:
+      # Quarkus runtime config
+      JAVA_OPTS_APPEND: >-
+        -Dquarkus.http.host=0.0.0.0
+        -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+        ${JAVA_UNSAFE_SSL:-}
+      QUARKUS_HTTP_PORT: "8090"
+      QUARKUS_LOG_CATEGORY__IO_GITHUB_RIGAZILLA_MEMORY__LEVEL: DEBUG
+      QUARKUS_LOG_CATEGORY__DEV_LANGCHAIN4J__LEVEL: DEBUG
+      QUARKUS_LOG_FILE_ENABLE: "false"
+
+      # Memory Service connection (use Docker network service name)
+      MEMORY_SERVICE_GRPC_HOST: memory-service
+      MEMORY_SERVICE_GRPC_PORT: "8080"
+      MEMORY_SERVICE_API_KEY: cognition-processor-key-123
+      MEMORY_SERVICE_CLIENT_ID: cognition_processor
+
+      # Worker identity
+      COGNITION_WORKER_ID: cognition_processor
+      COGNITION_RUNTIME_ID: cognition-processor-v1
+      COGNITION_RUNTIME_VERSION: 1.0.0-SNAPSHOT
+      COGNITION_CHECKPOINT_RESET_ON_STARTUP: "false"
+
+      # LLM configuration - memory model for extraction and verification
+      MEMORY_MODEL_PROVIDER: ${COGNITION_MEMORY_MODEL_PROVIDER}
+      OPENAI_BASE_URL: ${COGNITION_OPENAI_BASE_URL}
+      OPENAI_MODEL_NAME: ${COGNITION_OPENAI_MODEL}
+      OPENAI_API_KEY: ${COGNITION_OPENAI_API_KEY}
+
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      memory-service:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8090/q/health/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  # ============================================================================
   # Langfuse Observability Stack.  Run with:
   #    docker compose --profile langfuse up -d
   # ============================================================================

--- a/site/src/pages/docs/getting-started.md
+++ b/site/src/pages/docs/getting-started.md
@@ -51,12 +51,53 @@ This will start:
 - **MinIO** for S3-compatible object storage (used by the memory service for attachments)
 - **Prometheus** for metrics collection
 - **Grafana** for metrics dashboards
-- **Langfuse** for turn-trace observability, fed by the Memory Service turn-traces processor
+
+## Optional Services
+
+### Langfuse Observability
+
+Enable turn-trace observability and LLM monitoring with Langfuse:
+
+```bash
+docker compose --profile langfuse up -d
+```
 
 Langfuse is available at `http://localhost:3002` with:
 
 - Email: `memory-service@example.com`
 - Password: `memory-service`
+
+### Cognition Processor
+
+Enable intelligent memory extraction and organization using LLMs:
+
+```bash
+docker compose --profile cognition up -d
+```
+
+The cognition processor extracts structured memories (facts, preferences, topics) from conversations. Configure it by adding these variables to your `.env` file:
+
+| Variable                    | Description                            | Default                     |
+| --------------------------- | -------------------------------------- | --------------------------- |
+| `COGNITION_OPENAI_API_KEY`  | API key for the LLM endpoint           | _(required)_                |
+| `COGNITION_OPENAI_BASE_URL` | OpenAI-compatible LLM endpoint         | `https://api.openai.com/v1` |
+| `COGNITION_OPENAI_MODEL`    | Model name for extraction/verification | `llama3.2`                  |
+
+**Minimum configuration** (using defaults):
+
+```bash
+COGNITION_OPENAI_API_KEY=your-api-key-here
+```
+
+**Custom endpoint and model**:
+
+```bash
+COGNITION_OPENAI_API_KEY=your-api-key-here
+COGNITION_OPENAI_BASE_URL=https://api.openai.com/v1
+COGNITION_OPENAI_MODEL=gpt-4o
+```
+
+Learn more about the cognition layer in the [Memory Cognition](https://github.com/chirino/memory-service/blob/main/docs/memory-cognition.md) documentation.
 
 ### 4. Access the Demo Chat App
 


### PR DESCRIPTION
## Summary
Adds the **cognition-processor** component to `compose.yaml` as an optional profile and cleans up its configuration by removing redundant environment variables and delegating defaults to cognitive-memory's application.properties.

## What is the Cognition Processor?
The cognition processor is an optional component that processes conversation events to extract and organize structured memories (facts, preferences, topics, etc.) using LLMs. It runs as a separate service on top of the memory-service substrate.

Enable it with:
```bash
docker compose --profile cognition up -d
```

## Changes

### compose.yaml
- **Added cognition-processor service** under the `cognition` profile
- **Cleaned up environment variables**:
  - Removed redundant `DEFAULT_LLM_*` and `GEMINI_API_KEY` variables
  - Removed hardcoded defaults, delegating to cognitive-memory's `application.properties`
  - Kept only essential LLM config: `COGNITION_OPENAI_BASE_URL`, `COGNITION_OPENAI_MODEL`, `COGNITION_OPENAI_API_KEY`
  - Preserved `JAVA_UNSAFE_SSL` for internal/self-signed SSL endpoints

### site/src/pages/docs/getting-started.md
- **Added "Optional Services" section** documenting Docker Compose profiles:
  - Langfuse observability (`--profile langfuse`)
  - **Cognition Processor** (`--profile cognition`) - NEW
- **Documented cognition-processor configuration**:
  - Environment variables table with descriptions and defaults from cognitive-memory
  - Minimum configuration example (API key only)
  - Custom endpoint and model example
  - Link to Memory Cognition architecture documentation

## Benefits
- ✅ Users can now easily enable the cognition layer for intelligent memory extraction
- ✅ Cleaner, more maintainable configuration with single source of truth for defaults
- ✅ Clear documentation showing required vs. optional settings
- ✅ Consistent pattern with other optional services (Langfuse)