### PR TITLE
feat(frontend): add infinite scroll pagination to conversations and memories lists

### DIFF
--- a/frontends/developer/src/api/client.ts
+++ b/frontends/developer/src/api/client.ts
@@ -31,5 +31,6 @@ export { client };
 // Re-export generated types and query options
 export * from "./generated/types.gen";
 export * from "./generated/@tanstack/react-query.gen";
+export * from "./generated/sdk.gen";
 
 // Made with Bob

--- a/frontends/developer/src/hooks/useAdminApi.ts
+++ b/frontends/developer/src/hooks/useAdminApi.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   adminListConversationsOptions,
   adminGetConversationOptions,
@@ -6,6 +6,8 @@ import {
   adminUpdateConversationMutation,
   adminListMemoriesOptions,
   adminGetMemoryOptions,
+  adminListConversations,
+  adminListMemories,
   type AdminConversation,
   type AdminMemoryItem,
   type Entry,
@@ -24,6 +26,31 @@ export function useAdminConversations(params?: {
       query: params,
     })
   );
+}
+
+export function useAdminConversationsInfinite(params?: {
+  userId?: string;
+  archived?: "include" | "exclude" | "only";
+  ancestry?: "all" | "roots" | "children";
+  limit?: number;
+}) {
+  const limit = params?.limit ?? 50;
+  return useInfiniteQuery({
+    queryKey: ["adminListConversations", params],
+    initialPageParam: null as string | null,
+    queryFn: async ({ pageParam }) => {
+      const { data } = await adminListConversations({
+        query: {
+          ...params,
+          limit,
+          afterCursor: pageParam ?? undefined,
+        },
+        throwOnError: true,
+      });
+      return data;
+    },
+    getNextPageParam: (lastPage) => lastPage.afterCursor ?? undefined,
+  });
 }
 
 export function useAdminConversation(conversationId: string) {
@@ -81,6 +108,30 @@ export function useAdminMemories(params?: {
       query: params,
     })
   );
