### PR TITLE
feat(quarkus): add selective chat memory mode

### DIFF
--- a/java/quarkus/FACTS.md
+++ b/java/quarkus/FACTS.md
@@ -2,7 +2,9 @@
 
 **AI service direct-call test**: `examples/doc-checkpoints/02-with-memory` has an `@QuarkusTest` that injects the generated `@RegisterAiService` `Agent`, calls it directly with a memory id, and points the real LangChain4j OpenAI client at a local OpenAI-compatible mock endpoint.
 
-**Configurable chat memory store**: The Quarkus extension registers the Memory Service-backed LangChain4j `ChatMemoryStore` when `memory-service.chat-memory.kind=memory-service` or is unset. Set `memory-service.chat-memory.kind=in-memory` to skip that extension bean and let Quarkiverse LangChain4j use its local in-memory store, avoiding Memory Service Dev Services.
+**Configurable chat memory store**: The Quarkus extension supports two modes via `memory-service.chat-memory.enabled` (default `true`). Global mode (`enabled=true`) registers `MemoryServiceChatMemoryStore` as the CDI `ChatMemoryStore` bean, overriding Quarkiverse's `InMemoryChatMemoryStore` for all `@RegisterAiService` agents. Selective mode (`enabled=false`) leaves Quarkiverse's default in place; individual agents opt in via `@RegisterAiService(chatMemoryProviderSupplier = MemoryService.class)`. The old `memory-service.chat-memory.kind` property is removed.
+
+**`MemoryService` indexing**: `ChatMemoryProcessor` emits an `AdditionalIndexedClassesBuildItem` so the Quarkiverse `AiServicesProcessor` can find `MemoryService` in the combined Jandex index, register it for reflection, and mark it unremovable when it appears as a `chatMemoryProviderSupplier`.
 
 **Standalone Keycloak tests**: Standalone Quarkus checkpoint tests that use `quarkus-test-keycloak-server` must set `keycloak.version` themselves; for Quarkus `3.35.4`, use Keycloak `26.5.7` from the Quarkus build parent. Older `24.0.5` starts but returns null admin/user tokens with the 3.35 test helper.
 

