### PR TITLE
fix: restore path and retry contracts

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -145,6 +145,18 @@ tasks:
         CGO_ENABLED=1 go run gotest.tools/gotestsum --format {{.GOTESTSUM_FMT | default .DEFAULT_GOTESTSUM_FMT}} -- -race -tags='sqlite_fts5' -run 'TestFeaturesPg(APIKeys|Keycloak|KeycloakAuthClients)$' ./internal/bdd/ {{.CLI_ARGS}}
       - |
         CGO_ENABLED=1 go run gotest.tools/gotestsum --format {{.GOTESTSUM_FMT | default .DEFAULT_GOTESTSUM_FMT}} -- -race -tags='sqlite_fts5 auth_testfixtures' -run 'TestFeaturesSQLiteMemoryKindRegressions$' ./internal/bdd/ {{.CLI_ARGS}}
+      - |
+        CGO_ENABLED=1 go run gotest.tools/gotestsum --format {{.GOTESTSUM_FMT | default .DEFAULT_GOTESTSUM_FMT}} -- -race -tags='sqlite_fts5 auth_testfixtures' -run 'TestFeaturesSQLite/conversations-rest$' ./internal/bdd/ {{.CLI_ARGS}}
+      - |
+        CGO_ENABLED=1 go run gotest.tools/gotestsum --format {{.GOTESTSUM_FMT | default .DEFAULT_GOTESTSUM_FMT}} -- -race -tags='sqlite_fts5 auth_testfixtures' -run 'TestFeaturesSQLiteOutbox$' ./internal/bdd/ {{.CLI_ARGS}}
+      - |
+        CGO_ENABLED=1 go run gotest.tools/gotestsum --format {{.GOTESTSUM_FMT | default .DEFAULT_GOTESTSUM_FMT}} -- -race -tags='sqlite_fts5 auth_testfixtures' -run 'TestFeaturesSQLiteSerial$' ./internal/bdd/ {{.CLI_ARGS}}
+      - |
+        CGO_ENABLED=1 go run gotest.tools/gotestsum --format {{.GOTESTSUM_FMT | default .DEFAULT_GOTESTSUM_FMT}} -- -race -tags='sqlite_fts5 auth_testfixtures' -run 'TestFeaturesSQLite/ownership-transfers-rest$' ./internal/bdd/ {{.CLI_ARGS}}
+      - |
+        CGO_ENABLED=1 go run gotest.tools/gotestsum --format {{.GOTESTSUM_FMT | default .DEFAULT_GOTESTSUM_FMT}} -- -race -tags='sqlite_fts5 auth_testfixtures' -run 'TestFeaturesSQLite/entries-seq-retry-grpc$' ./internal/bdd/ {{.CLI_ARGS}}
+      - |
+        CGO_ENABLED=1 go run gotest.tools/gotestsum --format {{.GOTESTSUM_FMT | default .DEFAULT_GOTESTSUM_FMT}} -- -race -tags='sqlite_fts5 auth_testfixtures' -run 'TestFeaturesSQLiteGRPCContractRegressions$' ./internal/bdd/ {{.CLI_ARGS}}
       - task: test:go:fixtures
         vars:
           CLI_ARGS: '{{.CLI_ARGS}}'

--- a/internal/bdd/cucumber_sqlite_grpc_contract_regression_test.go
+++ b/internal/bdd/cucumber_sqlite_grpc_contract_regression_test.go
@@ -1,0 +1,46 @@
+package bdd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/chirino/memory-service/internal/buildcaps"
+	"github.com/chirino/memory-service/internal/config"
+)
+
+// TestFeaturesSQLiteGRPCContractRegressions keeps string-valued conversation
+// IDs covered outside the broad PostgreSQL runner. Each scenario gets its own
+// server and database, so these features remain safe at normal BDD concurrency.
+func TestFeaturesSQLiteGRPCContractRegressions(t *testing.T) {
+	if !buildcaps.SQLite {
+		requireCapabilities(t, "sqlite")
+	}
+
+	cfg := defaultBDDConfig()
+	cfg.Mode = config.ModeTesting
+	cfg.DatastoreType = "sqlite"
+	cfg.CacheType = "local"
+	cfg.AttachType = "fs"
+	cfg.VectorType = "none"
+	cfg.SearchSemanticEnabled = false
+	cfg.EncryptionDBDisabled = true
+	cfg.EncryptionAttachmentsDisabled = true
+	cfg.APIKeys = map[string]string{"test-agent-key": "test-agent-key"}
+	cfg.AdminUsers = bddAdminUsers()
+	cfg.AuditorUsers = bddAuditorUsers()
+	cfg.IndexerUsers = bddIndexerUsers()
+	cfg.Listener.Port = 0
+	cfg.Listener.EnableTLS = false
+
+	featureFiles := []string{
+		filepath.Join("testdata", "features", "response-recorder-grpc.feature"),
+		filepath.Join("testdata", "features-grpc", "forking-grpc.feature"),
+		filepath.Join("testdata", "features-grpc", "ownership-transfers-grpc.feature"),
+		filepath.Join("testdata", "features-grpc", "sharing-grpc.feature"),
+		filepath.Join("testdata", "features-grpc", "update-conversation-grpc.feature"),
+	}
+	runBDDFeaturesWithScenarioSetupAndTags(
+		t, "sqlite-grpc-contract-regressions", featureFiles, "", "", &cfg, nil, nil,
+		newSQLiteScenarioSetup(t, cfg), bddScenarioConcurrency(), sqliteTagFilter(),
+	)
+}

