### PR TITLE
fix: auto-detect embedding dimension for models without matryoshka support

### DIFF
--- a/internal/cmd/serve/server.go
+++ b/internal/cmd/serve/server.go
@@ -83,6 +83,28 @@ func BuildServer(ctx context.Context, cfg *config.Config) (*Server, error) {
 	}
 	security.InitMetrics(metricsLabels)
 
+	// Initialize embedder early so vector store migrations can use the detected dimension
+	var embedder registryembed.Embedder
+	if cfg.SearchSemanticEnabled && cfg.EmbedType != "" && cfg.EmbedType != "none" {
+		embedLoader, err := registryembed.Select(cfg.EmbedType)
+		if err != nil {
+			log.Warn("Embedder not available", "err", err)
+		} else {
+			embedder, err = embedLoader(ctx)
+			if err != nil {
+				log.Warn("Failed to initialize embedder", "err", err)
+			} else if embedder != nil {
+				// Update config with detected dimension for vector store initialization
+				if cfg.OpenAIDimensions <= 0 {
+					cfg.OpenAIDimensions = embedder.Dimension()
+					log.Info("Auto-detected embedding dimension", "dimension", cfg.OpenAIDimensions)
+					// Update the context with the modified config so migrations see the detected dimension
+					ctx = config.WithContext(ctx, cfg)
+				}
+			}
+		}
+	}
+
 	// Run migrations
 	if err := registrymigrate.RunAll(ctx); err != nil {
 		return nil, fmt.Errorf("migrations failed: %w", err)
@@ -201,22 +223,11 @@ func BuildServer(ctx context.Context, cfg *config.Config) (*Server, error) {
 		}
 	}
 
-	// Initialize embedder and vector store (optional, for semantic search)
-	var embedder registryembed.Embedder
+	// Initialize vector store (optional, for semantic search)
+	// Note: embedder was already initialized earlier before migrations
 	var vectorStore registryvector.VectorStore
 	if cfg.VectorType == "sqlite" && cfg.DatastoreType != "sqlite" {
 		return nil, fmt.Errorf("vector-kind=%q requires db-kind=sqlite", cfg.VectorType)
-	}
-	if cfg.SearchSemanticEnabled && cfg.EmbedType != "" && cfg.EmbedType != "none" {
-		embedLoader, err := registryembed.Select(cfg.EmbedType)
-		if err != nil {
-			log.Warn("Embedder not available", "err", err)
-		} else {
-			embedder, err = embedLoader(ctx)
-			if err != nil {
-				log.Warn("Failed to initialize embedder", "err", err)
-			}
-		}
 	}
 	if cfg.SearchSemanticEnabled && cfg.VectorType != "" && cfg.VectorType != "none" {
 		if embedder == nil {

--- a/internal/plugin/embed/openai/openai.go
+++ b/internal/plugin/embed/openai/openai.go
@@ -39,17 +39,28 @@ func load(ctx context.Context) (registryembed.Embedder, error) {
 	if cfg == nil || cfg.OpenAIAPIKey == "" {
 		return nil, fmt.Errorf("openai embedder: MEMORY_SERVICE_OPENAI_API_KEY is required")
 	}
-	dim := cfg.OpenAIDimensions
-	if dim <= 0 && strings.EqualFold(cfg.OpenAIModelName, "text-embedding-3-small") {
-		dim = 1536
-	}
-	return &OpenAIEmbedder{
+
+	embedder := &OpenAIEmbedder{
 		apiKey:     cfg.OpenAIAPIKey,
 		model:      cfg.OpenAIModelName,
 		baseURL:    strings.TrimRight(cfg.OpenAIBaseURL, "/"),
 		dimensions: cfg.OpenAIDimensions,
-		defaultDim: dim,
-	}, nil
+		defaultDim: cfg.OpenAIDimensions,
+	}
+
+	// If dimensions not configured, auto-detect by doing a test embedding
+	if cfg.OpenAIDimensions <= 0 {
+		embeddings, err := embedder.EmbedTexts(ctx, []string{"test"})
+		if err != nil {
+			// If auto-detect fails, fall back to a common default (1536)
+			// This allows the service to start even when the embedding API is unreachable
+			embedder.defaultDim = 1536
+		} else if len(embeddings) > 0 && len(embeddings[0]) > 0 {
+			embedder.defaultDim = len(embeddings[0])
+		}
+	}
+
+	return embedder, nil
 }
 
 type OpenAIEmbedder struct {

--- a/internal/plugin/vector/qdrant/qdrant.go
+++ b/internal/plugin/vector/qdrant/qdrant.go
@@ -265,8 +265,10 @@ func effectiveEmbeddingDimension(cfg *config.Config) uint64 {
 		return 1536
 	}
 	if cfg.OpenAIDimensions > 0 {
+		log.Info("Qdrant using explicit dimension", "dimension", cfg.OpenAIDimensions)
 		return uint64(cfg.OpenAIDimensions)
 	}
+	log.Info("Qdrant using default dimension", "embedType", cfg.EmbedType, "defaultDim", 1536)
 	switch strings.ToLower(strings.TrimSpace(cfg.EmbedType)) {
 	case "local":
 		return 384


### PR DESCRIPTION
## Problem

Models like `nomic-ai/nomic-embed-text-v1.5` reject any `dimensions` parameter in the API request, even when set to their native dimension (768). This caused a catch-22:

- Setting `MEMORY_SERVICE_EMBEDDING_OPENAI_DIMENSIONS=0` → API works, but Qdrant defaults to 1536 → **dimension mismatch error**
- Setting `MEMORY_SERVICE_EMBEDDING_OPENAI_DIMENSIONS=768` → API rejects with **"does not support matryoshka representation" error**

## Solution

When `MEMORY_SERVICE_EMBEDDING_OPENAI_DIMENSIONS` is 0 or empty:

1. Initialize embedder **before** migrations (not after)
2. Auto-detect actual dimension via test embedding (no dimensions param sent)
3. Update config with detected dimension
4. Update context so migrations see the detected value
5. Qdrant migration creates collection with correct dimension

## Changes

- `internal/plugin/embed/openai/openai.go`: Auto-detect dimension when set to 0
- `internal/cmd/serve/server.go`: Initialize embedder before migrations and update context with detected dimension
- `internal/plugin/vector/qdrant/qdrant.go`: Add debug logging for dimension selection

## Backward Compatibility

✅ Explicit dimensions (e.g., 1536 for text-embedding-3-small) still work as before
✅ Auto-detection only activates when `DIMENSIONS=0` or empty
✅ Works with any embedding model (nomic-embed, text-embedding-3-*, custom models)

## Testing

Tested with `nomic-ai/nomic-embed-text-v1.5`:
- ✅ Auto-detected dimension: 768
- ✅ Qdrant collection created: `memory-service_nomic-ai-nomic-embed-text-v1.5-768`
- ✅ No matryoshka or dimension mismatch errors
- ✅ Memory search/indexing working correctly

## Benefits

Makes the system **self-configuring** - no need to manually specify dimensions when switching between embedding models. Just set `MEMORY_SERVICE_EMBEDDING_OPENAI_DIMENSIONS=0` and the system auto-detects the correct dimension from the API response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)