--- a/java/quarkus/examples/doc-checkpoints/02-with-memory/src/main/java/org/acme/NoMemoryAgent.java
+++ b/java/quarkus/examples/doc-checkpoints/02-with-memory/src/main/java/org/acme/NoMemoryAgent.java
@@ -1,0 +1,14 @@
+package org.acme;
+
+import io.quarkiverse.langchain4j.RegisterAiService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * An agent that explicitly opts out of all chat memory.
+ */
+@ApplicationScoped
+@RegisterAiService(
+        chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+public interface NoMemoryAgent {
+    String chat(String userMessage);
+}

--- a/java/quarkus/examples/doc-checkpoints/02-with-memory/src/main/java/org/acme/SelectiveAgent.java
+++ b/java/quarkus/examples/doc-checkpoints/02-with-memory/src/main/java/org/acme/SelectiveAgent.java
@@ -1,0 +1,16 @@
+package org.acme;
+
+import dev.langchain4j.service.MemoryId;
+import io.github.chirino.memory.langchain4j.MemoryService;
+import io.quarkiverse.langchain4j.RegisterAiService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * An agent that explicitly opts into Memory Service-backed chat memory.
+ * Works even when {@code memory-service.chat-memory.enabled=false} (selective mode).
+ */
+@ApplicationScoped
+@RegisterAiService(chatMemoryProviderSupplier = MemoryService.class)
+public interface SelectiveAgent {
+    String chat(@MemoryId String conversationId, String userMessage);
+}

--- a/java/quarkus/examples/doc-checkpoints/02-with-memory/src/test/java/org/acme/AgentAiServiceTest.java
+++ b/java/quarkus/examples/doc-checkpoints/02-with-memory/src/test/java/org/acme/AgentAiServiceTest.java
@@ -1,23 +1,123 @@
 package org.acme;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.store.memory.chat.ChatMemoryStore;
+import dev.langchain4j.store.memory.chat.InMemoryChatMemoryStore;
+import io.github.chirino.memory.langchain4j.MemoryService;
+import io.github.chirino.memory.langchain4j.MemoryServiceChatMemoryStore;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
+import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Tests for the two chat-memory modes supported by the memory-service extension:
+ *
+ * <ul>
+ *   <li>Global mode ({@code memory-service.chat-memory.enabled=true}): every
+ *       {@code @RegisterAiService} uses Memory Service-backed chat memory by default.
+ *   <li>Selective mode ({@code memory-service.chat-memory.enabled=false}): Quarkiverse keeps its
+ *       default in-memory store; individual agents opt in via {@code chatMemoryProviderSupplier =
+ *       MemoryService.class}.
+ * </ul>
+ */
 @QuarkusTest
 @QuarkusTestResource(MockOpenAiTestResource.class)
+// Default test profile uses memory-service.chat-memory.enabled=false (see
+// test/resources/application.properties)
 class AgentAiServiceTest {
 
     @Inject Agent agent;
+    @Inject SelectiveAgent selectiveAgent;
+    @Inject NoMemoryAgent noMemoryAgent;
+    @Inject ChatMemoryStore chatMemoryStore;
+    @Inject MemoryService memoryService;
 
+    /**
+     * When {@code memory-service.chat-memory.enabled=false} (selective mode), the global CDI
+     * {@link ChatMemoryStore} bean should be Quarkiverse's default {@link InMemoryChatMemoryStore}.
+     */
     @Test
-    void testAgentRequest() {
-        String result = agent.chat(UUID.randomUUID().toString(), "hi");
+    void testDisabledMode_globalStoreIsInMemory() {
+        assertInstanceOf(
+                InMemoryChatMemoryStore.class,
+                chatMemoryStore,
+                "With enabled=false, global ChatMemoryStore should be InMemoryChatMemoryStore");
+    }
 
+    /**
+     * Plain {@code @RegisterAiService} (no explicit {@code chatMemoryProviderSupplier}) uses the
+     * global store, which is in-memory when {@code enabled=false}.
+     */
+    @Test
+    void testDisabledMode_plainAgentUsesInMemoryStore() {
+        String result = agent.chat(UUID.randomUUID().toString(), "hi");
         assertEquals("test-response", result);
+    }
+
+    /**
+     * {@code @RegisterAiService(chatMemoryProviderSupplier = MemoryService.class)} opts into
+     * Memory Service-backed memory even when the global mode is disabled. The {@link MemoryService}
+     * bean must be injectable and its {@link MemoryService#get()} must return a non-null provider.
+     */
+    @Test
+    void testSelectiveMode_memoryServiceSupplierIsInjectable() {
+        assertNotNull(memoryService, "MemoryService CDI bean must be injectable");
+        ChatMemoryProvider provider = memoryService.get();
+        assertNotNull(provider, "MemoryService.get() must return a non-null ChatMemoryProvider");
+    }
+
+    /**
+     * {@code @RegisterAiService(chatMemoryProviderSupplier = NoChatMemoryProviderSupplier.class)}
+     * agents must still respond without any memory.
+     */
+    @Test
+    void testNoMemoryAgent_respondsWithoutMemory() {
+        String result = noMemoryAgent.chat("hi");
+        assertEquals("test-response", result);
+    }
+}
+
+/**
+ * Separate test class that enables global mode ({@code memory-service.chat-memory.enabled=true})
+ * and verifies the {@link MemoryServiceChatMemoryStore} becomes the active CDI
+ * {@link ChatMemoryStore} bean.
+ */
+@QuarkusTest
+@TestProfile(GlobalMemoryModeTest.GlobalMemoryProfile.class)
+@QuarkusTestResource(MockOpenAiTestResource.class)
+class GlobalMemoryModeTest {
+
+    public static class GlobalMemoryProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "memory-service.chat-memory.enabled", "true",
+                    // Point to a non-existent URL so startup succeeds but actual calls would fail
+                    // fast
+                    "memory-service.client.url", "http://localhost:19999");
+        }
+    }
+
+    @Inject ChatMemoryStore chatMemoryStore;
+
+    /**
+     * When {@code memory-service.chat-memory.enabled=true}, the global {@link ChatMemoryStore}
+     * bean should be the {@link MemoryServiceChatMemoryStore}.
+     */
+    @Test
+    void testEnabledMode_globalStoreIsMemoryService() {
+        assertInstanceOf(
+                MemoryServiceChatMemoryStore.class,
+                chatMemoryStore,
+                "With enabled=true, global ChatMemoryStore should be MemoryServiceChatMemoryStore");
     }
 }

