### PR TITLE
Make sure we can run in dev mode locally

### DIFF
--- a/deploy/dev/air.toml
+++ b/deploy/dev/air.toml
@@ -3,7 +3,7 @@ tmp_dir = "/tmp"
 [build]
   args_bin = []
   pre_cmd = []
-  cmd = "CGO_ENABLED=1 go build -tags \"sqlite_fts5 sqlite_json\" ${GO_BUILD_FLAGS} -ldflags=\"${GO_LD_FLAGS}\" -o ./bin/memory-service ."
+  cmd = "CGO_ENABLED=1 go build -tags \"sqlite_fts5 sqlite_json auth_testfixtures\" ${GO_BUILD_FLAGS} -ldflags=\"${GO_LD_FLAGS}\" -o ./bin/memory-service ."
   post_cmd = []
   full_bin = "TERM=dumb ${MEMORY_SERVICE_AIR_FULL_BIN:-dlv --check-go-version=false --continue --listen=:2345 --api-version=2 --only-same-user=false --headless --accept-multiclient exec -- ./bin/memory-service serve}"
   # full_bin = "./bin/memory-service serve"

--- a/internal/config/compat.go
+++ b/internal/config/compat.go
@@ -18,6 +18,7 @@ func (c *Config) ApplyJavaCompatFromEnv() error {
 	}
 
 	var err error
+	applyStringEnv("MEMORY_SERVICE_MODE", &c.Mode)
 	if err = applyBoolEnv("MEMORY_SERVICE_DB_MIGRATE_AT_START", &c.DatastoreMigrateAtStart); err != nil {
 		return err
 	}


### PR DESCRIPTION
I had to change this to run locally memory service + cognition + benchmark


Local setup

```bash

export MAVEN_OPTS="-Xmx8g"
cd ..
cd memory-service
MEMORY_SERVICE_OPENAI_API_KEY=$OPENAI_API_KEY \
  MEMORY_SERVICE_MODE=testing \
  MEMORY_SERVICE_ROLES_ADMIN_CLIENTS="admin,turn_traces_processor,cognition_processor" \
  MEMORY_SERVICE_ROLES_INDEXER_CLIENTS="agent,cognition_processor" \
  MEMORY_SERVICE_API_KEYS_COGNITION_PROCESSOR=cognition-processor-key-123 \
  MEMORY_SERVICE_AIR_FULL_BIN="./bin/memory-service serve" \
  MEMORY_SERVICE_OIDC_ISSUER="" \
  MEMORY_SERVICE_OIDC_DISCOVERY_URL="" \
  COGNITION_MEMORY_MODEL_PROVIDER=openai \
  COGNITION_OPENAI_BASE_URL=https://api.openai.com/v1 \
  COGNITION_OPENAI_MODEL=gpt-4o-mini \
  COGNITION_OPENAI_API_KEY=$OPENAI_API_KEY \
  task dev:memory-service
```
```bash
export MAVEN_OPTS="-Xmx10g"
cd ..
cd cognitive-memory/cognition-processor-quarkus
MEMORY_SERVICE_API_KEY=cognition-processor-key-123 \
  MEMORY_MODEL_PROVIDER=openai \
  MEMORY_MODEL_ID=gpt-4o-mini \
  OPENAI_BASE_URL=https://api.openai.com/v1 \
  OPENAI_MODEL_NAME=gpt-4o-mini \
  OPENAI_API_KEY=$OPENAI_API_KEY \
  ./mvnw quarkus:dev
```