+}
+
+export function useAdminMemoriesInfinite(params?: {
+  namespacePrefix?: string[];
+  keyPrefix?: string;
+  limit?: number;
+}) {
+  const limit = params?.limit ?? 50;
+  return useInfiniteQuery({
+    queryKey: ["adminListMemories", params],
+    initialPageParam: null as string | null,
+    queryFn: async ({ pageParam }) => {
+      const { data } = await adminListMemories({
+        query: {
+          ...params,
+          limit,
+          afterCursor: pageParam ?? undefined,
+        },
+        throwOnError: true,
+      });
+      return data;
+    },
+    getNextPageParam: (lastPage) => lastPage.afterCursor ?? undefined,
+  });
 }
 
 export function useAdminMemory(memoryId: string) {

--- a/frontends/developer/src/routes/conversations/index.tsx
+++ b/frontends/developer/src/routes/conversations/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { Archive, ArchiveRestore, Eye, SlidersHorizontal } from "lucide-react";
-import { useAdminConversations, useArchiveConversation, useUnarchiveConversation } from "@/hooks/useAdminApi";
+import { useAdminConversationsInfinite, useArchiveConversation, useUnarchiveConversation } from "@/hooks/useAdminApi";
 import { useAuth } from "@/lib/auth";
 import { formatRelativeTime, cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -17,13 +17,23 @@ export const Route = createFileRoute("/conversations/")({
 
 function ConversationsPage() {
   const [archiveFilter, setArchiveFilter] = useState<"exclude" | "include" | "only">("exclude");
-  const { data, isLoading, error } = useAdminConversations({ archived: archiveFilter, limit: 50 });
+  const {
+    data,
+    isLoading,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useAdminConversationsInfinite({ archived: archiveFilter, limit: 50 });
   const archiveMutation = useArchiveConversation();
   const unarchiveMutation = useUnarchiveConversation();
   const auth = useAuth();
   const isAdmin = auth.hasRole("admin");
 
-  const conversations = data?.data || [];
+  const conversations = useMemo(() => {
+    const pages = data?.pages ?? [];
+    return pages.flatMap((page) => page.data ?? []);
+  }, [data]);
 
   const handleArchive = (conversationId: string) => {
     if (confirm("Archive this conversation?")) {
@@ -214,9 +224,23 @@ function ConversationsPage() {
         )}
 
         {!isLoading && !error && conversations.length > 0 && (
-          <div className="mt-4 text-center text-sm text-muted-foreground">
-            Showing {conversations.length} conversation{conversations.length !== 1 ? "s" : ""}
-          </div>
+          <>
+            {hasNextPage && (
+              <div className="mt-6 flex justify-center">
+                <button
+                  type="button"
+                  onClick={() => void fetchNextPage()}
+                  disabled={isFetchingNextPage}
+                  className="console-panel rounded-lg px-6 py-3 text-sm text-muted-foreground transition-colors hover:text-foreground disabled:cursor-wait disabled:opacity-60"
+                >
+                  {isFetchingNextPage ? "Loading more conversations..." : "Load more conversations"}
+                </button>
+              </div>
+            )}
+            <div className="mt-4 text-center text-sm text-muted-foreground">
+              Showing {conversations.length} conversation{conversations.length !== 1 ? "s" : ""}
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/frontends/developer/src/routes/memories/index.tsx
+++ b/frontends/developer/src/routes/memories/index.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { ChevronRight, Eye } from "lucide-react";
-import { useAdminMemories } from "@/hooks/useAdminApi";
+import { useAdminMemoriesInfinite } from "@/hooks/useAdminApi";
 import { formatRelativeTime, truncate, cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -25,13 +25,24 @@ function MemoriesPage() {
   const [namespaceFilter, setNamespaceFilter] = useState<string[]>([]);
   const [keyPrefixFilter, setKeyPrefixFilter] = useState("");
 
-  const { data, isLoading, error } = useAdminMemories({
+  const {
+    data,
+    isLoading,
+    error,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useAdminMemoriesInfinite({
     namespacePrefix: namespaceFilter.length > 0 ? namespaceFilter : undefined,
     keyPrefix: keyPrefixFilter || undefined,
     limit: 50,
   });
 
-  const rawMemories = data?.items || [];
+  const rawMemories = useMemo(() => {
+    const pages = data?.pages ?? [];
+    return pages.flatMap((page) => page.items ?? []);
+  }, [data]);
+
   const memories = rawMemories.filter((memory) => {
     if (archiveFilter === "include") return true;
     if (archiveFilter === "only") return memory.archived;
@@ -294,9 +305,23 @@ function MemoriesPage() {
           )}
 
           {!isLoading && !error && memories.length > 0 && (
-            <div className="mt-4 text-center text-sm text-muted-foreground">
-              Showing {memories.length} memor{memories.length !== 1 ? "ies" : "y"}
-            </div>
+            <>
+              {hasNextPage && (
+                <div className="mt-6 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => void fetchNextPage()}
+                    disabled={isFetchingNextPage}
+                    className="console-panel rounded-lg px-6 py-3 text-sm text-muted-foreground transition-colors hover:text-foreground disabled:cursor-wait disabled:opacity-60"
+                  >
+                    {isFetchingNextPage ? "Loading more memories..." : "Load more memories"}
+                  </button>
+                </div>
+              )}
+              <div className="mt-4 text-center text-sm text-muted-foreground">
+                Showing {memories.length} memor{memories.length !== 1 ? "ies" : "y"}
+              </div>
+            </>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Add Infinite Scroll Pagination to Conversations and Memories Lists

### Current State (Before)
- **Conversations list**: Shows only first 50 conversations, no way to load more
- **Memories list**: Shows only first 50 memories, no way to load more
- **Conversation entries**: Already has "Load older entries" button ✅
- **Search page**: Only searches first 50 items client-side (separate issue)

### Improvements (After)
- ✅ **Conversations list**: Infinite scroll with "Load more conversations" button
- ✅ **Memories list**: Infinite scroll with "Load more memories" button
- ✅ **Consistent UX**: All list pages now follow the same pagination pattern
- ✅ **Filter compatibility**: All existing filters work correctly with pagination
- ✅ **Performance**: Loads data in batches of 50, reducing initial load time

### Technical Changes

**New Hooks** (`src/hooks/useAdminApi.ts`):
- `useAdminConversationsInfinite()` - TanStack Query infinite query for conversations
- `useAdminMemoriesInfinite()` - TanStack Query infinite query for memories

**Updated Pages**:
- `src/routes/conversations/index.tsx` - Switched to infinite query, added "Load more" button
- `src/routes/memories/index.tsx` - Switched to infinite query, added "Load more" button

**API Client** (`src/api/client.ts`):
- Export SDK functions for direct API calls in infinite queries

### Implementation Details
- Uses `useInfiniteQuery` with cursor-based pagination (`afterCursor`)
- Accumulates all loaded pages in memory (infinite scroll pattern)
- Button appears only when more data is available (`hasNextPage`)
- Loading states prevent duplicate requests
- All filters reset pagination and start fresh

### Testing
- ✅ Build successful
- ✅ TypeScript compilation clean
- ✅ Manual testing confirmed functionality
- ✅ All filters work with pagination

### Known Limitations
- Search page still uses client-side filtering on first 50 items (will be addressed in separate PR using server-side search endpoints)