--- a/internal/bdd/steps_domain_assertions.go
+++ b/internal/bdd/steps_domain_assertions.go
@@ -3,6 +3,7 @@ package bdd
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/chirino/memory-service/internal/testutil/cucumber"
@@ -19,8 +20,8 @@ func init() {
 		// Response body assertions (JSON matching)
 		ctx.Step(`^the response body should be json:$`, d.theResponseBodyShouldBeJSON)
 		ctx.Step(`^the response body should contain json:$`, d.theResponseBodyShouldContainJSON)
-		ctx.Step(`^the response body should contain "([^"]*)"$`, d.theResponseBodyShouldContainText)
-		ctx.Step(`^the response body should not contain "([^"]*)"$`, d.theResponseBodyShouldNotContainText)
+		ctx.Step(`^the response body should contain "((?:\\.|[^"])*)"$`, d.theResponseBodyShouldContainText)
+		ctx.Step(`^the response body should not contain "((?:\\.|[^"])*)"$`, d.theResponseBodyShouldNotContainText)
 
 		// Response body field assertions
 		ctx.Step(`^the response body "([^"]*)" should be "([^"]*)"$`, d.theResponseBodyFieldShouldBe)
@@ -30,6 +31,7 @@ func init() {
 		ctx.Step(`^the response body field "([^"]*)" should contain "([^"]*)"$`, d.theResponseBodyFieldShouldContain)
 		ctx.Step(`^the response body "([^"]*)" should have at least (\d+) items?$`, d.theResponseBodyFieldShouldHaveAtLeastItems)
 		ctx.Step(`^the response body "([^"]*)" should have at most (\d+) items?$`, d.theResponseBodyFieldShouldHaveAtMostItems)
+		ctx.Step(`^the response body "([^"]*)" should have (\d+) items?$`, d.theResponseBodyFieldShouldHaveItems)
 
 		// Collection size assertions
 		ctx.Step(`^the response should contain at least (\d+) conversations?$`, d.theResponseShouldContainAtLeastItems)
@@ -125,12 +127,18 @@ func (d *domainAssertionSteps) theResponseBodyShouldContainJSON(expected *godog.
 }
 
 func (d *domainAssertionSteps) theResponseBodyShouldContainText(expected string) error {
+	expected = decodeStepQuotedContent(expected)
 	expanded, err := d.s.Expand(expected)
 	if err != nil {
 		return err
 	}
 	session := d.s.Session()
 	body := string(session.RespBytes)
+	if respJSON, jsonErr := session.RespJSON(); jsonErr == nil {
+		if _, found := jsonPathLookup(respJSON, expanded); found {
+			return nil
+		}
+	}
 	if !strings.Contains(body, expanded) {
 		return fmt.Errorf("expected response to contain '%s', but it does not. Response body: %s", expanded, body)
 	}
@@ -138,12 +146,21 @@ func (d *domainAssertionSteps) theResponseBodyShouldContainText(expected string)
 }
 
 func (d *domainAssertionSteps) theResponseBodyShouldNotContainText(expected string) error {
+	expected = decodeStepQuotedContent(expected)
 	session := d.s.Session()
 	body := string(session.RespBytes)
 	if strings.Contains(body, expected) {
 		return fmt.Errorf("expected response not to contain '%s', but it does. Response body: %s", expected, body)
 	}
 	return nil
+}
+
+func decodeStepQuotedContent(value string) string {
+	decoded, err := strconv.Unquote(`"` + value + `"`)
+	if err != nil {
+		return value
+	}
+	return decoded
 }
 
 func (d *domainAssertionSteps) theResponseBodyFieldShouldBe(path, expected string) error {
@@ -226,6 +243,23 @@ func (d *domainAssertionSteps) theResponseBodyFieldShouldHaveAtMostItems(path st
 	}
 	if len(arr) > maxCount {
 		return fmt.Errorf("field '%s' has %d items, expected at most %d. Response: %s", path, len(arr), maxCount, string(session.RespBytes))
+	}
+	return nil
+}
+
+func (d *domainAssertionSteps) theResponseBodyFieldShouldHaveItems(path string, count int) error {
+	session := d.s.Session()
+	respJSON, err := session.RespJSON()
+	if err != nil {
+		return err
+	}
+	value := jsonPathGet(respJSON, path)
+	arr, ok := value.([]interface{})
+	if !ok {
+		return fmt.Errorf("field '%s' is not an array. Response: %s", path, string(session.RespBytes))
+	}
+	if len(arr) != count {
+		return fmt.Errorf("field '%s' has %d items, expected %d. Response: %s", path, len(arr), count, string(session.RespBytes))
 	}
 	return nil
 }
@@ -678,6 +712,11 @@ func (d *domainAssertionSteps) setContextVariableToJSONResponseField(name, path 
 // jsonPathGet navigates a JSON structure using dot-separated path with array index support.
 // e.g. "data.0.content.0.text" or "data[0].content[0].text"
 func jsonPathGet(obj interface{}, path string) interface{} {
+	value, _ := jsonPathLookup(obj, path)
+	return value
+}
+
+func jsonPathLookup(obj interface{}, path string) (interface{}, bool) {
 	// Normalize bracket notation: data[0] → data.0
 	path = strings.ReplaceAll(path, "[", ".")
 	path = strings.ReplaceAll(path, "]", "")
@@ -690,13 +729,17 @@ func jsonPathGet(obj interface{}, path string) interface{} {
 		}
 		switch v := current.(type) {
 		case map[string]interface{}:
-			current = v[part]
+			var found bool
+			current, found = v[part]
+			if !found {
+				return nil, false
+			}
 		case []interface{}:
 			var idx int
 			if _, err := fmt.Sscanf(part, "%d", &idx); err == nil && idx >= 0 && idx < len(v) {
 				current = v[idx]
 			} else {
-				return nil
+				return nil, false
 			}
 		default:
 			// Try JSON unmarshal if it's a string containing JSON
@@ -707,17 +750,21 @@ func jsonPathGet(obj interface{}, path string) interface{} {
 					// Re-navigate this part
 					switch v2 := current.(type) {
 					case map[string]interface{}:
-						current = v2[part]
+						var found bool
+						current, found = v2[part]
+						if !found {
+							return nil, false
+						}
 					default:
-						return nil
+						return nil, false
 					}
 				} else {
-					return nil
+					return nil, false
 				}
 			} else {
-				return nil
+				return nil, false
 			}
 		}
 	}
-	return current
+	return current, true
 }

--- a/internal/bdd/steps_taskqueue.go
+++ b/internal/bdd/steps_taskqueue.go
@@ -72,6 +72,9 @@ func (t *taskQueueSteps) theTaskProcessorRuns() error {
 
 func (t *taskQueueSteps) theMemoryKindMigrationProcessorRuns() error {
 	cfg, ok := t.s.Extra["config"].(*config.Config)
+	if (!ok || cfg == nil) && t.s.Suite != nil {
+		cfg, ok = t.s.Suite.Context.(*config.Config)
+	}
 	if !ok || cfg == nil {
 		return fmt.Errorf("scenario server config is unavailable")
 	}

--- a/internal/bdd/testdata/features-grpc/entries-seq-retry-grpc.feature
+++ b/internal/bdd/testdata/features-grpc/entries-seq-retry-grpc.feature
@@ -186,6 +186,34 @@ Feature: Sequenced entry retry gRPC API
     Then the gRPC response should not have an error
     And the gRPC response field "id" should be "${unarchiveRetryEntryId}"
 
+  Scenario: Retry unarchives an archived conversation without repeating append side effects
+    Given "alice" is connected to the SSE event stream
+    When I send gRPC request "EntriesService/AppendEntry" with body:
+    """
+    conversation_id: "${conversationId}"
+    entry { channel: HISTORY content_type: "history" seq: 170 content { struct_value { fields { key: "role" value { string_value: "USER" } } fields { key: "text" value { string_value: "stored before archive" } } } } }
+    """
+    Then the gRPC response should not have an error
+    And set "grpcArchivedRetryEntryId" to the gRPC response field "id"
+    And "alice" should receive an SSE event with kind "entry" and event "created"
+    Given I am authenticated as user "alice"
+    When I archive the conversation
+    Then the response status should be 200
+    And "alice" should receive an SSE event with kind "conversation" and event "updated"
+    Given I am authenticated as agent with API key "test-agent-key"
+    When I send gRPC request "EntriesService/AppendEntry" with body:
+    """
+    conversation_id: "${conversationId}"
+    entry { channel: HISTORY content_type: "history" seq: 170 content { struct_value { fields { key: "role" value { string_value: "USER" } } fields { key: "text" value { string_value: "stored before archive" } } } } }
+    conversation_patch { archived: false }
+    """
+    Then the gRPC response should not have an error
+    And the gRPC response field "id" should be "${grpcArchivedRetryEntryId}"
+    And "alice" should receive an SSE event with kind "conversation" and event "updated"
+    And the SSE event data "archived" should be "false"
+    And "alice" should not receive an SSE event with kind "conversation" and event "updated" within 2 seconds
+    And "alice" should not receive an SSE event with kind "entry" and event "created" within 2 seconds
+
   Scenario: archived false on an active conversation emits no conversation update
     Given "alice" is connected to the SSE event stream
     When I send gRPC request "EntriesService/AppendEntry" with body:

--- a/internal/bdd/testdata/features-grpc/forking-grpc.feature
+++ b/internal/bdd/testdata/features-grpc/forking-grpc.feature
@@ -19,7 +19,7 @@ Feature: Conversation Forking gRPC API
     And set "forkedConversationId" to "${forkedConversationId}"
     When I send gRPC request "ConversationsService/GetConversation" with body:
     """
-    conversation_id: "${forkedConversationId | uuid_to_hex_string}"
+    conversation_id: "${forkedConversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "id" should be "${forkedConversationId}"
@@ -37,7 +37,7 @@ Feature: Conversation Forking gRPC API
     Given I am authenticated as agent with API key "test-agent-key"
     When I send gRPC request "EntriesService/ListEntries" with body:
     """
-    conversation_id: "${forkedConversationId | uuid_to_hex_string}"
+    conversation_id: "${forkedConversationId}"
     channel: HISTORY
     """
     Then the gRPC response should not have an error
@@ -49,7 +49,7 @@ Feature: Conversation Forking gRPC API
     Given I am authenticated as agent with API key "test-agent-key"
     When I send gRPC request "EntriesService/AppendEntry" with body:
     """
-    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee01" | uuid_to_hex_string}"
+    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee01"}"
     entry {
       user_id: "alice"
       channel: HISTORY
@@ -66,7 +66,7 @@ Feature: Conversation Forking gRPC API
           }
         }
       }
-      forked_at_conversation_id: "${parentConversationId | uuid_to_hex_string}"
+      forked_at_conversation_id: "${parentConversationId}"
       forked_at_entry_id: "${secondEntryId | uuid_to_hex_string}"
     }
     """
@@ -75,7 +75,7 @@ Feature: Conversation Forking gRPC API
     # Verify the fork conversation was created correctly
     When I send gRPC request "ConversationsService/GetConversation" with body:
     """
