### PR TITLE
fix(java): generate aggregate binary javadocs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,27 +570,38 @@ jobs:
             -Dcentral.skipPublishing=true \
             -pl :memory-service-binaries -am clean verify
 
-      - name: Inspect packaged resources
+      - name: Inspect packaged JARs
         shell: bash
         run: |
           set -euo pipefail
-          jar tf java/memory-service-binary-linux-amd64/target/memory-service-binary-linux-amd64-*.jar \
+          primary_jar() {
+            local binary_module="$1"
+            local primary_path
+            primary_path="$(find "java/$binary_module/target" -maxdepth 1 -type f \
+              -name "$binary_module-*.jar" \
+              ! -name '*-sources.jar' \
+              ! -name '*-javadoc.jar' \
+              -print -quit)"
+            if [ -z "$primary_path" ]; then
+              echo "Missing primary JAR for $binary_module" >&2
+              return 1
+            fi
+            printf '%s\n' "$primary_path"
+          }
+
+          jar tf "$(primary_jar memory-service-binary-linux-amd64)" \
             | grep -Fx 'META-INF/memory-service/linux-amd64/memory-service'
-          jar tf java/memory-service-binary-linux-arm64/target/memory-service-binary-linux-arm64-*.jar \
+          jar tf "$(primary_jar memory-service-binary-linux-arm64)" \
             | grep -Fx 'META-INF/memory-service/linux-arm64/memory-service'
-          jar tf java/memory-service-binary-macos-arm64/target/memory-service-binary-macos-arm64-*.jar \
+          jar tf "$(primary_jar memory-service-binary-macos-arm64)" \
             | grep -Fx 'META-INF/memory-service/macos-arm64/memory-service'
 
-      - name: Validate aggregate Java module path
-        shell: bash
-        run: |
-          set -euo pipefail
           jars=(
-            java/memory-service-process/target/memory-service-process-*.jar
-            java/memory-service-binary-linux-amd64/target/memory-service-binary-linux-amd64-*.jar
-            java/memory-service-binary-linux-arm64/target/memory-service-binary-linux-arm64-*.jar
-            java/memory-service-binary-macos-arm64/target/memory-service-binary-macos-arm64-*.jar
-            java/memory-service-binaries/target/memory-service-binaries-*.jar
+            "$(primary_jar memory-service-process)"
+            "$(primary_jar memory-service-binary-linux-amd64)"
+            "$(primary_jar memory-service-binary-linux-arm64)"
+            "$(primary_jar memory-service-binary-macos-arm64)"
+            "$(primary_jar memory-service-binaries)"
           )
           module_path="$(IFS=:; echo "${jars[*]}")"
           java --validate-modules --module-path "$module_path"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,9 +563,11 @@ jobs:
       - name: Build and test native binary JARs
         run: |
           ./java/mvnw -B -f java/pom.xml \
-            -Pbinary-jars \
+            -Pcentral-release,binary-jars \
             -Dmemory-service.binaries.dir=/tmp/memory-service-binaries \
             -Dmemory-service.packaged.test=true \
+            -Dgpg.skip=true \
+            -Dcentral.skipPublishing=true \
             -pl :memory-service-binaries -am clean verify
 
       - name: Inspect packaged resources

--- a/java/memory-service-binaries/FACTS.md
+++ b/java/memory-service-binaries/FACTS.md
@@ -2,3 +2,4 @@
 
 - The aggregate `memory-service-binaries` JAR contains no behavior or native payload. Keep its public `MemoryServiceBinaries` marker type because a `package-info.java` by itself is not enough for JDK 21 Javadoc generation under the inherited `central-release` profile.
 - The `test-binary-jars` CI job activates both `binary-jars` and `central-release`, with GPG signing and Central publishing disabled, so release-only Javadoc and source attachment remain covered before a release.
+- The `central-release` profile adds `-sources.jar` and `-javadoc.jar` beside each primary JAR. CI resource and module-path checks must exclude those classifier artifacts instead of passing an unfiltered `*.jar` expansion to `jar` or `java`.

--- a/java/memory-service-binaries/FACTS.md
+++ b/java/memory-service-binaries/FACTS.md
@@ -1,0 +1,4 @@
+# Memory Service Binaries Facts
+
+- The aggregate `memory-service-binaries` JAR contains no behavior or native payload. Keep its public `MemoryServiceBinaries` marker type because a `package-info.java` by itself is not enough for JDK 21 Javadoc generation under the inherited `central-release` profile.
+- The `test-binary-jars` CI job activates both `binary-jars` and `central-release`, with GPG signing and Central publishing disabled, so release-only Javadoc and source attachment remain covered before a release.

--- a/java/memory-service-binaries/src/main/java/io/github/chirino/memoryservice/process/binaries/MemoryServiceBinaries.java
+++ b/java/memory-service-binaries/src/main/java/io/github/chirino/memoryservice/process/binaries/MemoryServiceBinaries.java
@@ -1,0 +1,11 @@
+package io.github.chirino.memoryservice.process.binaries;
+
+/**
+ * Marker type for the aggregate Memory Service native binary dependency.
+ *
+ * <p>Depending on this artifact makes every supported native binary provider available through
+ * the {@code memory-service-process} API.
+ */
+public final class MemoryServiceBinaries {
+    private MemoryServiceBinaries() {}
+}


### PR DESCRIPTION
## Summary
Fix the Maven Central release bundle failure for the aggregate native-binaries artifact and prevent the release-only Javadoc path from regressing.

## Changes
- Add a documented `MemoryServiceBinaries` marker type so JDK 21 can generate the required Javadoc JAR.
- Exercise the `central-release` profile in binary-JAR CI with signing and publishing disabled.
- Record the aggregate module's Javadoc requirement in module facts.
