### PR TITLE
ci: configure release tag git identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,6 +343,8 @@ jobs:
             echo "Tag $TAG already exists"
             exit 0
           fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
 


### PR DESCRIPTION
## Summary
Configure the release finalization job with a Git author identity before creating the annotated release tag.

## Changes
- Add GitHub Actions bot `user.name` and `user.email` setup in the `finish` job
- Preserve the existing annotated tag and push flow for release tags