-    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee01" | uuid_to_hex_string}"
+    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee01"}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "forkedAtEntryId" should be "${secondEntryId}"
@@ -85,7 +85,7 @@ Feature: Conversation Forking gRPC API
     Given I am authenticated as agent with API key "test-agent-key"
     When I send gRPC request "EntriesService/AppendEntry" with body:
     """
-    conversation_id: "${parentConversationId | uuid_to_hex_string}"
+    conversation_id: "${parentConversationId}"
     entry {
       user_id: "alice"
       channel: JOURNAL
@@ -104,7 +104,7 @@ Feature: Conversation Forking gRPC API
     And set "journalEntryId" to the gRPC response field "id"
     When I send gRPC request "EntriesService/AppendEntry" with body:
     """
-    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee02" | uuid_to_hex_string}"
+    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee02"}"
     entry {
       user_id: "alice"
       channel: HISTORY
@@ -121,7 +121,7 @@ Feature: Conversation Forking gRPC API
           }
         }
       }
-      forked_at_conversation_id: "${parentConversationId | uuid_to_hex_string}"
+      forked_at_conversation_id: "${parentConversationId}"
       forked_at_entry_id: "${journalEntryId | uuid_to_hex_string}"
     }
     """
@@ -129,7 +129,7 @@ Feature: Conversation Forking gRPC API
     And set "journalForkEntryId" to the gRPC response field "id"
     When I send gRPC request "ConversationsService/GetConversation" with body:
     """