--- a/java/quarkus/examples/doc-checkpoints/02-with-memory/src/test/resources/application.properties
+++ b/java/quarkus/examples/doc-checkpoints/02-with-memory/src/test/resources/application.properties
@@ -1,2 +1,2 @@
 quarkus.langchain4j.openai.api-key=test-openai-key
-memory-service.chat-memory.kind=in-memory
+memory-service.chat-memory.enabled=false

--- a/java/quarkus/memory-service-extension/deployment/src/main/java/io/github/chirino/memory/deployment/ChatMemoryProcessor.java
+++ b/java/quarkus/memory-service-extension/deployment/src/main/java/io/github/chirino/memory/deployment/ChatMemoryProcessor.java
@@ -3,52 +3,52 @@ package io.github.chirino.memory.deployment;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.AdditionalIndexedClassesBuildItem;
 import org.eclipse.microprofile.config.ConfigProvider;
 
 public class ChatMemoryProcessor {
 
-    private static final String CHAT_MEMORY_KIND = "memory-service.chat-memory.kind";
-    private static final String MEMORY_SERVICE_KIND = "memory-service";
-    private static final String IN_MEMORY_KIND = "in-memory";
+    private static final String CHAT_MEMORY_ENABLED = "memory-service.chat-memory.enabled";
 
     @BuildStep
     void registerBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
-        switch (chatMemoryKind()) {
-            case MEMORY_SERVICE_KIND ->
-                    additionalBeans.produce(
-                            AdditionalBeanBuildItem.builder()
-                                    .setUnremovable()
-                                    .addBeanClasses(
-                                            // We can replace MemoryServiceChatMemoryProvider once
-                                            // langchain4j picks up:
-                                            // https://github.com/langchain4j/langchain4j/pull/4416
-                                            "io.github.chirino.memory.langchain4j.MemoryServiceChatMemoryStore"
-                                            // "io.github.chirino.memory.langchain4j.MemoryServiceChatMemoryProvider"
-                                            )
-                                    .build());
-            case IN_MEMORY_KIND -> {
-                // Quarkiverse LangChain4j provides the in-memory ChatMemoryStore.
-            }
-            default ->
-                    throw new IllegalArgumentException(
-                            CHAT_MEMORY_KIND
-                                    + " must be either '"
-                                    + MEMORY_SERVICE_KIND
-                                    + "' or '"
-                                    + IN_MEMORY_KIND
-                                    + "'");
+        if (chatMemoryEnabled()) {
+            additionalBeans.produce(
+                    AdditionalBeanBuildItem.builder()
+                            .setUnremovable()
+                            .addBeanClasses(
+                                    // We can replace MemoryServiceChatMemoryProvider once
+                                    // langchain4j picks up:
+                                    // https://github.com/langchain4j/langchain4j/pull/4416
+                                    "io.github.chirino.memory.langchain4j.MemoryServiceChatMemoryStore"
+                                    // "io.github.chirino.memory.langchain4j.MemoryServiceChatMemoryProvider"
+                                    )
+                            .build());
         }
+        // Always register the factory and supplier so MemoryService can be used as a
+        // chatMemoryProviderSupplier even when the global store is disabled.
+        additionalBeans.produce(
+                AdditionalBeanBuildItem.builder()
+                        .setUnremovable()
+                        .addBeanClasses(
+                                "io.github.chirino.memory.langchain4j.MemoryServiceChatMemoryStoreFactory",
+                                "io.github.chirino.memory.langchain4j.MemoryService")
+                        .build());
     }
 
-    private static String chatMemoryKind() {
+    @BuildStep
+    AdditionalIndexedClassesBuildItem indexSupplierClasses() {
+        return new AdditionalIndexedClassesBuildItem(
+                "io.github.chirino.memory.langchain4j.MemoryService");
+    }
+
+    private static boolean chatMemoryEnabled() {
         try {
             return ConfigProvider.getConfig()
-                    .getOptionalValue(CHAT_MEMORY_KIND, String.class)
-                    .map(value -> value.trim().toLowerCase())
-                    .filter(value -> !value.isEmpty())
-                    .orElse(MEMORY_SERVICE_KIND);
+                    .getOptionalValue(CHAT_MEMORY_ENABLED, Boolean.class)
+                    .orElse(true);
         } catch (IllegalStateException e) {
-            return MEMORY_SERVICE_KIND;
+            return true;
         }
     }
 }

--- a/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryService.java
+++ b/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryService.java
@@ -1,0 +1,56 @@
+package io.github.chirino.memory.langchain4j;
+
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.function.Supplier;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+/**
+ * A {@link Supplier} of {@link ChatMemoryProvider} backed by the Memory Service.
+ *
+ * <p>Use this as the {@code chatMemoryProviderSupplier} on a specific {@code @RegisterAiService}
+ * when the global chat memory store is disabled ({@code memory-service.chat-memory.enabled=false})
+ * but you want selected agents to use durable Memory Service-backed chat memory:
+ *
+ * <pre>{@code
+ * @RegisterAiService(chatMemoryProviderSupplier = MemoryService.class)
+ * public interface DurableAgent {
+ *     String chat(@MemoryId String conversationId, String message);
+ * }
+ * }</pre>
+ */
+@ApplicationScoped
+public class MemoryService implements Supplier<ChatMemoryProvider> {
+
+    private final MemoryServiceChatMemoryStoreFactory storeFactory;
+    private final int maxMessages;
+
+    @Inject
+    public MemoryService(
+            MemoryServiceChatMemoryStoreFactory storeFactory,
+            @ConfigProperty(
+                            name = "quarkus.langchain4j.chat-memory.memory-window.max-messages",
+                            defaultValue = "10")
+                    int maxMessages) {
+        this.storeFactory = storeFactory;
+        this.maxMessages = maxMessages;
+    }
+
+    @Override
+    public ChatMemoryProvider get() {
+        MemoryServiceChatMemoryStore store = storeFactory.get();
+        return new ChatMemoryProvider() {
+            @Override
+            public ChatMemory get(Object memoryId) {
+                return MessageWindowChatMemory.builder()
+                        .maxMessages(maxMessages)
+                        .id(memoryId)
+                        .chatMemoryStore(store)
+                        .build();
+            }
+        };
+    }
+}

--- a/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryServiceChatMemoryStoreFactory.java
+++ b/java/quarkus/memory-service-extension/runtime/src/main/java/io/github/chirino/memory/langchain4j/MemoryServiceChatMemoryStoreFactory.java
@@ -1,0 +1,34 @@
+package io.github.chirino.memory.langchain4j;
+
+import io.github.chirino.memory.runtime.MemoryServiceApiBuilder;
+import io.quarkus.security.identity.SecurityIdentity;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import java.util.function.Supplier;
+
+/**
+ * Produces a {@link MemoryServiceChatMemoryStore} instance. Registered as a CDI bean regardless of
+ * whether the global chat-memory store is enabled, so that {@link MemoryService} (and any other
+ * component that needs a store reference) can inject it without being affected by the
+ * {@code memory-service.chat-memory.enabled} toggle.
+ */
+@ApplicationScoped
+public class MemoryServiceChatMemoryStoreFactory implements Supplier<MemoryServiceChatMemoryStore> {
+
+    private final MemoryServiceApiBuilder apiBuilder;
+    private final Instance<SecurityIdentity> securityIdentityInstance;
+
+    @Inject
+    public MemoryServiceChatMemoryStoreFactory(
+            MemoryServiceApiBuilder apiBuilder,
+            Instance<SecurityIdentity> securityIdentityInstance) {
+        this.apiBuilder = apiBuilder;
+        this.securityIdentityInstance = securityIdentityInstance;
+    }
+
+    @Override
+    public MemoryServiceChatMemoryStore get() {
+        return new MemoryServiceChatMemoryStore(apiBuilder, securityIdentityInstance);
+    }
+}

--- a/site/src/pages/docs/quarkus/getting-started.mdx
+++ b/site/src/pages/docs/quarkus/getting-started.mdx
@@ -225,6 +225,107 @@ If you browse to the demo agent app at [http://localhost:8080/](http://localhost
 But it won't show any messages. That's because we are not yet storing what we call the history of the conversation. The only thing being stored is the agent memory, and
 that's not typically what you want to display to a user in a UI.
 
+## Chat Memory Modes
+
+The extension supports two modes for chat memory, controlled by `memory-service.chat-memory.enabled`.
+
+### Global mode (default)
+
+When `memory-service.chat-memory.enabled=true` (the default), the extension registers `MemoryServiceChatMemoryStore` as the active CDI `ChatMemoryStore` bean. Every `@RegisterAiService` agent automatically uses it — no per-agent annotation is needed.
+
+```properties
+# application.properties — this is the default, no property required
+memory-service.chat-memory.enabled=true
+```
+
+```java
+@ApplicationScoped
+@RegisterAiService
+public interface Agent {
+    String chat(@MemoryId String conversationId, String userMessage);
+}
+```
+
+### Selective mode
+
+Set `memory-service.chat-memory.enabled=false` to leave Quarkiverse's default `InMemoryChatMemoryStore` in place. Individual agents opt into durable Memory Service-backed memory by setting `chatMemoryProviderSupplier = MemoryService.class`.
+
+```properties
+# application.properties
+memory-service.chat-memory.enabled=false
+```
+
+```java
+import io.github.chirino.memory.langchain4j.MemoryService;
+
+// This agent uses Memory Service-backed memory
+@ApplicationScoped
+@RegisterAiService(chatMemoryProviderSupplier = MemoryService.class)
+public interface DurableAgent {
+    String chat(@MemoryId String conversationId, String userMessage);
+}
+
+// This agent uses Quarkiverse's default InMemoryChatMemoryStore
+@ApplicationScoped
+@RegisterAiService
+public interface ScratchAgent {
+    String chat(String userMessage);
+}
+```
+
+### Custom supplier
+
+You can also supply your own `ChatMemoryProvider` for full control — wrapping `MemoryServiceChatMemoryStore` with compression, a custom window size, or any other logic. Implement `Supplier<ChatMemoryProvider>`, annotate it as a CDI bean, and reference the class in `chatMemoryProviderSupplier`.
+
+Inject `MemoryServiceChatMemoryStore` directly when global mode is enabled (the store is a registered CDI bean), or inject `MemoryServiceChatMemoryStoreFactory` when you need the store available regardless of the `enabled` flag:
+
+```java
+import dev.langchain4j.memory.ChatMemory;
+import dev.langchain4j.memory.chat.ChatMemoryProvider;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
+import io.github.chirino.memory.langchain4j.MemoryServiceChatMemoryStore;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import java.util.function.Supplier;
+
+@ApplicationScoped
+public class CompressingMemorySupplier implements Supplier<ChatMemoryProvider> {
+
+    @Inject MemoryServiceChatMemoryStore store;
+
+    @Override
+    public ChatMemoryProvider get() {
+        return memoryId -> MessageWindowChatMemory.builder()
+                .maxMessages(50)
+                .id(memoryId)
+                .chatMemoryStore(store)
+                .build();
+    }
+}
+```
+
+```java
+@ApplicationScoped
+@RegisterAiService(chatMemoryProviderSupplier = CompressingMemorySupplier.class)
+public interface Agent {
+    String chat(@MemoryId String conversationId, String userMessage);
+}
+```
+
+> **Note:** `MemoryServiceChatMemoryStore` is only a CDI bean when `memory-service.chat-memory.enabled=true` (the default). If you use selective mode (`enabled=false`), inject `MemoryServiceChatMemoryStoreFactory` instead — it is always registered — and call `storeFactory.get()` to obtain the store.
+
+### No memory
+
+Any agent can opt out of chat memory entirely with `NoChatMemoryProviderSupplier`, regardless of the global mode:
+
+```java
+@ApplicationScoped
+@RegisterAiService(chatMemoryProviderSupplier = RegisterAiService.NoChatMemoryProviderSupplier.class)
+public interface StatelessAgent {
+    String summarize(String text);
+}
+```
+
 ## Next Steps
 
 Continue to [Conversation History](/docs/quarkus/conversation-history/) to learn how to:


### PR DESCRIPTION
## Summary
Add a selective chat memory mode for the Quarkus extension so apps can keep Quarkiverse's default in-memory store globally while opting individual agents into Memory Service-backed memory.

## Changes
- Replace the old chat-memory kind selector with a boolean enabled flag and register a reusable MemoryService supplier/factory path.
- Add checkpoint agents and tests for global, selective, and no-memory modes.
- Document the new modes and update Quarkus module facts.