### PR TITLE
chore(deps): consolidate 1 dependabot update (2026-08-07 batch)

### DIFF
--- a/python/langchain/pyproject.toml
+++ b/python/langchain/pyproject.toml
@@ -23,7 +23,7 @@ Repository = "https://github.com/chirino/memory-service"
 Documentation = "https://chirino.github.io/memory-service/docs/python-langchain/getting-started/"
 
 [build-system]
-requires = ["hatchling>=1.30.1"]
+requires = ["hatchling>=1.31.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Dependabot batch: 2026-08-07 (batch ca983abe)

Consolidates 1 eligible Dependabot PR onto `main` @ `ff6f8cb96682eed7cd3562e4cee39d3f2c1354de`.

### Source PRs

| PR | Package | Change | CI | Cooldown |
|----|---------|--------|----|----------|
| #474 | hatchling (python) | `>=1.30.1` → `>=1.31.0` | ✅ all green | ✅ published 2026-07-08 (30.6 days ago) |

### Local validation gates (host, manual — DinD/cgroup v2 nesting unavailable in devcontainer)

- `task generate` — ✅ passed; worktree clean post-generate
- `task test` — ✅ passed (Go: 578+ tests, Java: BUILD SUCCESS)
- `task test:site` — ✅ passed (50 site BDD tests)

### Deferred PRs (not yet eligible)

| PR | Package | Reason |
|----|---------|--------|
| #427 | brace-expansion 1.1.16 | CONFLICTING — needs `@dependabot rebase`; superseded by 1.1.17/1.1.18 |
| #472 | ubi9/openjdk-25:1.24-3 | Published 2026-08-03 (4.2d < 7d); eligible 2026-08-10 |
| #478 | js-yaml 4.3.1 | Published 2026-07-31 (6.97d < 7d); eligible 2026-08-07T17:40Z |
| #485 | dompurify 3.4.13 | Published 2026-08-03 (4.1d < 7d); eligible 2026-08-10 |
| #486 | mermaid 11.16.1 | Published 2026-08-04 (3.1d < 7d); eligible 2026-08-11 |
| #487 | postcss+dompurify+mermaid (developer) | Newest: postcss 8.5.26 published 2026-08-06 (1.3d); eligible 2026-08-13 |
| #488 | vite 8.2.1 | Published 2026-08-06 (1.1d < 7d); eligible 2026-08-13 |
| #489 | undici 8.10.0 | Published 2026-08-03 (4.1d); CI FAILURE: test-site; eligible 2026-08-10 |
| #490 | postcss 8.5.26 (site) | Published 2026-08-06 (1.3d); eligible 2026-08-13 |
| #491 | postcss 8.5.26 (chat-frontend) | Published 2026-08-06 (1.3d); eligible 2026-08-13 |

### Cooldown report
Stored at `.bob/skills/verify-dependabot-prs/cooldown-2026-08-07.json` (checked 2026-08-07T16:42:35Z).