-    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee02" | uuid_to_hex_string}"
+    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee02"}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "forkedAtEntryId" should be "${journalEntryId}"
@@ -137,7 +137,7 @@ Feature: Conversation Forking gRPC API
 
     When I send gRPC request "ConversationsService/ListForks" with body:
     """
-    conversation_id: "${parentConversationId | uuid_to_hex_string}"
+    conversation_id: "${parentConversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "forkPoints" should have size 1
@@ -145,7 +145,7 @@ Feature: Conversation Forking gRPC API
 
     When I send gRPC request "ConversationsService/ListForks" with body:
     """
-    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee02" | uuid_to_hex_string}"
+    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee02"}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "forkPoints" should have size 1
@@ -154,7 +154,7 @@ Feature: Conversation Forking gRPC API
     Given I am authenticated as user "alice"
     When I send gRPC request "ConversationsService/ListForks" with body:
     """
-    conversation_id: "${parentConversationId | uuid_to_hex_string}"
+    conversation_id: "${parentConversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "forkPoints" should have size 0
@@ -162,7 +162,7 @@ Feature: Conversation Forking gRPC API
     Given I am authenticated as agent with API key "test-agent-key-b"
     When I send gRPC request "ConversationsService/ListForks" with body:
     """
-    conversation_id: "${parentConversationId | uuid_to_hex_string}"
+    conversation_id: "${parentConversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "forkPoints" should have size 0
@@ -170,7 +170,7 @@ Feature: Conversation Forking gRPC API
     Given I am authenticated as admin user "alice"
     When I send gRPC request "AdminConversationsService/ListForks" with body:
     """
-    conversation_id: "${parentConversationId | uuid_to_hex_string}"
+    conversation_id: "${parentConversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "forkPoints" should have size 1
@@ -180,7 +180,7 @@ Feature: Conversation Forking gRPC API
     Given I am authenticated as agent with API key "test-agent-key"
     When I send gRPC request "EntriesService/AppendEntry" with body:
     """
-    conversation_id: "${parentConversationId | uuid_to_hex_string}"
+    conversation_id: "${parentConversationId}"
     entry {
       user_id: "alice"
       channel: JOURNAL
@@ -200,7 +200,7 @@ Feature: Conversation Forking gRPC API
     Given I am authenticated as agent with API key "test-agent-key-b"
     When I send gRPC request "EntriesService/AppendEntry" with body:
     """
-    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee03" | uuid_to_hex_string}"
+    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee03"}"
     entry {
       user_id: "alice"
       channel: HISTORY
@@ -217,7 +217,7 @@ Feature: Conversation Forking gRPC API
           }
         }
       }
-      forked_at_conversation_id: "${parentConversationId | uuid_to_hex_string}"
+      forked_at_conversation_id: "${parentConversationId}"
       forked_at_entry_id: "${journalEntryId | uuid_to_hex_string}"
     }
     """
@@ -227,7 +227,7 @@ Feature: Conversation Forking gRPC API
     Given I am authenticated as agent with API key "test-agent-key"
     When I send gRPC request "EntriesService/AppendEntry" with body:
     """
-    conversation_id: "${parentConversationId | uuid_to_hex_string}"
+    conversation_id: "${parentConversationId}"
     entry {
       user_id: "alice"
       channel: CONTEXT
@@ -241,7 +241,7 @@ Feature: Conversation Forking gRPC API
     And set "contextEntryId" to the gRPC response field "id"
     When I send gRPC request "EntriesService/AppendEntry" with body:
     """
-    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee04" | uuid_to_hex_string}"
+    conversation_id: "${"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee04"}"
     entry {
       user_id: "alice"
       channel: HISTORY
@@ -258,7 +258,7 @@ Feature: Conversation Forking gRPC API
           }
         }
       }
-      forked_at_conversation_id: "${parentConversationId | uuid_to_hex_string}"
+      forked_at_conversation_id: "${parentConversationId}"
       forked_at_entry_id: "${contextEntryId | uuid_to_hex_string}"
     }
     """
@@ -273,7 +273,7 @@ Feature: Conversation Forking gRPC API
     And set "fork2Id" to "${forkedConversationId}"
     When I send gRPC request "ConversationsService/ListForks" with body:
     """
-    conversation_id: "${parentConversationId | uuid_to_hex_string}"
+    conversation_id: "${parentConversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "conversationIds" should not be null
@@ -287,7 +287,7 @@ Feature: Conversation Forking gRPC API
     Given I am authenticated as admin user "alice"
     When I send gRPC request "AdminConversationsService/ListForks" with body:
     """
-    conversation_id: "${adminForkId | uuid_to_hex_string}"
+    conversation_id: "${adminForkId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "conversationIds" should not be null
@@ -296,7 +296,7 @@ Feature: Conversation Forking gRPC API
   Scenario: List forks for non-existent conversation via gRPC
     When I send gRPC request "ConversationsService/ListForks" with body:
     """
-    conversation_id: "${"00000000-0000-0000-0000-000000000000" | uuid_to_hex_string}"
+    conversation_id: "${"00000000-0000-0000-0000-000000000000"}"
     """
     Then the gRPC response should have status "NOT_FOUND"
 
@@ -304,6 +304,6 @@ Feature: Conversation Forking gRPC API
     Given there is a conversation owned by "bob"
     When I send gRPC request "ConversationsService/ListForks" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     """
     Then the gRPC response should have status "PERMISSION_DENIED"

