### PR TITLE
style(site): add spacing above deployment nav

### DIFF
--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -247,6 +247,10 @@
     @apply mb-1;
   }
 
+  .sidebar-section-collapsible + .sidebar-section:not(.sidebar-section-collapsible) {
+    @apply mt-4;
+  }
+
   .sidebar-heading {
     @apply text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 px-3;
   }


### PR DESCRIPTION
## Summary
Add visual separation between the collapsible guide groups and the Deployment section in the documentation sidebar.

## Changes
- Add a top margin when a regular sidebar section follows a collapsible section
- Preserve the compact spacing between adjacent collapsible guide sections
