### PR TITLE
feat(auth): support local authentication over unix sockets

### DIFF
--- a/docs/enhancements/implemented/077-unix-socket-listener-support.md
+++ b/docs/enhancements/implemented/077-unix-socket-listener-support.md
@@ -73,6 +73,19 @@ Add new flags and env vars:
 | Main | `--unix-socket` | `MEMORY_SERVICE_UNIX_SOCKET` | Absolute path to the main HTTP/gRPC Unix socket |
 | Management | `--management-unix-socket` | `MEMORY_SERVICE_MANAGEMENT_UNIX_SOCKET` | Absolute path to the dedicated management Unix socket |
 
+The main listener also supports trusted local authentication with
+`--unix-socket-auth=local` (`MEMORY_SERVICE_UNIX_SOCKET_AUTH=local`). This mode is
+accepted only when the API listener uses `--unix-socket`; it cannot be combined
+with a TCP API listener. Requests are authenticated as `--local-user-id` (the
+current OS username by default) and `--local-client-id` (`local-agent` by default)
+for both REST and gRPC. The identity receives no roles unless the normal role
+configuration explicitly grants them.
+
+Socket permissions are the authentication boundary in local mode. Any process
+running as the Unix user that owns and can access the socket is trusted as the
+configured local principal. Use the default `credentials` mode when processes
+running as that user must remain isolated from one another.
+
 Validation rules:
 
 1. `--port` and `--unix-socket` are mutually exclusive for the same listener when both are explicitly provided by the user via CLI flag or env var.

--- a/internal/FACTS.md
+++ b/internal/FACTS.md
@@ -34,6 +34,8 @@
 **Wrapper auth middleware gotcha**: Wrapper-native endpoints must run auth (and for memories, client-id) as wrapper middlewares in `internal/cmd/serve/wrapper_routes.go`; otherwise role checks can fail even when tokens are valid.
 **Unix-socket listener validation**: Listener selection conflicts must use explicit flag/env detection (`cmd.IsSet(...)`), not non-zero resolved port values, otherwise the default port `8080` falsely conflicts with `--unix-socket`. When a Unix-socket parent directory is missing, the serve layer creates it as `0700`; if it already exists and is group/world accessible, startup must fail fast instead of chmod-ing it.
 
+**Unix-socket local auth boundary**: `--unix-socket-auth=local` is valid only with an exclusive main UDS listener. It supplies the same configured local user/client identity to REST and gRPC without credentials; management listener selection does not broaden the API transport. Any process able to access the socket as its owning Unix user is inside this trust boundary.
+
 **TLS self-signed certificate opt-in**: Omitting `MEMORY_SERVICE_TLS_CERT_FILE` and `MEMORY_SERVICE_TLS_KEY_FILE` only generates an ephemeral self-signed certificate when `MEMORY_SERVICE_TLS_SELF_SIGNED=true` / `--tls-self-signed` is set. Dev launch surfaces that enable TLS without cert files must set this explicitly.
 **OIDC self-signed issuer opt-in**: `MEMORY_SERVICE_OIDC_TLS_INSECURE_SKIP_VERIFY=true` / `--oidc-tls-insecure-skip-verify` only affects outbound OIDC discovery and JWKS fetches in `internal/security/auth.go`; it does not change listener TLS or general HTTP client behavior.
 

--- a/internal/cmd/serve/listener_test.go
+++ b/internal/cmd/serve/listener_test.go
@@ -5,9 +5,11 @@ package serve
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
+	"os/user"
 	"path/filepath"
 	"testing"
 	"time"