--- a/internal/bdd/testdata/features-grpc/ownership-transfers-grpc.feature
+++ b/internal/bdd/testdata/features-grpc/ownership-transfers-grpc.feature
@@ -19,7 +19,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: Owner can create ownership transfer via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -31,7 +31,7 @@ Feature: Ownership Transfers gRPC API
     Given I am authenticated as user "bob"
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "charlie"
     """
     Then the gRPC response should have status "PERMISSION_DENIED"
@@ -39,13 +39,13 @@ Feature: Ownership Transfers gRPC API
   Scenario: Cannot create second transfer while one is pending via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should have status "ABORTED"
@@ -53,7 +53,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: Cannot transfer to non-member via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "stranger"
     """
     Then the gRPC response should have status "INVALID_ARGUMENT"
@@ -61,7 +61,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: Cannot transfer to self via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "alice"
     """
     Then the gRPC response should have status "INVALID_ARGUMENT"
@@ -71,7 +71,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: List transfers as sender via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -85,7 +85,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: List transfers as recipient via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -101,7 +101,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: List all transfers via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -116,7 +116,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: Sender can get transfer details via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -131,7 +131,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: Recipient can get transfer details via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -147,7 +147,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: Non-participant cannot see transfer via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -164,7 +164,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: Recipient can accept transfer via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -178,14 +178,14 @@ Feature: Ownership Transfers gRPC API
     # Verify ownership changed
     When I send gRPC request "ConversationMembershipsService/ListMemberships" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     """
     Then the gRPC response should not have an error
 
   Scenario: Sender cannot accept own transfer via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -199,7 +199,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: Cannot accept already-accepted transfer via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -222,7 +222,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: Sender can cancel (delete) transfer via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -242,7 +242,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: Recipient can decline (delete) transfer via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error
@@ -257,7 +257,7 @@ Feature: Ownership Transfers gRPC API
   Scenario: Non-participant cannot delete transfer via gRPC
     When I send gRPC request "OwnershipTransfersService/CreateOwnershipTransfer" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     new_owner_user_id: "bob"
     """
     Then the gRPC response should not have an error

--- a/internal/bdd/testdata/features-grpc/sharing-grpc.feature
+++ b/internal/bdd/testdata/features-grpc/sharing-grpc.feature
@@ -10,7 +10,7 @@ Feature: Conversation Sharing gRPC API
   Scenario: Share a conversation with a user via gRPC
     When I send gRPC request "ConversationMembershipsService/ShareConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     user_id: "bob"
     access_level: WRITER
     """
@@ -19,7 +19,7 @@ Feature: Conversation Sharing gRPC API
     And the gRPC response field "accessLevel" should be "WRITER"
     And the gRPC response text should match text proto:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     user_id: "bob"
     access_level: WRITER
     """
@@ -27,7 +27,7 @@ Feature: Conversation Sharing gRPC API
   Scenario: Share a conversation with reader access via gRPC
     When I send gRPC request "ConversationMembershipsService/ShareConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     user_id: "charlie"
     access_level: READER
     """
@@ -38,7 +38,7 @@ Feature: Conversation Sharing gRPC API
   Scenario: Share a conversation with manager access via gRPC
     When I send gRPC request "ConversationMembershipsService/ShareConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     user_id: "dave"
     access_level: MANAGER
     """
@@ -49,13 +49,13 @@ Feature: Conversation Sharing gRPC API
   Scenario: List conversation memberships via gRPC
     When I send gRPC request "ConversationMembershipsService/ShareConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     user_id: "bob"
     access_level: WRITER
     """
     When I send gRPC request "ConversationMembershipsService/ListMemberships" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "memberships" should not be null
@@ -67,13 +67,13 @@ Feature: Conversation Sharing gRPC API
   Scenario: Update membership access level via gRPC
     When I send gRPC request "ConversationMembershipsService/ShareConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     user_id: "bob"
     access_level: READER
     """
     When I send gRPC request "ConversationMembershipsService/UpdateMembership" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     member_user_id: "bob"
     access_level: WRITER
     """
@@ -82,7 +82,7 @@ Feature: Conversation Sharing gRPC API
     And the gRPC response field "accessLevel" should be "WRITER"
     And the gRPC response text should match text proto:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     user_id: "bob"
     access_level: WRITER
     """
@@ -90,19 +90,19 @@ Feature: Conversation Sharing gRPC API
   Scenario: Delete a membership via gRPC
     When I send gRPC request "ConversationMembershipsService/ShareConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     user_id: "bob"
     access_level: WRITER
     """
     When I send gRPC request "ConversationMembershipsService/DeleteMembership" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     member_user_id: "bob"
     """
     Then the gRPC response should not have an error
     When I send gRPC request "ConversationMembershipsService/ListMemberships" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "memberships" should not be null
@@ -110,7 +110,7 @@ Feature: Conversation Sharing gRPC API
   Scenario: Share non-existent conversation via gRPC
     When I send gRPC request "ConversationMembershipsService/ShareConversation" with body:
     """
-    conversation_id: "${"00000000-0000-0000-0000-000000000000" | uuid_to_hex_string}"
+    conversation_id: "${"00000000-0000-0000-0000-000000000000"}"
     user_id: "bob"
     access_level: WRITER
     """
@@ -120,7 +120,7 @@ Feature: Conversation Sharing gRPC API
     Given there is a conversation owned by "bob"
     When I send gRPC request "ConversationMembershipsService/ShareConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     user_id: "charlie"
     access_level: WRITER
     """
@@ -132,7 +132,7 @@ Feature: Conversation Sharing gRPC API
     And the conversation is shared with user "charlie" with access level "reader"
     When I send gRPC request "ConversationMembershipsService/ListMemberships" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     """
     Then the gRPC response should not have an error
 
@@ -142,7 +142,7 @@ Feature: Conversation Sharing gRPC API
     And the conversation is shared with user "charlie" with access level "writer"
     When I send gRPC request "ConversationMembershipsService/UpdateMembership" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     member_user_id: "dave"
     access_level: READER
     """
@@ -154,7 +154,7 @@ Feature: Conversation Sharing gRPC API
     And the conversation is shared with user "charlie" with access level "writer"
     When I send gRPC request "ConversationMembershipsService/DeleteMembership" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     member_user_id: "dave"
     """
     Then the gRPC response should have status "PERMISSION_DENIED"
@@ -162,7 +162,7 @@ Feature: Conversation Sharing gRPC API
   Scenario: Membership response contains conversation_id instead of conversation_group_id via gRPC
     When I send gRPC request "ConversationMembershipsService/ShareConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     user_id: "bob"
     access_level: WRITER
     """

--- a/internal/bdd/testdata/features-grpc/update-conversation-grpc.feature
+++ b/internal/bdd/testdata/features-grpc/update-conversation-grpc.feature
@@ -10,7 +10,7 @@ Feature: Update Conversation gRPC API
   Scenario: Update conversation title via gRPC
     When I send gRPC request "ConversationsService/UpdateConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     title: "Updated Title"
     """
     Then the gRPC response should not have an error
@@ -21,7 +21,7 @@ Feature: Update Conversation gRPC API
   Scenario: Update non-existent conversation via gRPC
     When I send gRPC request "ConversationsService/UpdateConversation" with body:
     """
-    conversation_id: "${"00000000-0000-0000-0000-000000000000" | uuid_to_hex_string}"
+    conversation_id: "${"00000000-0000-0000-0000-000000000000"}"
     title: "New Title"
     """
     Then the gRPC response should have status "NOT_FOUND"
@@ -30,7 +30,7 @@ Feature: Update Conversation gRPC API
     Given there is a conversation owned by "bob"
     When I send gRPC request "ConversationsService/UpdateConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     title: "Hacked Title"
     """
     Then the gRPC response should have status "PERMISSION_DENIED"
@@ -47,7 +47,7 @@ Feature: Update Conversation gRPC API
     Given I am authenticated as user "bob"
     When I send gRPC request "ConversationsService/UpdateConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     title: "Writer Updated Title"
     """
     Then the gRPC response should not have an error
@@ -66,7 +66,7 @@ Feature: Update Conversation gRPC API
     Given I am authenticated as user "charlie"
     When I send gRPC request "ConversationsService/UpdateConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     title: "Reader Title"
     """
     Then the gRPC response should have status "PERMISSION_DENIED"
@@ -74,14 +74,14 @@ Feature: Update Conversation gRPC API
   Scenario: Archive conversation via gRPC and keep it readable
     When I send gRPC request "ConversationsService/UpdateConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     archived: true
     """
     Then the gRPC response should not have an error
     And the gRPC response field "archived" should be true
     When I send gRPC request "ConversationsService/GetConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "archived" should be true
@@ -98,7 +98,7 @@ Feature: Update Conversation gRPC API
     Given I am authenticated as user "charlie"
     When I send gRPC request "ConversationsService/UpdateConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     archived: true
     """
     Then the gRPC response should have status "PERMISSION_DENIED"
@@ -107,7 +107,7 @@ Feature: Update Conversation gRPC API
     Given I am authenticated as auditor user "charlie"
     When I send gRPC request "AdminConversationsService/UpdateConversation" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     archived: true
     """
     Then the gRPC response should have status "PERMISSION_DENIED"

--- a/internal/bdd/testdata/features/eviction-rest.feature
+++ b/internal/bdd/testdata/features/eviction-rest.feature
@@ -6,9 +6,11 @@ Feature: Data Eviction
   # Serial required: this scenario runs a datastore-wide eviction sweep that can hard-delete records and queue tasks for data created by other scenarios.
   Scenario: Evict conversation groups past retention period (default response)
     Given I have a conversation with title "Old Conversation"
+    And set "oldConversationId" to "${conversationId}"
     And set "oldGroupId" to "${conversationGroupId}"
     And the conversation was archived 100 days ago
     And I have a conversation with title "Recent Conversation"
+    And set "recentConversationId" to "${conversationId}"
     And set "recentGroupId" to "${conversationGroupId}"
     And the conversation was archived 10 days ago
     When I call POST "/v1/admin/evict" with body:
@@ -23,7 +25,7 @@ Feature: Data Eviction
     # Verify old conversation is gone
     When I execute SQL query:
       """
-      SELECT COUNT(*) as count FROM conversations WHERE id = '${oldGroupId}'
+      SELECT COUNT(*) as count FROM conversations WHERE id = '${oldConversationId}'
       """
     Then the SQL result should match:
       | count |
@@ -34,7 +36,7 @@ Feature: Data Eviction
         "collection": "conversations",
         "operation": "count",
         "filter": {
-          "_id": "${oldGroupId}"
+          "_id": "${oldConversationId}"
         }
       }
       """
@@ -44,7 +46,7 @@ Feature: Data Eviction
     # Verify recent conversation still exists
     When I execute SQL query:
       """
-      SELECT COUNT(*) as count FROM conversations WHERE id = '${recentGroupId}'
+      SELECT COUNT(*) as count FROM conversations WHERE id = '${recentConversationId}'
       """
     Then the SQL result should match:
       | count |
@@ -229,9 +231,11 @@ Feature: Data Eviction
   # Serial required: this scenario runs a datastore-wide eviction sweep that can hard-delete records created by other scenarios.
   Scenario: Evict multiple conversations in single request
     Given I have a conversation with title "Group To Evict"
+    And set "conversationAId" to "${conversationId}"
     And set "groupAId" to "${conversationGroupId}"
     And the conversation was archived 100 days ago
     And I have a conversation with title "Another Group"
+    And set "conversationBId" to "${conversationId}"
     And set "groupBId" to "${conversationGroupId}"
     When I call POST "/v1/admin/evict" with body:
       """
@@ -244,7 +248,7 @@ Feature: Data Eviction
     # Group A should be hard-deleted
     When I execute SQL query:
       """