@@ -20,6 +22,39 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+func TestResolveUnixSocketAuth(t *testing.T) {
+	t.Run("rejects local auth on TCP", func(t *testing.T) {
+		cfg := config.DefaultConfig()
+		cfg.UnixSocketAuth = "local"
+		err := resolveUnixSocketAuth(&cfg)
+		require.EqualError(t, err, "--unix-socket-auth=local requires the API to be exposed exclusively through --unix-socket")
+	})
+
+	t.Run("defaults local identity", func(t *testing.T) {
+		original := currentOSUser
+		currentOSUser = func() (*user.User, error) { return &user.User{Username: "socket-owner"}, nil }
+		defer func() { currentOSUser = original }()
+		cfg := config.DefaultConfig()
+		cfg.Listener.UnixSocket = "/tmp/memory-service.sock"
+		cfg.UnixSocketAuth = "local"
+		cfg.LocalClientID = ""
+		require.NoError(t, resolveUnixSocketAuth(&cfg))
+		require.Equal(t, "socket-owner", cfg.LocalUserID)
+		require.Equal(t, "local-agent", cfg.LocalClientID)
+	})
+
+	t.Run("requires resolvable username", func(t *testing.T) {
+		original := currentOSUser
+		currentOSUser = func() (*user.User, error) { return nil, fmt.Errorf("unknown user") }
+		defer func() { currentOSUser = original }()
+		cfg := config.DefaultConfig()
+		cfg.Listener.UnixSocket = "/tmp/memory-service.sock"
+		cfg.UnixSocketAuth = "local"
+		err := resolveUnixSocketAuth(&cfg)
+		require.EqualError(t, err, "resolve OS username for --unix-socket-auth=local: set --local-user-id explicitly")
+	})
+}
 
 func TestValidateListenerSelections(t *testing.T) {
 	t.Run("allows unix socket with default port when port not explicitly set", func(t *testing.T) {

--- a/internal/cmd/serve/serve.go
+++ b/internal/cmd/serve/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os/user"
 	"strconv"
 	"strings"
 	"time"
@@ -305,6 +306,11 @@ func listenerFlags(cfg *config.Config) []cli.Flag {
 	}
 	flags = append(flags, tcpListenerFlags(cfg)...)
 	flags = append(flags, udsListenerFlags(cfg)...)
+	flags = append(flags,
+		&cli.StringFlag{Name: "unix-socket-auth", Category: "Network Listener:", Sources: cli.EnvVars("MEMORY_SERVICE_UNIX_SOCKET_AUTH"), Destination: &cfg.UnixSocketAuth, Value: cfg.UnixSocketAuth, Usage: "Unix socket authentication mode (credentials|local)"},
+		&cli.StringFlag{Name: "local-user-id", Category: "Network Listener:", Sources: cli.EnvVars("MEMORY_SERVICE_LOCAL_USER_ID"), Destination: &cfg.LocalUserID, Usage: "User ID for local Unix socket authentication (defaults to the OS username)"},
+		&cli.StringFlag{Name: "local-client-id", Category: "Network Listener:", Sources: cli.EnvVars("MEMORY_SERVICE_LOCAL_CLIENT_ID"), Destination: &cfg.LocalClientID, Value: cfg.LocalClientID, Usage: "Client ID for local Unix socket authentication"},
+	)
 	return flags
 }
 
@@ -857,7 +863,40 @@ func ApplyParsedFlags(cfg *config.Config, cmd *cli.Command, state *FlagState, va
 	if err := validateListenerSelections(*cfg, selections); err != nil {
 		return err
 	}
+	if err := resolveUnixSocketAuth(cfg); err != nil {
+		return err
+	}
 	cfg.ManagementListenerEnabled = selections.mgmtPortExplicit || selections.mgmtUnixSocketExplicit
+	return nil
+}
+
+var currentOSUser = user.Current
+
+func resolveUnixSocketAuth(cfg *config.Config) error {
+	mode := strings.TrimSpace(cfg.UnixSocketAuth)
+	if mode == "" {
+		mode = "credentials"
+	}
+	if mode != "credentials" && mode != "local" {
+		return fmt.Errorf("--unix-socket-auth must be credentials or local")
+	}
+	cfg.UnixSocketAuth = mode
+	if mode != "local" {
+		return nil
+	}
+	if strings.TrimSpace(cfg.Listener.UnixSocket) == "" {
+		return fmt.Errorf("--unix-socket-auth=local requires the API to be exposed exclusively through --unix-socket")
+	}
+	if strings.TrimSpace(cfg.LocalClientID) == "" {
+		cfg.LocalClientID = "local-agent"
+	}
+	if strings.TrimSpace(cfg.LocalUserID) == "" {
+		u, err := currentOSUser()
+		if err != nil || u == nil || strings.TrimSpace(u.Username) == "" {
+			return fmt.Errorf("resolve OS username for --unix-socket-auth=local: set --local-user-id explicitly")
+		}
+		cfg.LocalUserID = u.Username
+	}
 	return nil
 }
 

--- a/internal/cmd/serve/server.go
+++ b/internal/cmd/serve/server.go
@@ -99,6 +99,9 @@ func resolveAttachmentStoreName(cfg *config.Config) (string, error) {
 
 // BuildServer initializes all subsystems without binding any network listeners.
 func BuildServer(ctx context.Context, cfg *config.Config) (*Server, error) {
+	if err := resolveUnixSocketAuth(cfg); err != nil {
+		return nil, err
+	}
 	log.Info("Initializing memory service",
 		"httpPort", cfg.Listener.Port,
 		"httpSocket", strings.TrimSpace(cfg.Listener.UnixSocket),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,6 +203,9 @@ type Config struct {
 	ManagementAccessLog bool
 	CORSEnabled         bool
 	CORSOrigins         string
+	UnixSocketAuth      string
+	LocalUserID         string
+	LocalClientID       string
 
 	// Security
 	// APIKeys maps API key values to client IDs (Java parity: MEMORY_SERVICE_API_KEYS_<CLIENT_ID>=<key>).
@@ -345,6 +348,8 @@ func DefaultConfig() Config {
 			EnablePlainText: true,
 			EnableTLS:       true,
 		},
+		UnixSocketAuth:               "credentials",
+		LocalClientID:                "local-agent",
 		MaxBodySize:                  20 * 1024 * 1024, // 2x attachment max-size
 		MaxPageSize:                  DefaultMaxPageSize,
 		DrainTimeout:                 30,

--- a/internal/security/auth.go
+++ b/internal/security/auth.go
@@ -52,7 +52,8 @@ const (
 	CredentialBearerAPIKey CredentialKind = "bearer-api-key"
 	// CredentialEmbeddedMCP — in-process embedded MCP synthetic identity.
 	// Accepted only when RequestCredentials.Transport == "embedded-mcp"; never from network traffic.
-	CredentialEmbeddedMCP CredentialKind = "embedded-mcp"
+	CredentialEmbeddedMCP     CredentialKind = "embedded-mcp"
+	CredentialLocalUnixSocket CredentialKind = "local-unix-socket"
 	// CredentialTesting — raw bearer user accepted only in testing mode with auth_testfixtures build tag.
 	CredentialTesting CredentialKind = "testing-bearer-user"
 )
@@ -244,6 +245,8 @@ type TokenResolver struct {
 	// to CredentialEmbeddedMCP without touching the bearer/API-key paths.
 	embeddedMCPUserID   string
 	embeddedMCPClientID string
+	localUserID         string
+	localClientID       string
 }
 
 // NewTokenResolver creates a TokenResolver from the application config. It performs
@@ -255,7 +258,7 @@ func NewTokenResolver(cfg *config.Config) (*TokenResolver, error) {
 	oidcIssuer := cfg.OIDCIssuer
 
 	// Fail closed in production: no auth mechanism configured at all.
-	if cfg.Mode != config.ModeTesting && oidcIssuer == "" && len(cfg.APIKeys) == 0 {
+	if cfg.Mode != config.ModeTesting && cfg.UnixSocketAuth != "local" && oidcIssuer == "" && len(cfg.APIKeys) == 0 {
 		return nil, fmt.Errorf("no authentication mechanism configured: set MEMORY_SERVICE_OIDC_ISSUER and/or MEMORY_SERVICE_API_KEYS_<CLIENT_ID>")
 	}
 
@@ -335,6 +338,8 @@ func NewTokenResolver(cfg *config.Config) (*TokenResolver, error) {
 		auditorClients:  splitCSV(cfg.AuditorClients),
 		indexerClients:  splitCSV(cfg.IndexerClients),
 		testingMode:     cfg.Mode == config.ModeTesting,
+		localUserID:     strings.TrimSpace(cfg.LocalUserID),
+		localClientID:   strings.TrimSpace(cfg.LocalClientID),
 	}, nil
 }
 
@@ -354,6 +359,11 @@ var (
 // Resolve resolves a RequestCredentials into a caller Identity.
 // It applies all configured credential policies based on the deployment configuration.
 func (r *TokenResolver) Resolve(ctx context.Context, creds RequestCredentials) (*Identity, error) {
+	if r.localUserID != "" {
+		roles := r.rolesForClient(r.localClientID)
+		r.addUserRoles(roles, r.localUserID)
+		return newIdentity(r.localUserID, r.localClientID, roles, CredentialLocalUnixSocket), nil
+	}
 	// Embedded MCP in-process transport: resolve synthetic identity without bearer/API-key paths.
 	// The Transport value is injected only by the in-process client; remote listeners strip the
 	// header that sets it, so this branch is unreachable from network traffic.
@@ -752,6 +762,12 @@ func EffectiveAdminRole(c *gin.Context) string {
 // when no Authorization header is present.
 func AuthMiddleware(resolver *TokenResolver) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if resolver.localUserID != "" {
+			id, _ := resolver.Resolve(c.Request.Context(), RequestCredentials{})
+			setGinIdentity(c, id)
+			c.Next()
+			return
+		}
 		auth := c.GetHeader("Authorization")
 		apiKey := c.GetHeader("X-API-Key")
 		clientIDHeader := c.GetHeader("X-Client-ID")
@@ -826,6 +842,16 @@ func AuthMiddleware(resolver *TokenResolver) gin.HandlerFunc {
 	}
 }
 
+func setGinIdentity(c *gin.Context, id *Identity) {
+	c.Set(ContextKeyUserID, id.UserID)
+	if id.ClientID != "" {
+		c.Set(ContextKeyClientID, id.ClientID)
+	}
+	c.Set(ContextKeyIdentity, id)
+	c.Set(ContextKeyRoles, id.Roles)
+	c.Set(ContextKeyIsAdmin, id.IsAdmin)
+}
+
 // RequireUser requires a non-empty authenticated user principal.
 // Client-only (API-key-only) identities are rejected with 401.
 // This should be applied to all normal user/agent endpoints.
@@ -898,6 +924,10 @@ func grpcMetadataValue(ctx context.Context, key string) string {
 
 // resolveGRPCIdentity extracts auth headers from gRPC metadata and resolves identity.
 func resolveGRPCIdentity(ctx context.Context, resolver *TokenResolver) context.Context {
+	if resolver.localUserID != "" {
+		id, _ := resolver.Resolve(ctx, RequestCredentials{})
+		return context.WithValue(ctx, grpcIdentityKey{}, id)
+	}
 	auth := grpcMetadataValue(ctx, "authorization")
 	apiKey := grpcMetadataValue(ctx, "x-api-key")
 

--- a/internal/security/auth_test.go
+++ b/internal/security/auth_test.go
@@ -1,14 +1,49 @@
 package security
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/chirino/memory-service/internal/config"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+func TestLocalUnixSocketIdentityForHTTPAndGRPC(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.UnixSocketAuth = "local"
+	cfg.LocalUserID = "alice"
+	cfg.LocalClientID = "local-agent"
+	resolver, err := NewTokenResolver(&cfg)
+	require.NoError(t, err)
+
+	router := gin.New()
+	router.Use(AuthMiddleware(resolver))
+	router.GET("/identity", func(c *gin.Context) {
+		id := GetIdentity(c)
+		require.Equal(t, "alice", id.UserID)
+		require.Equal(t, "local-agent", id.ClientID)
+		require.Empty(t, id.Roles)
+		c.Status(http.StatusNoContent)
+	})
+	router.GET("/admin", RequireAdminRole(), func(c *gin.Context) { c.Status(http.StatusNoContent) })
+	recorder := httptest.NewRecorder()
+	router.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/identity", nil))
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+	adminRecorder := httptest.NewRecorder()
+	router.ServeHTTP(adminRecorder, httptest.NewRequest(http.MethodGet, "/admin", nil))
+	require.Equal(t, http.StatusForbidden, adminRecorder.Code)
+
+	ctx := resolveGRPCIdentity(context.Background(), resolver)
+	id := IdentityFromContext(ctx)
+	require.NotNil(t, id)
+	require.Equal(t, "alice", id.UserID)
+	require.Equal(t, "local-agent", id.ClientID)
+	require.False(t, id.IsAdmin)
+}
 
 func TestNewTokenResolverOIDCSelfSignedIssuerRequiresExplicitTLSBypass(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/site/src/pages/docs/concepts/unix-domain-sockets.mdx
+++ b/site/src/pages/docs/concepts/unix-domain-sockets.mdx
@@ -25,12 +25,19 @@ memory-service serve \
   --db-url=file:$HOME/.local/share/memory-service/memory.db \
   --vector-kind=sqlite \
   --cache-kind=local \
-  --unix-socket=$HOME/.local/run/memory-service/api.sock
+  --unix-socket=$HOME/.local/run/memory-service/api.sock \
+  --unix-socket-auth=local
 ```
 
 These options keep the local stack self-contained. `db-kind=sqlite` and `vector-kind=sqlite` keep both the primary datastore and vector index in local files instead of requiring Postgres, MongoDB, or Qdrant; `cache-kind=local` keeps caching in-process instead of requiring Redis or Infinispan; `db-url=file:$HOME/.local/share/...` stores persistent data in the user's home directory; and `--unix-socket=$HOME/.local/run/...` keeps the live socket out of `/tmp`, where other local users are more likely to discover and probe it.
 
 The server creates the socket parent directory with `0700` permissions and the socket file with `0600` permissions, so only the owning user can connect by default.
+
+With `--unix-socket-auth=local`, access to that socket is the authentication boundary. REST and gRPC calls do not need bearer tokens or API keys; both are authorized as the current OS username with client ID `local-agent`. Override those values with `--local-user-id` and `--local-client-id` when the application needs stable IDs that differ from the defaults. The local principal receives no admin, auditor, or indexer role unless you explicitly grant one through the normal role configuration.
+
+> **Security boundary:** Any process running as the Unix user that owns the socket can act as this local principal. Use the default `--unix-socket-auth=credentials` mode if applications running under the same OS account should not trust one another.
+
+Local authentication is rejected unless the main API is exposed exclusively through `--unix-socket`. A separate TCP management listener may still expose health and metrics endpoints because it does not expose the authenticated API.
 
 The framework guides reuse that same server shape. They only change the client-side configuration.
 

--- a/site/src/pages/docs/configuration.mdx
+++ b/site/src/pages/docs/configuration.mdx
@@ -32,14 +32,19 @@ Memory Service is configured through CLI flags or environment variables. Use the
 
 `--port` and `--unix-socket` are mutually exclusive when both are explicitly configured. If `--unix-socket` is set, the default port value is ignored for the main listener.
 
-| Flag                                                     | Values          | Default   | Description                                             |
-| -------------------------------------------------------- | --------------- | --------- | ------------------------------------------------------- |
-| <Cfg p="--port" e="MEMORY_SERVICE_PORT" />               | integer         | `8080`    | HTTP/gRPC server port                                   |
-| <Cfg p="--unix-socket" e="MEMORY_SERVICE_UNIX_SOCKET" /> | path            | _(unset)_ | Absolute path to a Unix socket for the HTTP/gRPC server |
-| <Cfg p="--plain-text" e="MEMORY_SERVICE_PLAIN_TEXT" />   | `true`, `false` | `true`    | Enable plaintext HTTP/1.1 + h2c + gRPC                  |
-| <Cfg p="--tls" e="MEMORY_SERVICE_TLS" />                 | `true`, `false` | `true`    | Enable TLS HTTP/1.1 + HTTP/2 + gRPC                     |
+| Flag                                                               | Values                 | Default       | Description                                                 |
+| ------------------------------------------------------------------ | ---------------------- | ------------- | ----------------------------------------------------------- |
+| <Cfg p="--port" e="MEMORY_SERVICE_PORT" />                         | integer                | `8080`        | HTTP/gRPC server port                                       |
+| <Cfg p="--unix-socket" e="MEMORY_SERVICE_UNIX_SOCKET" />           | path                   | _(unset)_     | Absolute path to a Unix socket for the HTTP/gRPC server     |
+| <Cfg p="--unix-socket-auth" e="MEMORY_SERVICE_UNIX_SOCKET_AUTH" /> | `credentials`, `local` | `credentials` | Require credentials or trust access to the main Unix socket |
+| <Cfg p="--local-user-id" e="MEMORY_SERVICE_LOCAL_USER_ID" />       | string                 | OS username   | User identity used by `unix-socket-auth=local`              |
+| <Cfg p="--local-client-id" e="MEMORY_SERVICE_LOCAL_CLIENT_ID" />   | string                 | `local-agent` | Client identity used by `unix-socket-auth=local`            |
+| <Cfg p="--plain-text" e="MEMORY_SERVICE_PLAIN_TEXT" />             | `true`, `false`        | `true`        | Enable plaintext HTTP/1.1 + h2c + gRPC                      |
+| <Cfg p="--tls" e="MEMORY_SERVICE_TLS" />                           | `true`, `false`        | `true`        | Enable TLS HTTP/1.1 + HTTP/2 + gRPC                         |
 
 When a Unix socket path points into a directory that does not exist yet, Memory Service creates the parent directory with permissions restricted to the current user.
+
+`unix-socket-auth=local` is valid only when the main API listener uses a Unix socket. It gives REST and gRPC the same local identity without granting privileged roles automatically. Any process running as the socket-owning Unix user is inside this trust boundary. Keep the default `credentials` mode when bearer-token or API-key authentication should remain mandatory.
 
 ### Management Network Listener
 
@@ -59,12 +64,14 @@ Unix socket example:
 <ConfigBlock
   property={`# Main API over a Unix socket
 --unix-socket=$HOME/.local/run/memory-service/api.sock
+--unix-socket-auth=local
 
 # Optional dedicated management socket
 
 --management-unix-socket=$HOME/.local/run/memory-service/mgmt.sock`}
   env={`# Main API over a Unix socket
 MEMORY_SERVICE_UNIX_SOCKET=$HOME/.local/run/memory-service/api.sock
+MEMORY_SERVICE_UNIX_SOCKET_AUTH=local
 
 # Optional dedicated management socket
 

--- a/site/src/pages/docs/faq.mdx
+++ b/site/src/pages/docs/faq.mdx
@@ -68,7 +68,8 @@ Yes. The Go server supports Unix domain sockets for local single-machine deploym
 ```bash
 memory-service serve \
   --db-url=postgresql://postgres:postgres@localhost:5432/memoryservice \
-  --unix-socket="$HOME/.local/run/memory-service/api.sock"
+  --unix-socket="$HOME/.local/run/memory-service/api.sock" \
+  --unix-socket-auth=local
 ```
 
 Then access it with tools that support Unix sockets:
@@ -78,7 +79,7 @@ curl --unix-socket "$HOME/.local/run/memory-service/api.sock" \
   http://localhost/ready
 ```
 
-This mode is intended for local agent processes. Browser apps cannot connect directly to a Unix socket.
+In local authentication mode, REST and gRPC calls use the current OS username and the `local-agent` client ID without application credentials. Any process running as the socket-owning Unix user is trusted as that principal. Omit `--unix-socket-auth=local` to retain normal bearer-token or API-key authentication. Browser apps cannot connect directly to a Unix socket.
 
 ## Features
 


### PR DESCRIPTION
## Summary
Allow Unix-domain-socket-only deployments to use socket permissions as the authentication boundary while preserving a concrete user and client identity for REST and gRPC authorization.

## Changes
- add validated `credentials` and `local` Unix socket authentication modes with configurable local user and client identities
- apply the same local principal to REST and gRPC while retaining normal role-based authorization
- add configuration, identity, and authorization coverage and document the same-user trust boundary

Fixes #382