-      SELECT COUNT(*) as count FROM conversations WHERE id = '${groupAId}'
+      SELECT COUNT(*) as count FROM conversations WHERE id = '${conversationAId}'
       """
     Then the SQL result should match:
       | count |
@@ -265,7 +269,7 @@ Feature: Data Eviction
     # Group B should still exist
     When I execute SQL query:
       """
-      SELECT COUNT(*) as count FROM conversations WHERE id = '${groupBId}'
+      SELECT COUNT(*) as count FROM conversations WHERE id = '${conversationBId}'
       """
     Then the SQL result should match:
       | count |

--- a/internal/bdd/testdata/features/response-recorder-grpc.feature
+++ b/internal/bdd/testdata/features/response-recorder-grpc.feature
@@ -17,7 +17,7 @@ Feature: Response Recorder gRPC API
   Scenario: Check if conversation has recording in progress when none exists
     When I send gRPC request "ResponseRecorderService/CheckRecordings" with body:
     """
-    conversation_ids: "${conversationId | uuid_to_hex_string}"
+    conversation_ids: "${conversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "conversationIds" should be "[]"
@@ -25,7 +25,7 @@ Feature: Response Recorder gRPC API
   Scenario: Check recording in progress for non-existent conversation
     When I send gRPC request "ResponseRecorderService/CheckRecordings" with body:
     """
-    conversation_ids: "${"00000000-0000-0000-0000-000000000000" | uuid_to_hex_string}"
+    conversation_ids: "${"00000000-0000-0000-0000-000000000000"}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "conversationIds" should be "[]"
@@ -34,7 +34,7 @@ Feature: Response Recorder gRPC API
     Given there is a conversation owned by "bob"
     When I send gRPC request "ResponseRecorderService/CheckRecordings" with body:
     """
-    conversation_ids: "${conversationId | uuid_to_hex_string}"
+    conversation_ids: "${conversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "conversationIds" should be "[]"
@@ -46,8 +46,8 @@ Feature: Response Recorder gRPC API
     And I set context variable "conversationId2" to "${conversationId}"
     When I send gRPC request "ResponseRecorderService/CheckRecordings" with body:
     """
-    conversation_ids: "${conversationId1 | uuid_to_hex_string}"
-    conversation_ids: "${conversationId2 | uuid_to_hex_string}"
+    conversation_ids: "${conversationId1}"
+    conversation_ids: "${conversationId2}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "conversationIds" should not be null
@@ -59,8 +59,8 @@ Feature: Response Recorder gRPC API
     And I set context variable "bobConversationId" to "${conversationId}"
     When I send gRPC request "ResponseRecorderService/CheckRecordings" with body:
     """
-    conversation_ids: "${myConversationId | uuid_to_hex_string}"
-    conversation_ids: "${bobConversationId | uuid_to_hex_string}"
+    conversation_ids: "${myConversationId}"
+    conversation_ids: "${bobConversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "conversationIds" should not be null
@@ -68,7 +68,7 @@ Feature: Response Recorder gRPC API
   Scenario: Record response content for a conversation
     When I send gRPC request "ResponseRecorderService/Record" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     content: "Hello"
     complete: true
     """
@@ -93,7 +93,7 @@ Feature: Response Recorder gRPC API
     And I wait for the response stream to send at least 2 tokens
     When I send gRPC request "ResponseRecorderService/Cancel" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     """
     Then the gRPC response should not have an error
     And the gRPC response field "accepted" should be true
@@ -112,7 +112,7 @@ Feature: Response Recorder gRPC API
     Given there is a conversation owned by "bob"
     When I send gRPC request "ResponseRecorderService/Record" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     content: "Hello"
     complete: false
     """
@@ -121,7 +121,7 @@ Feature: Response Recorder gRPC API
   Scenario: Record for non-existent conversation
     When I send gRPC request "ResponseRecorderService/Record" with body:
     """
-    conversation_id: "${"00000000-0000-0000-0000-000000000000" | uuid_to_hex_string}"
+    conversation_id: "${"00000000-0000-0000-0000-000000000000"}"
     content: "Hello"
     complete: false
     """
@@ -131,7 +131,7 @@ Feature: Response Recorder gRPC API
     Given I have streamed tokens "Hello World" to the conversation
     When I send gRPC request "ResponseRecorderService/Replay" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     """
     Then the gRPC response should not have an error
     # Note: Server streaming responses need special handling in step definitions
@@ -140,13 +140,13 @@ Feature: Response Recorder gRPC API
     Given there is a conversation owned by "bob"
     When I send gRPC request "ResponseRecorderService/Replay" with body:
     """
-    conversation_id: "${conversationId | uuid_to_hex_string}"
+    conversation_id: "${conversationId}"
     """
     Then the gRPC response should have status "PERMISSION_DENIED"
 
   Scenario: Replay for non-existent conversation
     When I send gRPC request "ResponseRecorderService/Replay" with body:
     """
-    conversation_id: "${"00000000-0000-0000-0000-000000000000" | uuid_to_hex_string}"
+    conversation_id: "${"00000000-0000-0000-0000-000000000000"}"
     """
     Then the gRPC response should have status "NOT_FOUND"

--- a/internal/cmd/serve/path_parameters.go
+++ b/internal/cmd/serve/path_parameters.go
@@ -2,17 +2,30 @@ package serve
 
 import (
 	"net/http"
+	"net/url"
 
 	"github.com/gin-gonic/gin"
 )
 
-// newGinRouter keeps percent encoding intact while Gin matches route segments.
-// The generated OpenAPI wrapper decodes each captured parameter exactly once
-// with path semantics before invoking the proxy server interface.
+// newGinRouter uses the escaped path for route matching, then decodes each
+// captured parameter once with path semantics. Gin's built-in unescape option
+// uses query semantics and incorrectly turns literal plus signs into spaces.
+// The generated OpenAPI wrappers bind Gin path parameters with
+// ValueIsUnescaped=true, so they must receive decoded values.
 func newGinRouter() *gin.Engine {
 	router := gin.New()
 	router.UseEscapedPath = true
 	router.UnescapePathValues = false
+	router.Use(func(c *gin.Context) {
+		for i := range c.Params {
+			value, err := url.PathUnescape(c.Params[i].Value)
+			if err != nil {
+				c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid escaped path parameter"})
+				return
+			}
+			c.Params[i].Value = value
+		}
+	})
 	// Make unmatched encoded paths explicit inside Gin's middleware chain so
 	// the error-envelope writer cannot commit its default 200 before Gin's
 	// fallback 404 runs.

--- a/internal/cmd/serve/path_parameters_test.go
+++ b/internal/cmd/serve/path_parameters_test.go
@@ -26,9 +26,10 @@ func newPathParameterTestRouter() *gin.Engine {
 			c.Param("id"),
 			&id,
 			openapi_runtime.BindStyledParameterOptions{
-				ParamLocation: openapi_runtime.ParamLocationPath,
-				Required:      true,
-				Type:          "string",
+				ParamLocation:    openapi_runtime.ParamLocationPath,
+				Required:         true,
+				Type:             "string",
+				ValueIsUnescaped: true,
 			},
 		)
 		if err != nil {

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -1908,7 +1908,7 @@ func (s *EntriesServer) appendEntries(ctx context.Context, conversationID string
 	if err != nil {
 		duplicateConflict := registrystore.IsDuplicateSequenceConflict(err)
 		var notFound *registrystore.NotFoundError
-		archivedRetry := retryEligible && validatedPatch != nil && validatedPatch.archived != nil && *validatedPatch.archived && errors.As(err, &notFound)
+		archivedRetry := retryEligible && validatedPatch != nil && validatedPatch.archived != nil && errors.As(err, &notFound)
 		if retryEligible && (duplicateConflict || archivedRetry) {
 			originalErr := err
 			eventsToPublish = nil
@@ -1929,6 +1929,30 @@ func (s *EntriesServer) appendEntries(ctx context.Context, conversationID string
 						return nil, registrystore.NewDuplicateSequenceConflict()
 					}
 					return nil, originalErr
+				}
+				// Exact retries skip stale title and metadata patches. An explicit
+				// archived=false still applies when the conversation was archived
+				// after the original append.
+				if validatedPatch.needsUnarchiveBeforeWrite() {
+					conv, convErr := s.Store.GetConversation(txCtx, userID, convID)
+					if convErr != nil {
+						return nil, convErr
+					}
+					if conv.ArchivedAt != nil {
+						unarchiveResult, unarchiveErr := s.Store.UnarchiveConversationIfNeeded(txCtx, userID, convID)
+						if unarchiveErr != nil {
+							return nil, unarchiveErr
+						}
+						if unarchiveResult.Changed && s.EventBus != nil {
+							eventsToPublish, convErr = s.conversationPatchEvents(txCtx, convID, conv.ConversationGroupID, grpcPatchResult{
+								changed:  true,
+								archived: validatedPatch.archived,
+							})
+							if convErr != nil {
+								return nil, convErr
+							}
+						}
+					}
 				}
 				for _, storedEntry := range match.Entries {
 					if repairErr := registrystore.RepairStoredEntryAttachmentLinks(txCtx, s.Store, userID, storedEntry); repairErr != nil {

--- a/internal/plugin/route/entries/entries.go
+++ b/internal/plugin/route/entries/entries.go
@@ -540,7 +540,7 @@ func appendEntry(c *gin.Context, store registrystore.MemoryStore, eventBus regis
 	})
 	if writeErr != nil {
 		duplicateConflict := registrystore.IsDuplicateSequenceConflict(writeErr)
-		archivedRetry := retryEligible && validatedPatch != nil && validatedPatch.archived != nil && *validatedPatch.archived && isNotFoundError(writeErr)
+		archivedRetry := retryEligible && validatedPatch != nil && validatedPatch.archived != nil && isNotFoundError(writeErr)
 		if retryEligible && (duplicateConflict || archivedRetry) {
 			originalErr := writeErr
 			eventsToPublish = nil
@@ -561,6 +561,32 @@ func appendEntry(c *gin.Context, store registrystore.MemoryStore, eventBus regis
 						return registrystore.NewDuplicateSequenceConflict()
 					}
 					return originalErr
+				}
+				// Exact retries normally skip all append-time patches so stale title or
+				// metadata cannot overwrite newer conversation state. Explicit
+				// archived=false is the exception: it describes the caller's desired
+				// current state and must unarchive a conversation archived after the
+				// original append.
+				if validatedPatch.needsUnarchiveBeforeWrite() {
+					conv, err := store.GetConversation(ctx, userID, convID)
+					if err != nil {
+						return err
+					}
+					if conv.ArchivedAt != nil {
+						unarchiveResult, err := store.UnarchiveConversationIfNeeded(ctx, userID, convID)
+						if err != nil {
+							return err
+						}
+						if unarchiveResult.Changed && eventBus != nil {
+							eventsToPublish, err = conversationPatchEvents(ctx, store, convID, conv.ConversationGroupID, conversationPatchResult{
+								changed:  true,
+								archived: validatedPatch.archived,
+							})
+							if err != nil {
+								return err
+							}
+						}
+					}
 				}
 				for _, storedEntry := range match.Entries {
 					if err := registrystore.RepairStoredEntryAttachmentLinks(ctx, store, userID, storedEntry); err != nil {


### PR DESCRIPTION
## Summary

Restore exact-once decoding for escaped REST path parameters and preserve explicit unarchive behavior on exact sequenced retries. Repair the BDD failures exposed by the expanded test run and add focused CI coverage for each contract.

## Changes

- Decode Gin path parameters once while retaining escaped-path route boundaries.
- Return stored entries on exact retries, apply only explicit `archived=false`, and emit one conversation update across REST and gRPC.
- Fix nested JSON assertions, eviction scenario identifiers, gRPC string UUID substitutions, and broad-runner configuration lookup.
- Add targeted SQLite BDD runners for path, outbox, serial eviction, ownership transfer, retry, and gRPC contract regressions.
